### PR TITLE
add intent preflight and conformance service.

### DIFF
--- a/cmd/aero-arc-api/main.go
+++ b/cmd/aero-arc-api/main.go
@@ -151,10 +151,13 @@ func run(ctx context.Context, cfg *config.Config) error {
 		slog.Info("seeded demo data")
 	}
 	fleetService := service.NewFleetService(durableStore, telemetryStore, replayStore, registryClient)
+	intentService := service.NewIntentService(durableStore)
+	preflightService := service.NewPreflightService(durableStore)
+	conformanceService := service.NewConformanceService(durableStore, telemetryStore)
 
 	httpServer := &http.Server{
 		Addr:              cfg.Addr,
-		Handler:           httpapi.New(fleetService, cfg.RequestTimeout).Handler(),
+		Handler:           httpapi.NewWithWorkflows(fleetService, intentService, preflightService, conformanceService, cfg.RequestTimeout).Handler(),
 		ReadHeaderTimeout: 5 * time.Second,
 	}
 

--- a/internal/httpapi/handlers.go
+++ b/internal/httpapi/handlers.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/Aero-Arc/aero-arc-api/internal/domain"
+	"github.com/Aero-Arc/aero-arc-api/internal/service"
 	"github.com/mrshabel/mach"
 )
 
@@ -234,6 +235,116 @@ func (s *Server) handleCreateMaintenanceEvent(c *mach.Context) {
 		return
 	}
 	writeJSON(c, http.StatusCreated, event)
+}
+
+func (s *Server) handleCreateOperationalIntent(c *mach.Context) {
+	var req service.CreateIntentRequest
+	if err := decodeJSON(c, &req); err != nil {
+		writeError(c, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	ctx, cancel := s.contextWithTimeout(c)
+	defer cancel()
+	intent, err := s.intents.CreateIntent(ctx, req)
+	if err != nil {
+		writeServiceError(c, err)
+		return
+	}
+	writeJSON(c, http.StatusCreated, intent)
+}
+
+func (s *Server) handleAddOperationalVolume(c *mach.Context) {
+	var req service.AddOperationalVolumeRequest
+	if err := decodeJSON(c, &req); err != nil {
+		writeError(c, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	ctx, cancel := s.contextWithTimeout(c)
+	defer cancel()
+	volume, err := s.intents.AddOperationalVolume(ctx, c.Param("intent_id"), req)
+	if err != nil {
+		writeServiceError(c, err)
+		return
+	}
+	writeJSON(c, http.StatusCreated, volume)
+}
+
+func (s *Server) handleSubmitOperationalIntent(c *mach.Context) {
+	ctx, cancel := s.contextWithTimeout(c)
+	defer cancel()
+	intent, err := s.intents.SubmitIntent(ctx, c.Param("intent_id"))
+	if err != nil {
+		writeServiceError(c, err)
+		return
+	}
+	writeJSON(c, http.StatusOK, intent)
+}
+
+func (s *Server) handleEvaluateOperationalIntentPreflight(c *mach.Context) {
+	ctx, cancel := s.contextWithTimeout(c)
+	defer cancel()
+	evaluation, err := s.preflight.EvaluateIntent(ctx, c.Param("intent_id"))
+	if err != nil {
+		writeServiceError(c, err)
+		return
+	}
+	writeJSON(c, http.StatusOK, evaluation)
+}
+
+func (s *Server) handleAcceptOperationalIntent(c *mach.Context) {
+	ctx, cancel := s.contextWithTimeout(c)
+	defer cancel()
+	intent, err := s.intents.AcceptIntent(ctx, c.Param("intent_id"))
+	if err != nil {
+		writeServiceError(c, err)
+		return
+	}
+	writeJSON(c, http.StatusOK, intent)
+}
+
+func (s *Server) handleActivateOperationalIntent(c *mach.Context) {
+	ctx, cancel := s.contextWithTimeout(c)
+	defer cancel()
+	intent, err := s.intents.ActivateIntent(ctx, c.Param("intent_id"))
+	if err != nil {
+		writeServiceError(c, err)
+		return
+	}
+	writeJSON(c, http.StatusOK, intent)
+}
+
+func (s *Server) handleTelemetry(c *mach.Context) {
+	var sample domain.TelemetrySample
+	if err := decodeJSON(c, &sample); err != nil {
+		writeError(c, http.StatusBadRequest, err.Error())
+		return
+	}
+	if strings.TrimSpace(sample.AircraftID) == "" {
+		writeError(c, http.StatusBadRequest, "aircraft_id is required")
+		return
+	}
+
+	ctx, cancel := s.contextWithTimeout(c)
+	defer cancel()
+	evaluation, err := s.conformance.EvaluateTelemetry(ctx, sample)
+	if err != nil {
+		writeServiceError(c, err)
+		return
+	}
+	writeJSON(c, http.StatusOK, evaluation)
+}
+
+func (s *Server) handleGetOperationalIntentConformance(c *mach.Context) {
+	ctx, cancel := s.contextWithTimeout(c)
+	defer cancel()
+	evaluation, err := s.conformance.GetIntentConformance(ctx, c.Param("intent_id"))
+	if err != nil {
+		writeServiceError(c, err)
+		return
+	}
+	writeJSON(c, http.StatusOK, evaluation)
 }
 
 func (s *Server) contextWithTimeout(c *mach.Context) (context.Context, context.CancelFunc) {

--- a/internal/httpapi/handlers.go
+++ b/internal/httpapi/handlers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -307,6 +308,15 @@ func (s *Server) handleAcceptOperationalIntent(c *mach.Context) {
 func (s *Server) handleActivateOperationalIntent(c *mach.Context) {
 	ctx, cancel := s.contextWithTimeout(c)
 	defer cancel()
+	evaluation, err := s.preflight.EvaluateIntent(ctx, c.Param("intent_id"))
+	if err != nil {
+		writeServiceError(c, err)
+		return
+	}
+	if evaluation.Blocked {
+		writeServiceError(c, fmt.Errorf("%w: preflight evaluation blocked", service.ErrActivationBlocked))
+		return
+	}
 	intent, err := s.intents.ActivateIntent(ctx, c.Param("intent_id"))
 	if err != nil {
 		writeServiceError(c, err)

--- a/internal/httpapi/handlers_test.go
+++ b/internal/httpapi/handlers_test.go
@@ -1,6 +1,7 @@
 package httpapi
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"net/http"
@@ -209,6 +210,66 @@ func TestHandleActivateOperationalIntentRunsPreflight(t *testing.T) {
 	}
 	if len(checks) == 0 {
 		t.Fatal("activate handler should have recorded preflight checks")
+	}
+}
+
+func TestHandleAddOperationalVolumeRejectsSubmittedIntent(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 6, 15, 15, 0, 0, 0, time.UTC)
+	durable := durablememory.NewStore()
+	telemetry := telemetrymemory.NewStore()
+	replay := replaymemory.NewStore()
+	reg := registry.NewMemoryClient()
+
+	if err := durable.CreateAircraft(ctx, domain.Aircraft{
+		ID:               "aircraft-1",
+		OperatorID:       "operator-1",
+		TailNumber:       "N100AA",
+		Status:           domain.AircraftStatusActive,
+		AcceptanceStatus: domain.AcceptanceStatusAccepted,
+		RemoteIDStatus:   domain.RemoteIDStatusBroadcasting,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	intents := service.NewIntentService(durable)
+	intent, err := intents.CreateIntent(ctx, service.CreateIntentRequest{
+		ID:                  "intent-1",
+		OperatorID:          "operator-1",
+		AircraftID:          "aircraft-1",
+		Name:                "Demo intent",
+		Summary:             "Volume edits should lock after submit",
+		AuthorizationPath:   domain.AuthorizationPathDemo,
+		PopulationCategory:  domain.PopulationCategoryOne,
+		ConformanceRequired: true,
+		PlannedStartAt:      now,
+		PlannedEndAt:        now.Add(time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("CreateIntent returned error: %v", err)
+	}
+	if _, err = intents.SubmitIntent(ctx, intent.ID); err != nil {
+		t.Fatalf("SubmitIntent returned error: %v", err)
+	}
+
+	fleet := service.NewFleetService(durable, telemetry, replay, reg)
+	server := NewWithWorkflows(
+		fleet,
+		intents,
+		service.NewPreflightService(durable),
+		service.NewConformanceService(durable, telemetry),
+		time.Second,
+	)
+	body := []byte(`{"id":"volume-1","sequence":1,"geojson":"{\"type\":\"Polygon\",\"coordinates\":[[[-98,35],[-97,35],[-97,36],[-98,36],[-98,35]]]}","min_altitude_m":10,"max_altitude_m":120,"starts_at":"2026-06-15T15:00:00Z","ends_at":"2026-06-15T16:00:00Z"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/operational-intents/intent-1/volumes", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+
+	server.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusConflict, rec.Body.String())
 	}
 }
 

--- a/internal/httpapi/handlers_test.go
+++ b/internal/httpapi/handlers_test.go
@@ -132,6 +132,86 @@ func TestHandleGetOverviewDashboard(t *testing.T) {
 	}
 }
 
+func TestHandleActivateOperationalIntentRunsPreflight(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 6, 15, 15, 0, 0, 0, time.UTC)
+	durable := durablememory.NewStore()
+	telemetry := telemetrymemory.NewStore()
+	replay := replaymemory.NewStore()
+	reg := registry.NewMemoryClient()
+
+	if err := durable.CreateAircraft(ctx, domain.Aircraft{
+		ID:               "aircraft-1",
+		OperatorID:       "operator-1",
+		TailNumber:       "N100AA",
+		Status:           domain.AircraftStatusActive,
+		AcceptanceStatus: domain.AcceptanceStatusAccepted,
+		RemoteIDStatus:   domain.RemoteIDStatusBroadcasting,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	intents := service.NewIntentService(durable)
+	intent, err := intents.CreateIntent(ctx, service.CreateIntentRequest{
+		ID:                  "intent-1",
+		OperatorID:          "operator-1",
+		AircraftID:          "aircraft-1",
+		Name:                "Demo intent",
+		Summary:             "Activation should evaluate preflight",
+		AuthorizationPath:   domain.AuthorizationPathDemo,
+		PopulationCategory:  domain.PopulationCategoryOne,
+		ConformanceRequired: true,
+		PlannedStartAt:      now,
+		PlannedEndAt:        now.Add(time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("CreateIntent returned error: %v", err)
+	}
+	if _, err = intents.AddOperationalVolume(ctx, intent.ID, service.AddOperationalVolumeRequest{
+		ID:           "volume-1",
+		Sequence:     1,
+		GeoJSON:      `{"type":"Polygon","coordinates":[[[-98,35],[-97,35],[-97,36],[-98,36],[-98,35]]]}`,
+		MinAltitudeM: 10,
+		MaxAltitudeM: 120,
+		StartsAt:     now,
+		EndsAt:       now.Add(time.Hour),
+	}); err != nil {
+		t.Fatalf("AddOperationalVolume returned error: %v", err)
+	}
+	if _, err = intents.SubmitIntent(ctx, intent.ID); err != nil {
+		t.Fatalf("SubmitIntent returned error: %v", err)
+	}
+	if _, err = intents.AcceptIntent(ctx, intent.ID); err != nil {
+		t.Fatalf("AcceptIntent returned error: %v", err)
+	}
+
+	fleet := service.NewFleetService(durable, telemetry, replay, reg)
+	server := NewWithWorkflows(
+		fleet,
+		intents,
+		service.NewPreflightService(durable),
+		service.NewConformanceService(durable, telemetry),
+		time.Second,
+	)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/operational-intents/intent-1/activate", nil)
+	rec := httptest.NewRecorder()
+
+	server.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusConflict, rec.Body.String())
+	}
+	checks, err := durable.ListPreflightChecks(ctx, intent.ID)
+	if err != nil {
+		t.Fatalf("ListPreflightChecks returned error: %v", err)
+	}
+	if len(checks) == 0 {
+		t.Fatal("activate handler should have recorded preflight checks")
+	}
+}
+
 func float64Ptr(value float64) *float64 {
 	return &value
 }

--- a/internal/httpapi/response.go
+++ b/internal/httpapi/response.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/Aero-Arc/aero-arc-api/internal/service"
 	"github.com/Aero-Arc/aero-arc-api/internal/store/durable"
 	"github.com/mrshabel/mach"
 )
@@ -23,6 +24,14 @@ func writeError(c *mach.Context, statusCode int, message string) {
 func writeServiceError(c *mach.Context, err error) {
 	if errors.Is(err, durable.ErrNotFound) {
 		writeError(c, http.StatusNotFound, "resource not found")
+		return
+	}
+	if errors.Is(err, service.ErrValidation) {
+		writeError(c, http.StatusBadRequest, strings.TrimSpace(err.Error()))
+		return
+	}
+	if errors.Is(err, service.ErrInvalidTransition) || errors.Is(err, service.ErrActivationBlocked) {
+		writeError(c, http.StatusConflict, strings.TrimSpace(err.Error()))
 		return
 	}
 	writeJSON(c, http.StatusInternalServerError, map[string]string{

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -10,11 +10,24 @@ import (
 
 type Server struct {
 	fleet          *service.FleetService
+	intents        *service.IntentService
+	preflight      *service.PreflightService
+	conformance    *service.ConformanceService
 	requestTimeout time.Duration
 }
 
 func New(fleet *service.FleetService, requestTimeout time.Duration) *Server {
 	return &Server{fleet: fleet, requestTimeout: requestTimeout}
+}
+
+func NewWithWorkflows(fleet *service.FleetService, intents *service.IntentService, preflight *service.PreflightService, conformance *service.ConformanceService, requestTimeout time.Duration) *Server {
+	return &Server{
+		fleet:          fleet,
+		intents:        intents,
+		preflight:      preflight,
+		conformance:    conformance,
+		requestTimeout: requestTimeout,
+	}
 }
 
 func (s *Server) Handler() http.Handler {
@@ -43,8 +56,23 @@ func (s *Server) Handler() http.Handler {
 	api.GET("/flights/{flight_id}", s.handleGetFlight)
 	api.GET("/flights/{flight_id}/replay", s.handleGetFlightReplay)
 
+	if s.workflowsAvailable() {
+		api.POST("/operational-intents", s.handleCreateOperationalIntent)
+		api.POST("/operational-intents/{intent_id}/volumes", s.handleAddOperationalVolume)
+		api.POST("/operational-intents/{intent_id}/submit", s.handleSubmitOperationalIntent)
+		api.POST("/operational-intents/{intent_id}/preflight/evaluate", s.handleEvaluateOperationalIntentPreflight)
+		api.POST("/operational-intents/{intent_id}/accept", s.handleAcceptOperationalIntent)
+		api.POST("/operational-intents/{intent_id}/activate", s.handleActivateOperationalIntent)
+		api.GET("/operational-intents/{intent_id}/conformance", s.handleGetOperationalIntentConformance)
+		api.POST("/telemetry", s.handleTelemetry)
+	}
+
 	api.POST("/batteries", s.handleCreateBattery)
 	api.POST("/maintenance-events", s.handleCreateMaintenanceEvent)
 
 	return app
+}
+
+func (s *Server) workflowsAvailable() bool {
+	return s.intents != nil && s.preflight != nil && s.conformance != nil
 }

--- a/internal/service/conformance_service.go
+++ b/internal/service/conformance_service.go
@@ -1,0 +1,245 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/Aero-Arc/aero-arc-api/internal/domain"
+	"github.com/Aero-Arc/aero-arc-api/internal/store/durable"
+	"github.com/Aero-Arc/aero-arc-api/internal/store/telemetry"
+)
+
+type ConformanceService struct {
+	durable   durable.Store
+	telemetry telemetry.Store
+	now       func() time.Time
+}
+
+type ConformanceEvaluation struct {
+	Intent  domain.OperationalIntent  `json:"intent"`
+	Summary domain.ConformanceSummary `json:"summary"`
+	Events  []domain.ConformanceEvent `json:"events"`
+}
+
+type telemetryWriter interface {
+	AddSample(ctx context.Context, sample domain.TelemetrySample) error
+}
+
+func NewConformanceService(durableStore durable.Store, telemetryStore telemetry.Store) *ConformanceService {
+	return NewConformanceServiceWithClock(durableStore, telemetryStore, nil)
+}
+
+func NewConformanceServiceWithClock(durableStore durable.Store, telemetryStore telemetry.Store, now func() time.Time) *ConformanceService {
+	if now == nil {
+		now = func() time.Time { return time.Now().UTC() }
+	}
+	return &ConformanceService{durable: durableStore, telemetry: telemetryStore, now: now}
+}
+
+func (s *ConformanceService) EvaluateTelemetry(ctx context.Context, sample domain.TelemetrySample) (ConformanceEvaluation, error) {
+	if sample.RecordedAt.IsZero() {
+		sample.RecordedAt = s.now().UTC()
+	}
+	if writer, ok := s.telemetry.(telemetryWriter); ok {
+		if err := writer.AddSample(ctx, sample); err != nil {
+			return ConformanceEvaluation{}, fmt.Errorf("add telemetry sample: %w", err)
+		}
+	}
+
+	intent, err := s.activeIntentForAircraft(ctx, sample.AircraftID, sample.RecordedAt)
+	if err != nil {
+		return ConformanceEvaluation{}, err
+	}
+	volumes, err := s.durable.ListOperationalVolumes(ctx, intent.ID)
+	if err != nil {
+		return ConformanceEvaluation{}, fmt.Errorf("list operational volumes: %w", err)
+	}
+
+	expectedVolumeID := ""
+	inside := false
+	for _, volume := range volumes {
+		if expectedVolumeID == "" {
+			expectedVolumeID = volume.ID
+		}
+		if sampleInsideVolume(sample, volume) {
+			expectedVolumeID = volume.ID
+			inside = true
+			break
+		}
+	}
+
+	score := 1.0
+	status := domain.ConformanceStatusConforming
+	reportability := domain.ReportabilityStatusNo
+	events := make([]domain.ConformanceEvent, 0)
+	if !inside {
+		score = 0
+		status = domain.ConformanceStatusNonConforming
+		reportability = domain.ReportabilityStatusReview
+		event := domain.ConformanceEvent{
+			ID:               conformanceEventID(sample, intent),
+			OperatorID:       intent.OperatorID,
+			IntentID:         intent.ID,
+			IntentVersion:    intent.Version,
+			FlightID:         sample.FlightID,
+			AircraftID:       sample.AircraftID,
+			Severity:         domain.SeverityWarning,
+			EventCode:        domain.ConformanceEventIntentExit,
+			ExpectedVolumeID: expectedVolumeID,
+			Message:          "telemetry sample is outside all active operational volumes",
+			Latitude:         &sample.Latitude,
+			Longitude:        &sample.Longitude,
+			AltitudeM:        &sample.AltitudeM,
+			AltitudeRef:      domain.AltitudeReferenceAGL,
+			OccurredAt:       sample.RecordedAt.UTC(),
+		}
+		if err := s.durable.RecordConformanceEvent(ctx, event); err != nil {
+			return ConformanceEvaluation{}, fmt.Errorf("record conformance event: %w", err)
+		}
+		events = append(events, event)
+	}
+
+	summary := domain.ConformanceSummary{
+		ID:                  fmt.Sprintf("conformance-%s", intent.ID),
+		OperatorID:          intent.OperatorID,
+		IntentID:            intent.ID,
+		IntentVersion:       intent.Version,
+		FlightID:            sample.FlightID,
+		AircraftID:          sample.AircraftID,
+		Status:              status,
+		Score:               &score,
+		AlertCount:          len(events),
+		ReportabilityStatus: reportability,
+		UpdatedAt:           s.now().UTC(),
+	}
+	if existing, err := s.durable.GetConformanceSummary(ctx, intent.ID); err != nil {
+		return ConformanceEvaluation{}, fmt.Errorf("get conformance summary: %w", err)
+	} else if existing != nil && !inside {
+		summary.AlertCount = existing.AlertCount + len(events)
+	}
+	if err := s.durable.UpsertConformanceSummary(ctx, summary); err != nil {
+		return ConformanceEvaluation{}, fmt.Errorf("upsert conformance summary: %w", err)
+	}
+
+	return ConformanceEvaluation{Intent: intent, Summary: summary, Events: events}, nil
+}
+
+func (s *ConformanceService) GetIntentConformance(ctx context.Context, intentID string) (ConformanceEvaluation, error) {
+	intent, err := s.durable.GetOperationalIntent(ctx, intentID)
+	if err != nil {
+		return ConformanceEvaluation{}, fmt.Errorf("get operational intent: %w", err)
+	}
+	summary, err := s.durable.GetConformanceSummary(ctx, intent.ID)
+	if err != nil {
+		return ConformanceEvaluation{}, fmt.Errorf("get conformance summary: %w", err)
+	}
+	events, err := s.durable.ListConformanceEvents(ctx, "")
+	if err != nil {
+		return ConformanceEvaluation{}, fmt.Errorf("list conformance events: %w", err)
+	}
+	filtered := make([]domain.ConformanceEvent, 0)
+	for _, event := range events {
+		if event.IntentID == intent.ID {
+			filtered = append(filtered, event)
+		}
+	}
+	if summary == nil {
+		return ConformanceEvaluation{Intent: intent, Events: filtered}, nil
+	}
+	return ConformanceEvaluation{Intent: intent, Summary: *summary, Events: filtered}, nil
+}
+
+func (s *ConformanceService) activeIntentForAircraft(ctx context.Context, aircraftID string, recordedAt time.Time) (domain.OperationalIntent, error) {
+	intents, err := s.durable.ListOperationalIntents(ctx, aircraftID)
+	if err != nil {
+		return domain.OperationalIntent{}, fmt.Errorf("list operational intents: %w", err)
+	}
+	for _, intent := range intents {
+		if intent.Status != domain.IntentStatusActive {
+			continue
+		}
+		if !recordedAt.Before(intent.PlannedStartAt) && !recordedAt.After(intent.PlannedEndAt) {
+			return intent, nil
+		}
+	}
+	for _, intent := range intents {
+		if intent.Status == domain.IntentStatusActive {
+			return intent, nil
+		}
+	}
+	return domain.OperationalIntent{}, fmt.Errorf("%w: active operational intent for aircraft %s", durable.ErrNotFound, aircraftID)
+}
+
+func sampleInsideVolume(sample domain.TelemetrySample, volume domain.OperationalVolume) bool {
+	if sample.RecordedAt.Before(volume.StartsAt) || sample.RecordedAt.After(volume.EndsAt) {
+		return false
+	}
+	if sample.AltitudeM < volume.MinAltitudeM || sample.AltitudeM > volume.MaxAltitudeM {
+		return false
+	}
+	if volume.GeoJSON == "" {
+		return true
+	}
+	return pointInGeoJSONPolygon(sample.Longitude, sample.Latitude, []byte(volume.GeoJSON))
+}
+
+func conformanceEventID(sample domain.TelemetrySample, intent domain.OperationalIntent) string {
+	if sample.ID != "" {
+		return fmt.Sprintf("conformance-event-%s-intent-exit", sample.ID)
+	}
+	return fmt.Sprintf("conformance-event-%s-%d-intent-exit", intent.ID, sample.RecordedAt.UTC().UnixNano())
+}
+
+func pointInGeoJSONPolygon(lon, lat float64, raw []byte) bool {
+	var payload struct {
+		Type        string          `json:"type"`
+		Geometry    json.RawMessage `json:"geometry"`
+		Coordinates json.RawMessage `json:"coordinates"`
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return false
+	}
+	coords := payload.Coordinates
+	if payload.Type == "Feature" {
+		var geometry struct {
+			Type        string          `json:"type"`
+			Coordinates json.RawMessage `json:"coordinates"`
+		}
+		if err := json.Unmarshal(payload.Geometry, &geometry); err != nil || geometry.Type != "Polygon" {
+			return false
+		}
+		coords = geometry.Coordinates
+	} else if payload.Type != "Polygon" {
+		return false
+	}
+
+	var polygon [][][]float64
+	if err := json.Unmarshal(coords, &polygon); err != nil || len(polygon) == 0 {
+		return false
+	}
+	return pointInRing(lon, lat, polygon[0])
+}
+
+func pointInRing(lon, lat float64, ring [][]float64) bool {
+	if len(ring) < 3 {
+		return false
+	}
+	inside := false
+	j := len(ring) - 1
+	for i := range ring {
+		if len(ring[i]) < 2 || len(ring[j]) < 2 {
+			j = i
+			continue
+		}
+		xi, yi := ring[i][0], ring[i][1]
+		xj, yj := ring[j][0], ring[j][1]
+		intersects := ((yi > lat) != (yj > lat)) && (lon < (xj-xi)*(lat-yi)/(yj-yi)+xi)
+		if intersects {
+			inside = !inside
+		}
+		j = i
+	}
+	return inside
+}

--- a/internal/service/conformance_service.go
+++ b/internal/service/conformance_service.go
@@ -78,12 +78,8 @@ func (s *ConformanceService) EvaluateTelemetry(ctx context.Context, sample domai
 	if err != nil {
 		return ConformanceEvaluation{}, fmt.Errorf("get conformance summary: %w", err)
 	}
-	alertCount := len(events)
-	if existing != nil {
-		alertCount = existing.AlertCount
-		if existing.ReportabilityStatus != domain.ReportabilityStatusNo {
-			reportability = existing.ReportabilityStatus
-		}
+	if existing != nil && existing.ReportabilityStatus != domain.ReportabilityStatusNo {
+		reportability = existing.ReportabilityStatus
 	}
 	if !inside {
 		score = 0
@@ -112,7 +108,10 @@ func (s *ConformanceService) EvaluateTelemetry(ctx context.Context, sample domai
 			return ConformanceEvaluation{}, fmt.Errorf("record conformance event: %w", err)
 		}
 		events = append(events, event)
-		alertCount += len(events)
+	}
+	alertCount, err := s.alertCount(ctx, intent)
+	if err != nil {
+		return ConformanceEvaluation{}, err
 	}
 
 	summary := domain.ConformanceSummary{
@@ -133,6 +132,20 @@ func (s *ConformanceService) EvaluateTelemetry(ctx context.Context, sample domai
 	}
 
 	return ConformanceEvaluation{Intent: intent, Summary: summary, Events: events}, nil
+}
+
+func (s *ConformanceService) alertCount(ctx context.Context, intent domain.OperationalIntent) (int, error) {
+	events, err := s.durable.ListConformanceEvents(ctx, "")
+	if err != nil {
+		return 0, fmt.Errorf("list conformance events: %w", err)
+	}
+	unique := make(map[string]struct{})
+	for _, event := range events {
+		if event.IntentID == intent.ID && event.IntentVersion == intent.Version {
+			unique[event.ID] = struct{}{}
+		}
+	}
+	return len(unique), nil
 }
 
 func (s *ConformanceService) GetIntentConformance(ctx context.Context, intentID string) (ConformanceEvaluation, error) {
@@ -189,7 +202,7 @@ func sampleInsideVolume(sample domain.TelemetrySample, volume domain.Operational
 		return false
 	}
 	if volume.GeoJSON == "" {
-		return true
+		return false
 	}
 	return pointInGeoJSONPolygon(sample.Longitude, sample.Latitude, []byte(volume.GeoJSON))
 }
@@ -228,7 +241,15 @@ func pointInGeoJSONPolygon(lon, lat float64, raw []byte) bool {
 	if err := json.Unmarshal(coords, &polygon); err != nil || len(polygon) == 0 {
 		return false
 	}
-	return pointInRing(lon, lat, polygon[0])
+	if !pointInRing(lon, lat, polygon[0]) {
+		return false
+	}
+	for _, hole := range polygon[1:] {
+		if pointInRing(lon, lat, hole) {
+			return false
+		}
+	}
+	return true
 }
 
 func pointInRing(lon, lat float64, ring [][]float64) bool {

--- a/internal/service/conformance_service.go
+++ b/internal/service/conformance_service.go
@@ -48,13 +48,20 @@ func (s *ConformanceService) EvaluateTelemetry(ctx context.Context, sample domai
 		}
 	}
 
-	intent, err := s.activeIntentForAircraft(ctx, sample.AircraftID, sample.RecordedAt)
+	intent, err := s.resolveIntentForTelemetry(ctx, sample)
 	if err != nil {
 		return ConformanceEvaluation{}, err
 	}
 	volumes, err := s.durable.ListOperationalVolumes(ctx, intent.ID)
 	if err != nil {
 		return ConformanceEvaluation{}, fmt.Errorf("list operational volumes: %w", err)
+	}
+	if len(volumes) == 0 {
+		summary, err := s.unknownSummary(ctx, intent, sample)
+		if err != nil {
+			return ConformanceEvaluation{}, err
+		}
+		return ConformanceEvaluation{Intent: intent, Summary: summary, Events: nil}, nil
 	}
 
 	expectedVolumeID := ""
@@ -132,6 +139,55 @@ func (s *ConformanceService) EvaluateTelemetry(ctx context.Context, sample domai
 	}
 
 	return ConformanceEvaluation{Intent: intent, Summary: summary, Events: events}, nil
+}
+
+func (s *ConformanceService) resolveIntentForTelemetry(ctx context.Context, sample domain.TelemetrySample) (domain.OperationalIntent, error) {
+	if sample.IntentID == "" {
+		return s.activeIntentForAircraft(ctx, sample.AircraftID, sample.RecordedAt)
+	}
+
+	intent, err := s.durable.GetOperationalIntent(ctx, sample.IntentID)
+	if err != nil {
+		return domain.OperationalIntent{}, fmt.Errorf("get operational intent: %w", err)
+	}
+	if intent.AircraftID != sample.AircraftID {
+		return domain.OperationalIntent{}, fmt.Errorf("%w: telemetry aircraft_id %s does not match intent aircraft_id %s", ErrValidation, sample.AircraftID, intent.AircraftID)
+	}
+	if intent.Status != domain.IntentStatusActive {
+		return domain.OperationalIntent{}, fmt.Errorf("%w: referenced intent %s is not active", ErrActivationBlocked, intent.ID)
+	}
+	if sample.RecordedAt.Before(intent.PlannedStartAt) || sample.RecordedAt.After(intent.PlannedEndAt) {
+		return domain.OperationalIntent{}, fmt.Errorf("%w: telemetry time is outside referenced intent window", ErrActivationBlocked)
+	}
+	return intent, nil
+}
+
+func (s *ConformanceService) unknownSummary(ctx context.Context, intent domain.OperationalIntent, sample domain.TelemetrySample) (domain.ConformanceSummary, error) {
+	reportability := domain.ReportabilityStatusNo
+	alertCount := 0
+	if existing, err := s.durable.GetConformanceSummary(ctx, intent.ID); err != nil {
+		return domain.ConformanceSummary{}, fmt.Errorf("get conformance summary: %w", err)
+	} else if existing != nil {
+		reportability = existing.ReportabilityStatus
+		alertCount = existing.AlertCount
+	}
+
+	summary := domain.ConformanceSummary{
+		ID:                  fmt.Sprintf("conformance-%s", intent.ID),
+		OperatorID:          intent.OperatorID,
+		IntentID:            intent.ID,
+		IntentVersion:       intent.Version,
+		FlightID:            sample.FlightID,
+		AircraftID:          sample.AircraftID,
+		Status:              domain.ConformanceStatusUnknown,
+		AlertCount:          alertCount,
+		ReportabilityStatus: reportability,
+		UpdatedAt:           s.now().UTC(),
+	}
+	if err := s.durable.UpsertConformanceSummary(ctx, summary); err != nil {
+		return domain.ConformanceSummary{}, fmt.Errorf("upsert conformance summary: %w", err)
+	}
+	return summary, nil
 }
 
 func (s *ConformanceService) alertCount(ctx context.Context, intent domain.OperationalIntent) (int, error) {

--- a/internal/service/conformance_service.go
+++ b/internal/service/conformance_service.go
@@ -74,10 +74,23 @@ func (s *ConformanceService) EvaluateTelemetry(ctx context.Context, sample domai
 	status := domain.ConformanceStatusConforming
 	reportability := domain.ReportabilityStatusNo
 	events := make([]domain.ConformanceEvent, 0)
+	existing, err := s.durable.GetConformanceSummary(ctx, intent.ID)
+	if err != nil {
+		return ConformanceEvaluation{}, fmt.Errorf("get conformance summary: %w", err)
+	}
+	alertCount := len(events)
+	if existing != nil {
+		alertCount = existing.AlertCount
+		if existing.ReportabilityStatus != domain.ReportabilityStatusNo {
+			reportability = existing.ReportabilityStatus
+		}
+	}
 	if !inside {
 		score = 0
 		status = domain.ConformanceStatusNonConforming
-		reportability = domain.ReportabilityStatusReview
+		if reportability == domain.ReportabilityStatusNo {
+			reportability = domain.ReportabilityStatusReview
+		}
 		event := domain.ConformanceEvent{
 			ID:               conformanceEventID(sample, intent),
 			OperatorID:       intent.OperatorID,
@@ -99,6 +112,7 @@ func (s *ConformanceService) EvaluateTelemetry(ctx context.Context, sample domai
 			return ConformanceEvaluation{}, fmt.Errorf("record conformance event: %w", err)
 		}
 		events = append(events, event)
+		alertCount += len(events)
 	}
 
 	summary := domain.ConformanceSummary{
@@ -110,14 +124,9 @@ func (s *ConformanceService) EvaluateTelemetry(ctx context.Context, sample domai
 		AircraftID:          sample.AircraftID,
 		Status:              status,
 		Score:               &score,
-		AlertCount:          len(events),
+		AlertCount:          alertCount,
 		ReportabilityStatus: reportability,
 		UpdatedAt:           s.now().UTC(),
-	}
-	if existing, err := s.durable.GetConformanceSummary(ctx, intent.ID); err != nil {
-		return ConformanceEvaluation{}, fmt.Errorf("get conformance summary: %w", err)
-	} else if existing != nil && !inside {
-		summary.AlertCount = existing.AlertCount + len(events)
 	}
 	if err := s.durable.UpsertConformanceSummary(ctx, summary); err != nil {
 		return ConformanceEvaluation{}, fmt.Errorf("upsert conformance summary: %w", err)

--- a/internal/service/fleet_service.go
+++ b/internal/service/fleet_service.go
@@ -334,6 +334,8 @@ func CalculateReadiness(battery *domain.Battery, maintenanceEvents []domain.Main
 
 	if battery == nil {
 		reasons = append(reasons, "battery missing")
+	} else if battery.StateOfHealth == nil {
+		reasons = append(reasons, "battery state of health unknown")
 	} else if battery.StateOfHealth != nil && *battery.StateOfHealth < 80 {
 		reasons = append(reasons, "battery state of health below 80")
 	}

--- a/internal/service/fleet_service_test.go
+++ b/internal/service/fleet_service_test.go
@@ -108,8 +108,47 @@ func TestReadinessCalculation(t *testing.T) {
 		t.Fatalf("missing live state readiness = %q, want warning", got.Status)
 	}
 
+	unknownSOH := &domain.Battery{ID: "battery-1"}
+	got := CalculateReadiness(unknownSOH, nil, true)
+	if got.Status != "warning" {
+		t.Fatalf("unknown SOH readiness = %q, want warning", got.Status)
+	}
+	if len(got.Reasons) != 1 || got.Reasons[0] != "battery state of health unknown" {
+		t.Fatalf("unknown SOH reasons = %#v, want battery state of health unknown", got.Reasons)
+	}
+
 	if got := CalculateReadiness(battery, nil, true); got.Status != "ready" {
 		t.Fatalf("healthy readiness = %q, want ready", got.Status)
+	}
+}
+
+func TestFleetServiceReadinessDoesNotReportReadyWhenBatterySOHUnknown(t *testing.T) {
+	ctx := context.Background()
+	now := time.Now().UTC()
+	durable := durablememory.NewStore()
+	telemetry := telemetrymemory.NewStore()
+	replay := replaymemory.NewStore()
+	registry := newTestRegistry()
+
+	must(t, durable.CreateAircraft(ctx, domain.Aircraft{ID: "aircraft-1", AgentID: "agent-1", TailNumber: "N100AA"}))
+	must(t, durable.CreateBattery(ctx, domain.Battery{ID: "battery-1"}))
+	must(t, durable.RecordBatteryInstallation(ctx, domain.BatteryInstallation{
+		ID: "install-1", AircraftID: "aircraft-1", BatteryID: "battery-1", InstalledAt: now,
+	}))
+	must(t, registry.SetLiveAircraftState(ctx, domain.LiveAircraftState{
+		AircraftID: "aircraft-1", AgentID: "agent-1", RelayID: "relay-1", Connected: true,
+	}))
+
+	svc := NewFleetService(durable, telemetry, replay, registry)
+	dashboard, err := svc.GetAircraftDashboard(ctx, "aircraft-1")
+	if err != nil {
+		t.Fatalf("GetAircraftDashboard returned error: %v", err)
+	}
+	if dashboard.Readiness.Status == domain.ReadinessStatusReady {
+		t.Fatal("readiness should not be ready when battery state of health is unknown")
+	}
+	if len(dashboard.Readiness.Reasons) != 1 || dashboard.Readiness.Reasons[0] != "battery state of health unknown" {
+		t.Fatalf("readiness reasons = %#v, want battery state of health unknown", dashboard.Readiness.Reasons)
 	}
 }
 

--- a/internal/service/intent_service.go
+++ b/internal/service/intent_service.go
@@ -248,13 +248,16 @@ func (s *IntentService) activationReadiness(ctx context.Context, intent domain.O
 	if err != nil {
 		return fmt.Errorf("list preflight checks: %w", err)
 	}
+	if len(checks) == 0 {
+		return fmt.Errorf("%w: current preflight checks are required", ErrActivationBlocked)
+	}
 	for _, check := range checks {
 		if check.Blocking && (check.Status == domain.PreflightStatusBlocked || check.Status == domain.PreflightStatusAction) {
 			return fmt.Errorf("%w: blocking preflight check %s", ErrActivationBlocked, check.ID)
 		}
 	}
 
-	findings, err := s.durable.ListComplianceFindings(ctx, "operational_intent", intent.ID)
+	findings, err := s.durable.ListComplianceFindingsForIntent(ctx, intent.ID)
 	if err != nil {
 		return fmt.Errorf("list compliance findings: %w", err)
 	}

--- a/internal/service/intent_service.go
+++ b/internal/service/intent_service.go
@@ -1,0 +1,267 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/Aero-Arc/aero-arc-api/internal/domain"
+	"github.com/Aero-Arc/aero-arc-api/internal/store/durable"
+)
+
+var (
+	ErrInvalidTransition = errors.New("invalid intent lifecycle transition")
+	ErrActivationBlocked = errors.New("intent activation blocked")
+	ErrValidation        = errors.New("validation failed")
+)
+
+type IntentService struct {
+	durable durable.Store
+	now     func() time.Time
+}
+
+type CreateIntentRequest struct {
+	ID                  string                    `json:"id,omitempty"`
+	OperatorID          string                    `json:"operator_id,omitempty"`
+	AircraftID          string                    `json:"aircraft_id"`
+	AuthorizationID     string                    `json:"authorization_id,omitempty"`
+	Name                string                    `json:"name"`
+	Summary             string                    `json:"summary"`
+	UseCase             string                    `json:"use_case,omitempty"`
+	AuthorizationPath   domain.AuthorizationPath  `json:"authorization_path,omitempty"`
+	PopulationCategory  domain.PopulationCategory `json:"population_category,omitempty"`
+	ConformanceRequired bool                      `json:"conformance_required"`
+	OperatingAreaID     string                    `json:"operating_area_id,omitempty"`
+	RouteSummary        string                    `json:"route_summary,omitempty"`
+	PlannedStartAt      time.Time                 `json:"planned_start_at"`
+	PlannedEndAt        time.Time                 `json:"planned_end_at"`
+	MinAltitudeFtAGL    *float64                  `json:"min_altitude_ft_agl,omitempty"`
+	MaxAltitudeFtAGL    *float64                  `json:"max_altitude_ft_agl,omitempty"`
+	SupervisorID        string                    `json:"supervisor_id,omitempty"`
+	FlightCoordinatorID string                    `json:"flight_coordinator_id,omitempty"`
+}
+
+type AddOperationalVolumeRequest struct {
+	ID           string                       `json:"id,omitempty"`
+	Sequence     int                          `json:"sequence"`
+	GeometryURI  string                       `json:"geometry_uri,omitempty"`
+	GeoJSON      string                       `json:"geojson,omitempty"`
+	MinAltitudeM float64                      `json:"min_altitude_m"`
+	MaxAltitudeM float64                      `json:"max_altitude_m"`
+	AltitudeRef  domain.AltitudeReference     `json:"altitude_ref,omitempty"`
+	StartsAt     time.Time                    `json:"starts_at"`
+	EndsAt       time.Time                    `json:"ends_at"`
+	BufferMeters *float64                     `json:"buffer_meters,omitempty"`
+	VolumeType   domain.OperationalVolumeType `json:"volume_type,omitempty"`
+}
+
+func NewIntentService(durableStore durable.Store) *IntentService {
+	return NewIntentServiceWithClock(durableStore, nil)
+}
+
+func NewIntentServiceWithClock(durableStore durable.Store, now func() time.Time) *IntentService {
+	if now == nil {
+		now = func() time.Time { return time.Now().UTC() }
+	}
+	return &IntentService{durable: durableStore, now: now}
+}
+
+func (s *IntentService) CreateIntent(ctx context.Context, req CreateIntentRequest) (domain.OperationalIntent, error) {
+	now := s.now().UTC()
+	id := strings.TrimSpace(req.ID)
+	if id == "" {
+		id = fmt.Sprintf("intent-%d", now.UnixNano())
+	}
+	if strings.TrimSpace(req.AircraftID) == "" {
+		return domain.OperationalIntent{}, fmt.Errorf("%w: aircraft_id is required", ErrValidation)
+	}
+	if req.PlannedStartAt.IsZero() || req.PlannedEndAt.IsZero() {
+		return domain.OperationalIntent{}, fmt.Errorf("%w: planned start and end are required", ErrValidation)
+	}
+
+	intent := domain.OperationalIntent{
+		ID:                  id,
+		OperatorID:          req.OperatorID,
+		AircraftID:          req.AircraftID,
+		AuthorizationID:     req.AuthorizationID,
+		Version:             1,
+		Name:                req.Name,
+		Summary:             req.Summary,
+		UseCase:             req.UseCase,
+		AuthorizationPath:   req.AuthorizationPath,
+		PopulationCategory:  req.PopulationCategory,
+		Status:              domain.IntentStatusDraft,
+		ConformanceRequired: req.ConformanceRequired,
+		OperatingAreaID:     req.OperatingAreaID,
+		RouteSummary:        req.RouteSummary,
+		PlannedStartAt:      req.PlannedStartAt.UTC(),
+		PlannedEndAt:        req.PlannedEndAt.UTC(),
+		MinAltitudeFtAGL:    req.MinAltitudeFtAGL,
+		MaxAltitudeFtAGL:    req.MaxAltitudeFtAGL,
+		SupervisorID:        req.SupervisorID,
+		FlightCoordinatorID: req.FlightCoordinatorID,
+		UpdatedAt:           now,
+	}
+	if intent.AuthorizationPath == "" {
+		intent.AuthorizationPath = domain.AuthorizationPathUnknown
+	}
+	if intent.PopulationCategory == "" {
+		intent.PopulationCategory = domain.PopulationCategoryUnknown
+	}
+
+	if err := s.durable.CreateOperationalIntent(ctx, intent); err != nil {
+		return domain.OperationalIntent{}, fmt.Errorf("create operational intent: %w", err)
+	}
+	return intent, nil
+}
+
+func (s *IntentService) AddOperationalVolume(ctx context.Context, intentID string, req AddOperationalVolumeRequest) (domain.OperationalVolume, error) {
+	intent, err := s.durable.GetOperationalIntent(ctx, intentID)
+	if err != nil {
+		return domain.OperationalVolume{}, fmt.Errorf("get operational intent: %w", err)
+	}
+
+	now := s.now().UTC()
+	id := strings.TrimSpace(req.ID)
+	if id == "" {
+		id = fmt.Sprintf("%s-volume-%d", intent.ID, now.UnixNano())
+	}
+	volume := domain.OperationalVolume{
+		ID:            id,
+		OperatorID:    intent.OperatorID,
+		IntentID:      intent.ID,
+		IntentVersion: intent.Version,
+		Sequence:      req.Sequence,
+		GeometryURI:   req.GeometryURI,
+		GeoJSON:       req.GeoJSON,
+		MinAltitudeM:  req.MinAltitudeM,
+		MaxAltitudeM:  req.MaxAltitudeM,
+		AltitudeRef:   req.AltitudeRef,
+		StartsAt:      req.StartsAt.UTC(),
+		EndsAt:        req.EndsAt.UTC(),
+		BufferMeters:  req.BufferMeters,
+		VolumeType:    req.VolumeType,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}
+	if volume.AltitudeRef == "" {
+		volume.AltitudeRef = domain.AltitudeReferenceAGL
+	}
+	if err := s.durable.RecordOperationalVolume(ctx, volume); err != nil {
+		return domain.OperationalVolume{}, fmt.Errorf("record operational volume: %w", err)
+	}
+	return volume, nil
+}
+
+func (s *IntentService) SubmitIntent(ctx context.Context, intentID string) (domain.OperationalIntent, error) {
+	return s.transitionIntent(ctx, intentID, domain.IntentStatusSubmitted, map[domain.IntentStatus]bool{
+		domain.IntentStatusDraft: true,
+	}, func(intent *domain.OperationalIntent, now time.Time) {
+		intent.SubmittedAt = &now
+	})
+}
+
+func (s *IntentService) AcceptIntent(ctx context.Context, intentID string) (domain.OperationalIntent, error) {
+	return s.transitionIntent(ctx, intentID, domain.IntentStatusAccepted, map[domain.IntentStatus]bool{
+		domain.IntentStatusSubmitted: true,
+		domain.IntentStatusReview:    true,
+	}, func(intent *domain.OperationalIntent, now time.Time) {
+		intent.AcceptedAt = &now
+	})
+}
+
+func (s *IntentService) ActivateIntent(ctx context.Context, intentID string) (domain.OperationalIntent, error) {
+	intent, err := s.durable.GetOperationalIntent(ctx, intentID)
+	if err != nil {
+		return domain.OperationalIntent{}, fmt.Errorf("get operational intent: %w", err)
+	}
+	if intent.Status != domain.IntentStatusAccepted {
+		return domain.OperationalIntent{}, fmt.Errorf("%w: %s -> %s", ErrInvalidTransition, intent.Status, domain.IntentStatusActive)
+	}
+	if err := s.activationReadiness(ctx, intent); err != nil {
+		return domain.OperationalIntent{}, err
+	}
+
+	now := s.now().UTC()
+	intent.Status = domain.IntentStatusActive
+	intent.ActivatedAt = &now
+	intent.UpdatedAt = now
+	if err := s.durable.UpdateOperationalIntent(ctx, intent); err != nil {
+		return domain.OperationalIntent{}, fmt.Errorf("update operational intent: %w", err)
+	}
+	return intent, nil
+}
+
+func (s *IntentService) CompleteIntent(ctx context.Context, intentID string) (domain.OperationalIntent, error) {
+	return s.transitionIntent(ctx, intentID, domain.IntentStatusComplete, map[domain.IntentStatus]bool{
+		domain.IntentStatusActive: true,
+	}, func(intent *domain.OperationalIntent, now time.Time) {
+		intent.CompletedAt = &now
+	})
+}
+
+func (s *IntentService) CancelIntent(ctx context.Context, intentID string) (domain.OperationalIntent, error) {
+	return s.transitionIntent(ctx, intentID, domain.IntentStatusCanceled, map[domain.IntentStatus]bool{
+		domain.IntentStatusDraft:     true,
+		domain.IntentStatusSubmitted: true,
+		domain.IntentStatusReview:    true,
+		domain.IntentStatusAccepted:  true,
+		domain.IntentStatusActive:    true,
+	}, func(intent *domain.OperationalIntent, now time.Time) {
+		intent.CanceledAt = &now
+	})
+}
+
+func (s *IntentService) transitionIntent(ctx context.Context, intentID string, next domain.IntentStatus, allowed map[domain.IntentStatus]bool, mutate func(*domain.OperationalIntent, time.Time)) (domain.OperationalIntent, error) {
+	intent, err := s.durable.GetOperationalIntent(ctx, intentID)
+	if err != nil {
+		return domain.OperationalIntent{}, fmt.Errorf("get operational intent: %w", err)
+	}
+	if !allowed[intent.Status] {
+		return domain.OperationalIntent{}, fmt.Errorf("%w: %s -> %s", ErrInvalidTransition, intent.Status, next)
+	}
+
+	now := s.now().UTC()
+	intent.Status = next
+	intent.UpdatedAt = now
+	if mutate != nil {
+		mutate(&intent, now)
+	}
+	if err := s.durable.UpdateOperationalIntent(ctx, intent); err != nil {
+		return domain.OperationalIntent{}, fmt.Errorf("update operational intent: %w", err)
+	}
+	return intent, nil
+}
+
+func (s *IntentService) activationReadiness(ctx context.Context, intent domain.OperationalIntent) error {
+	volumes, err := s.durable.ListOperationalVolumes(ctx, intent.ID)
+	if err != nil {
+		return fmt.Errorf("list operational volumes: %w", err)
+	}
+	if len(volumes) == 0 {
+		return fmt.Errorf("%w: at least one operational volume is required", ErrActivationBlocked)
+	}
+
+	checks, err := s.durable.ListPreflightChecks(ctx, intent.ID)
+	if err != nil {
+		return fmt.Errorf("list preflight checks: %w", err)
+	}
+	for _, check := range checks {
+		if check.Blocking && (check.Status == domain.PreflightStatusBlocked || check.Status == domain.PreflightStatusAction) {
+			return fmt.Errorf("%w: blocking preflight check %s", ErrActivationBlocked, check.ID)
+		}
+	}
+
+	findings, err := s.durable.ListComplianceFindings(ctx, "operational_intent", intent.ID)
+	if err != nil {
+		return fmt.Errorf("list compliance findings: %w", err)
+	}
+	for _, finding := range findings {
+		if finding.Blocking && (finding.Status == domain.ComplianceFindingFail || finding.Status == domain.ComplianceFindingReview) {
+			return fmt.Errorf("%w: blocking compliance finding %s", ErrActivationBlocked, finding.ID)
+		}
+	}
+	return nil
+}

--- a/internal/service/intent_service.go
+++ b/internal/service/intent_service.go
@@ -122,6 +122,9 @@ func (s *IntentService) AddOperationalVolume(ctx context.Context, intentID strin
 	if err != nil {
 		return domain.OperationalVolume{}, fmt.Errorf("get operational intent: %w", err)
 	}
+	if intent.Status != domain.IntentStatusDraft {
+		return domain.OperationalVolume{}, fmt.Errorf("%w: operational volumes are locked after draft status (%s)", ErrInvalidTransition, intent.Status)
+	}
 
 	now := s.now().UTC()
 	id := strings.TrimSpace(req.ID)

--- a/internal/service/preflight_service.go
+++ b/internal/service/preflight_service.go
@@ -191,6 +191,21 @@ func (b *preflightBuilder) check(category domain.PreflightCheckCategory, key, so
 	}
 	b.checks = append(b.checks, check)
 	if !blocking {
+		b.findings = append(b.findings, domain.ComplianceFinding{
+			ID:              fmt.Sprintf("finding-%s-%s", b.intent.ID, key),
+			OperatorID:      b.intent.OperatorID,
+			IntentID:        b.intent.ID,
+			IntentVersion:   b.intent.Version,
+			SubjectType:     "operational_intent",
+			SubjectID:       b.intent.ID,
+			RequirementCode: requirementCode,
+			Status:          domain.ComplianceFindingPass,
+			Severity:        domain.SeverityInfo,
+			Blocking:        false,
+			RuleVersion:     "demo.v1",
+			Message:         summary,
+			EvaluatedAt:     b.now,
+		})
 		return
 	}
 	b.findings = append(b.findings, domain.ComplianceFinding{

--- a/internal/service/preflight_service.go
+++ b/internal/service/preflight_service.go
@@ -50,7 +50,7 @@ func (s *PreflightService) EvaluateIntent(ctx context.Context, intentID string) 
 		builder.block(domain.PreflightCheckAirspace, "aircraft_exists", "fleet_registry", "AIRCRAFT-EXISTS", "aircraft does not exist", "create or select a valid aircraft")
 	} else {
 		builder.clear(domain.PreflightCheckAirspace, "aircraft_exists", "fleet_registry", "AIRCRAFT-EXISTS", "aircraft exists")
-		if aircraft.Status != domain.AircraftStatusActive && aircraft.AcceptanceStatus != domain.AcceptanceStatusAccepted {
+		if aircraft.Status != domain.AircraftStatusActive || aircraft.AcceptanceStatus != domain.AcceptanceStatusAccepted {
 			builder.block(domain.PreflightCheckAirspace, "aircraft_operational_status", "fleet_registry", "AIRCRAFT-STATUS", "aircraft is not active or accepted", "set aircraft active or complete acceptance")
 		} else {
 			builder.clear(domain.PreflightCheckAirspace, "aircraft_operational_status", "fleet_registry", "AIRCRAFT-STATUS", "aircraft status allows operation")

--- a/internal/service/preflight_service.go
+++ b/internal/service/preflight_service.go
@@ -1,0 +1,212 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/Aero-Arc/aero-arc-api/internal/domain"
+	"github.com/Aero-Arc/aero-arc-api/internal/store/durable"
+)
+
+type PreflightService struct {
+	durable durable.Store
+	now     func() time.Time
+}
+
+type PreflightEvaluation struct {
+	Intent   domain.OperationalIntent   `json:"intent"`
+	Checks   []domain.PreflightCheck    `json:"checks"`
+	Findings []domain.ComplianceFinding `json:"findings"`
+	Blocked  bool                       `json:"blocked"`
+}
+
+func NewPreflightService(durableStore durable.Store) *PreflightService {
+	return NewPreflightServiceWithClock(durableStore, nil)
+}
+
+func NewPreflightServiceWithClock(durableStore durable.Store, now func() time.Time) *PreflightService {
+	if now == nil {
+		now = func() time.Time { return time.Now().UTC() }
+	}
+	return &PreflightService{durable: durableStore, now: now}
+}
+
+func (s *PreflightService) EvaluateIntent(ctx context.Context, intentID string) (PreflightEvaluation, error) {
+	intent, err := s.durable.GetOperationalIntent(ctx, intentID)
+	if err != nil {
+		return PreflightEvaluation{}, fmt.Errorf("get operational intent: %w", err)
+	}
+
+	aircraft, aircraftErr := s.durable.GetAircraft(ctx, intent.AircraftID)
+	volumes, err := s.durable.ListOperationalVolumes(ctx, intent.ID)
+	if err != nil {
+		return PreflightEvaluation{}, fmt.Errorf("list operational volumes: %w", err)
+	}
+
+	now := s.now().UTC()
+	builder := preflightBuilder{intent: intent, now: now}
+	if aircraftErr != nil {
+		builder.block(domain.PreflightCheckAirspace, "aircraft_exists", "fleet_registry", "AIRCRAFT-EXISTS", "aircraft does not exist", "create or select a valid aircraft")
+	} else {
+		builder.clear(domain.PreflightCheckAirspace, "aircraft_exists", "fleet_registry", "AIRCRAFT-EXISTS", "aircraft exists")
+		if aircraft.Status != domain.AircraftStatusActive && aircraft.AcceptanceStatus != domain.AcceptanceStatusAccepted {
+			builder.block(domain.PreflightCheckAirspace, "aircraft_operational_status", "fleet_registry", "AIRCRAFT-STATUS", "aircraft is not active or accepted", "set aircraft active or complete acceptance")
+		} else {
+			builder.clear(domain.PreflightCheckAirspace, "aircraft_operational_status", "fleet_registry", "AIRCRAFT-STATUS", "aircraft status allows operation")
+		}
+		if aircraft.RemoteIDStatus == domain.RemoteIDStatusOffline {
+			builder.block(domain.PreflightCheckRemoteID, "remote_id_online", "remote_id_monitor", "RID-ONLINE", "remote ID is offline", "restore Remote ID broadcast before activation")
+		} else {
+			builder.clear(domain.PreflightCheckRemoteID, "remote_id_online", "remote_id_monitor", "RID-ONLINE", "remote ID is not offline")
+		}
+	}
+
+	if intent.PlannedStartAt.Before(intent.PlannedEndAt) {
+		builder.clear(domain.PreflightCheckAirspace, "intent_time_window", "intent_service", "INTENT-WINDOW", "intent planned time window is valid")
+	} else {
+		builder.block(domain.PreflightCheckAirspace, "intent_time_window", "intent_service", "INTENT-WINDOW", "intent planned start must be before planned end", "set planned_start_at before planned_end_at")
+	}
+
+	if len(volumes) == 0 {
+		builder.block(domain.PreflightCheckAirspace, "operational_volume_exists", "intent_service", "VOLUME-EXISTS", "at least one operational volume is required", "add an operational volume")
+	} else {
+		builder.clear(domain.PreflightCheckAirspace, "operational_volume_exists", "intent_service", "VOLUME-EXISTS", "operational volume exists")
+	}
+	for _, volume := range volumes {
+		prefix := fmt.Sprintf("volume_%s", volume.ID)
+		if volume.StartsAt.Before(volume.EndsAt) {
+			builder.clear(domain.PreflightCheckAirspace, prefix+"_time_window", "intent_service", "VOLUME-WINDOW", "operational volume time window is valid")
+		} else {
+			builder.block(domain.PreflightCheckAirspace, prefix+"_time_window", "intent_service", "VOLUME-WINDOW", "operational volume start must be before end", "set volume starts_at before ends_at")
+		}
+		if volume.MinAltitudeM <= volume.MaxAltitudeM {
+			builder.clear(domain.PreflightCheckAirspace, prefix+"_altitude_range", "intent_service", "VOLUME-ALTITUDE", "operational volume altitude range is valid")
+		} else {
+			builder.block(domain.PreflightCheckAirspace, prefix+"_altitude_range", "intent_service", "VOLUME-ALTITUDE", "operational volume minimum altitude exceeds maximum altitude", "set min_altitude_m <= max_altitude_m")
+		}
+		if !volume.StartsAt.Before(intent.PlannedStartAt) && !volume.EndsAt.After(intent.PlannedEndAt) {
+			builder.clear(domain.PreflightCheckAirspace, prefix+"_inside_intent_window", "intent_service", "VOLUME-IN-INTENT", "operational volume is inside planned intent window")
+		} else {
+			builder.block(domain.PreflightCheckAirspace, prefix+"_inside_intent_window", "intent_service", "VOLUME-IN-INTENT", "operational volume must be inside planned intent window", "adjust volume or planned intent time window")
+		}
+	}
+
+	s.evaluateBattery(ctx, &builder, intent)
+	s.evaluateMaintenance(ctx, &builder, intent)
+	builder.clear(domain.PreflightCheckWeather, "demo_weather", "demo_weather_provider", "WX-DEMO", "demo weather check clear")
+	builder.clear(domain.PreflightCheckNOTAM, "demo_notam", "demo_notam_provider", "NOTAM-DEMO", "demo NOTAM check clear")
+
+	for _, check := range builder.checks {
+		if err := s.durable.RecordPreflightCheck(ctx, check); err != nil {
+			return PreflightEvaluation{}, fmt.Errorf("record preflight check: %w", err)
+		}
+	}
+	for _, finding := range builder.findings {
+		if err := s.durable.RecordComplianceFinding(ctx, finding); err != nil {
+			return PreflightEvaluation{}, fmt.Errorf("record compliance finding: %w", err)
+		}
+	}
+
+	return PreflightEvaluation{
+		Intent:   intent,
+		Checks:   builder.checks,
+		Findings: builder.findings,
+		Blocked:  builder.blocked,
+	}, nil
+}
+
+func (s *PreflightService) evaluateBattery(ctx context.Context, builder *preflightBuilder, intent domain.OperationalIntent) {
+	installation, err := s.durable.GetActiveBatteryInstallation(ctx, intent.AircraftID)
+	if err != nil || installation == nil {
+		builder.block(domain.PreflightCheckBattery, "battery_installed", "maintenance_control", "BATTERY-INSTALLED", "battery is not installed", "install a battery")
+		return
+	}
+	builder.clear(domain.PreflightCheckBattery, "battery_installed", "maintenance_control", "BATTERY-INSTALLED", "battery is installed")
+
+	battery, err := s.durable.GetBattery(ctx, installation.BatteryID)
+	if err != nil {
+		builder.block(domain.PreflightCheckBattery, "battery_soh_known", "maintenance_control", "BATTERY-SOH-KNOWN", "battery state of health is unknown", "record battery state of health")
+		return
+	}
+	if battery.StateOfHealth == nil {
+		builder.block(domain.PreflightCheckBattery, "battery_soh_known", "maintenance_control", "BATTERY-SOH-KNOWN", "battery state of health is unknown", "record battery state of health")
+		return
+	}
+	builder.clear(domain.PreflightCheckBattery, "battery_soh_known", "maintenance_control", "BATTERY-SOH-KNOWN", "battery state of health is known")
+	if *battery.StateOfHealth < 80 {
+		builder.block(domain.PreflightCheckBattery, "battery_soh_minimum", "maintenance_control", "BATTERY-SOH-80", "battery state of health is below 80", "replace or service battery")
+		return
+	}
+	builder.clear(domain.PreflightCheckBattery, "battery_soh_minimum", "maintenance_control", "BATTERY-SOH-80", "battery state of health is at least 80")
+}
+
+func (s *PreflightService) evaluateMaintenance(ctx context.Context, builder *preflightBuilder, intent domain.OperationalIntent) {
+	events, err := s.durable.ListMaintenanceEvents(ctx, intent.AircraftID)
+	if err != nil {
+		builder.block(domain.PreflightCheckMaintenance, "maintenance_events_available", "maintenance_control", "MX-AVAILABLE", "maintenance status could not be loaded", "retry maintenance status lookup")
+		return
+	}
+	for _, event := range events {
+		if event.Severity == domain.SeverityCritical && event.ResolvedAt == nil && event.Status != domain.MaintenanceStatusClosed {
+			builder.block(domain.PreflightCheckMaintenance, "critical_open_maintenance", "maintenance_control", "MX-CRITICAL-OPEN", "critical open maintenance event exists", "resolve critical maintenance before activation")
+			return
+		}
+	}
+	builder.clear(domain.PreflightCheckMaintenance, "critical_open_maintenance", "maintenance_control", "MX-CRITICAL-OPEN", "no critical open maintenance events")
+}
+
+type preflightBuilder struct {
+	intent   domain.OperationalIntent
+	now      time.Time
+	checks   []domain.PreflightCheck
+	findings []domain.ComplianceFinding
+	blocked  bool
+}
+
+func (b *preflightBuilder) clear(category domain.PreflightCheckCategory, key, source, requirementCode, summary string) {
+	b.check(category, key, source, requirementCode, summary, "", domain.PreflightStatusClear, false)
+}
+
+func (b *preflightBuilder) block(category domain.PreflightCheckCategory, key, source, requirementCode, summary, remediation string) {
+	b.check(category, key, source, requirementCode, summary, remediation, domain.PreflightStatusBlocked, true)
+	b.blocked = true
+}
+
+func (b *preflightBuilder) check(category domain.PreflightCheckCategory, key, source, requirementCode, summary, remediation string, status domain.PreflightStatus, blocking bool) {
+	check := domain.PreflightCheck{
+		ID:              fmt.Sprintf("preflight-%s-%s", b.intent.ID, key),
+		OperatorID:      b.intent.OperatorID,
+		IntentID:        b.intent.ID,
+		IntentVersion:   b.intent.Version,
+		AircraftID:      b.intent.AircraftID,
+		Category:        category,
+		Source:          source,
+		Status:          status,
+		Summary:         summary,
+		RequirementCode: requirementCode,
+		RuleVersion:     "demo.v1",
+		Blocking:        blocking,
+		CapturedAt:      b.now,
+	}
+	b.checks = append(b.checks, check)
+	if !blocking {
+		return
+	}
+	b.findings = append(b.findings, domain.ComplianceFinding{
+		ID:              fmt.Sprintf("finding-%s-%s", b.intent.ID, key),
+		OperatorID:      b.intent.OperatorID,
+		IntentID:        b.intent.ID,
+		IntentVersion:   b.intent.Version,
+		SubjectType:     "operational_intent",
+		SubjectID:       b.intent.ID,
+		RequirementCode: requirementCode,
+		Status:          domain.ComplianceFindingFail,
+		Severity:        domain.SeverityCritical,
+		Blocking:        true,
+		RuleVersion:     "demo.v1",
+		Remediation:     remediation,
+		Message:         summary,
+		EvaluatedAt:     b.now,
+	})
+}

--- a/internal/service/preflight_service.go
+++ b/internal/service/preflight_service.go
@@ -90,6 +90,11 @@ func (s *PreflightService) EvaluateIntent(ctx context.Context, intentID string) 
 		} else {
 			builder.block(domain.PreflightCheckAirspace, prefix+"_inside_intent_window", "intent_service", "VOLUME-IN-INTENT", "operational volume must be inside planned intent window", "adjust volume or planned intent time window")
 		}
+		if volume.GeoJSON != "" {
+			builder.clear(domain.PreflightCheckAirspace, prefix+"_inline_geojson", "intent_service", "VOLUME-GEOJSON", "operational volume has inline GeoJSON evaluable by this server")
+		} else {
+			builder.block(domain.PreflightCheckAirspace, prefix+"_inline_geojson", "intent_service", "VOLUME-GEOJSON", "operational volume requires inline GeoJSON for local conformance evaluation", "provide inline GeoJSON; geometry_uri resolution is not implemented")
+		}
 	}
 
 	s.evaluateBattery(ctx, &builder, intent)

--- a/internal/service/workflow_service_test.go
+++ b/internal/service/workflow_service_test.go
@@ -108,6 +108,78 @@ func TestActivationBlockedWhenNoPreflightChecksExist(t *testing.T) {
 	}
 }
 
+func TestAddOperationalVolumeSucceedsForDraftIntent(t *testing.T) {
+	ctx := context.Background()
+	store := durablememory.NewStore()
+	now := fixedWorkflowTime()
+	seedWorkflowAircraft(t, ctx, store, now, float64Ptr(95))
+
+	intents := NewIntentServiceWithClock(store, fixedClock(now))
+	intent, err := intents.CreateIntent(ctx, workflowIntentRequest(now))
+	if err != nil {
+		t.Fatalf("CreateIntent returned error: %v", err)
+	}
+
+	volume, err := intents.AddOperationalVolume(ctx, intent.ID, workflowVolumeRequest(now))
+	if err != nil {
+		t.Fatalf("AddOperationalVolume returned error: %v", err)
+	}
+	if volume.IntentID != intent.ID {
+		t.Fatalf("volume intent ID = %q, want %q", volume.IntentID, intent.ID)
+	}
+}
+
+func TestAddOperationalVolumeFailsAfterSubmit(t *testing.T) {
+	ctx := context.Background()
+	store := durablememory.NewStore()
+	now := fixedWorkflowTime()
+	seedWorkflowAircraft(t, ctx, store, now, float64Ptr(95))
+
+	intents := NewIntentServiceWithClock(store, fixedClock(now))
+	intent, err := intents.CreateIntent(ctx, workflowIntentRequest(now))
+	if err != nil {
+		t.Fatalf("CreateIntent returned error: %v", err)
+	}
+	if _, err = intents.SubmitIntent(ctx, intent.ID); err != nil {
+		t.Fatalf("SubmitIntent returned error: %v", err)
+	}
+
+	if _, err = intents.AddOperationalVolume(ctx, intent.ID, workflowVolumeRequest(now)); !errors.Is(err, ErrInvalidTransition) {
+		t.Fatalf("AddOperationalVolume error = %v, want ErrInvalidTransition", err)
+	}
+}
+
+func TestAddOperationalVolumeFailsAfterAccept(t *testing.T) {
+	ctx := context.Background()
+	store := durablememory.NewStore()
+	now := fixedWorkflowTime()
+	seedWorkflowAircraft(t, ctx, store, now, float64Ptr(95))
+
+	intents := NewIntentServiceWithClock(store, fixedClock(now))
+	intent := seedSubmittedIntentWithVolume(t, ctx, store, now)
+	if _, err := intents.AcceptIntent(ctx, intent.ID); err != nil {
+		t.Fatalf("AcceptIntent returned error: %v", err)
+	}
+
+	if _, err := intents.AddOperationalVolume(ctx, intent.ID, workflowVolumeRequest(now)); !errors.Is(err, ErrInvalidTransition) {
+		t.Fatalf("AddOperationalVolume error = %v, want ErrInvalidTransition", err)
+	}
+}
+
+func TestAddOperationalVolumeFailsAfterActivate(t *testing.T) {
+	ctx := context.Background()
+	store := durablememory.NewStore()
+	now := fixedWorkflowTime()
+	seedWorkflowAircraft(t, ctx, store, now, float64Ptr(95))
+
+	intents := NewIntentServiceWithClock(store, fixedClock(now))
+	intent := seedActiveIntentWithVolume(t, ctx, store, now)
+
+	if _, err := intents.AddOperationalVolume(ctx, intent.ID, workflowVolumeRequest(now)); !errors.Is(err, ErrInvalidTransition) {
+		t.Fatalf("AddOperationalVolume error = %v, want ErrInvalidTransition", err)
+	}
+}
+
 func TestPreflightBlockedWhenBatterySOHMissing(t *testing.T) {
 	ctx := context.Background()
 	store := durablememory.NewStore()

--- a/internal/service/workflow_service_test.go
+++ b/internal/service/workflow_service_test.go
@@ -275,6 +275,35 @@ func TestPreflightBlockedWhenCriticalMaintenanceOpen(t *testing.T) {
 	}
 }
 
+func TestPreflightBlockedWhenOperationalVolumeMissingInlineGeoJSON(t *testing.T) {
+	ctx := context.Background()
+	store := durablememory.NewStore()
+	now := fixedWorkflowTime()
+	seedWorkflowAircraft(t, ctx, store, now, float64Ptr(95))
+	intent := seedSubmittedIntentWithVolumeRequest(t, ctx, store, now, AddOperationalVolumeRequest{
+		ID:           "volume-uri-only",
+		Sequence:     1,
+		GeometryURI:  "s3://demo/volume.geojson",
+		MinAltitudeM: 10,
+		MaxAltitudeM: 120,
+		AltitudeRef:  domain.AltitudeReferenceAGL,
+		StartsAt:     now,
+		EndsAt:       now.Add(time.Hour),
+		VolumeType:   domain.OperationalVolumeLoiter,
+	})
+
+	evaluation, err := NewPreflightServiceWithClock(store, fixedClock(now)).EvaluateIntent(ctx, intent.ID)
+	if err != nil {
+		t.Fatalf("EvaluateIntent returned error: %v", err)
+	}
+	if !evaluation.Blocked {
+		t.Fatal("preflight should block URI-only geometry")
+	}
+	if !hasFinding(evaluation.Findings, "VOLUME-GEOJSON") {
+		t.Fatalf("findings = %#v, want VOLUME-GEOJSON", evaluation.Findings)
+	}
+}
+
 func TestConformanceTelemetryInsideVolumeConforming(t *testing.T) {
 	ctx := context.Background()
 	store := durablememory.NewStore()
@@ -312,6 +341,62 @@ func TestConformanceTelemetryInsideVolumeConforming(t *testing.T) {
 	}
 }
 
+func TestConformanceTelemetryRespectsPolygonInteriorRing(t *testing.T) {
+	ctx := context.Background()
+	store := durablememory.NewStore()
+	telemetry := telemetrymemory.NewStore()
+	now := fixedWorkflowTime()
+	seedWorkflowAircraft(t, ctx, store, now, float64Ptr(95))
+	seedActiveIntentWithVolumeRequest(t, ctx, store, now, AddOperationalVolumeRequest{
+		ID:           "volume-with-hole",
+		Sequence:     1,
+		GeoJSON:      polygonWithHoleGeoJSON(),
+		MinAltitudeM: 10,
+		MaxAltitudeM: 120,
+		AltitudeRef:  domain.AltitudeReferenceAGL,
+		StartsAt:     now,
+		EndsAt:       now.Add(time.Hour),
+		VolumeType:   domain.OperationalVolumeLoiter,
+	})
+	conformance := NewConformanceServiceWithClock(store, telemetry, fixedClock(now))
+
+	inHole, err := conformance.EvaluateTelemetry(ctx, domain.TelemetrySample{
+		ID:         "sample-in-hole",
+		AircraftID: "aircraft-1",
+		RecordedAt: now.Add(30 * time.Minute),
+		Latitude:   35.5,
+		Longitude:  -97.5,
+		AltitudeM:  60,
+	})
+	if err != nil {
+		t.Fatalf("EvaluateTelemetry in hole returned error: %v", err)
+	}
+	if inHole.Summary.Status != domain.ConformanceStatusNonConforming {
+		t.Fatalf("hole sample status = %q, want non_conforming", inHole.Summary.Status)
+	}
+	if len(inHole.Events) != 1 || inHole.Events[0].EventCode != domain.ConformanceEventIntentExit {
+		t.Fatalf("hole events = %#v, want one intent_exit", inHole.Events)
+	}
+
+	inExterior, err := conformance.EvaluateTelemetry(ctx, domain.TelemetrySample{
+		ID:         "sample-in-exterior",
+		AircraftID: "aircraft-1",
+		RecordedAt: now.Add(31 * time.Minute),
+		Latitude:   35.1,
+		Longitude:  -97.9,
+		AltitudeM:  60,
+	})
+	if err != nil {
+		t.Fatalf("EvaluateTelemetry in exterior returned error: %v", err)
+	}
+	if inExterior.Summary.Status != domain.ConformanceStatusConforming {
+		t.Fatalf("exterior sample status = %q, want conforming", inExterior.Summary.Status)
+	}
+	if len(inExterior.Events) != 0 {
+		t.Fatalf("exterior events = %#v, want none", inExterior.Events)
+	}
+}
+
 func TestConformanceTelemetryOutsideVolumeCreatesIntentExit(t *testing.T) {
 	ctx := context.Background()
 	store := durablememory.NewStore()
@@ -339,6 +424,52 @@ func TestConformanceTelemetryOutsideVolumeCreatesIntentExit(t *testing.T) {
 	}
 	if evaluation.Events[0].EventCode != domain.ConformanceEventIntentExit {
 		t.Fatalf("event code = %q, want intent_exit", evaluation.Events[0].EventCode)
+	}
+}
+
+func TestConformanceTelemetryDuplicateOutsideSampleDoesNotDoubleCountAlert(t *testing.T) {
+	ctx := context.Background()
+	store := durablememory.NewStore()
+	telemetry := telemetrymemory.NewStore()
+	now := fixedWorkflowTime()
+	seedWorkflowAircraft(t, ctx, store, now, float64Ptr(95))
+	intent := seedActiveIntentWithVolume(t, ctx, store, now)
+	conformance := NewConformanceServiceWithClock(store, telemetry, fixedClock(now))
+	sample := domain.TelemetrySample{
+		ID:         "sample-outside-retry",
+		AircraftID: "aircraft-1",
+		RecordedAt: now.Add(30 * time.Minute),
+		Latitude:   36.5,
+		Longitude:  -98.5,
+		AltitudeM:  60,
+	}
+
+	first, err := conformance.EvaluateTelemetry(ctx, sample)
+	if err != nil {
+		t.Fatalf("first EvaluateTelemetry returned error: %v", err)
+	}
+	second, err := conformance.EvaluateTelemetry(ctx, sample)
+	if err != nil {
+		t.Fatalf("second EvaluateTelemetry returned error: %v", err)
+	}
+	if first.Summary.AlertCount != 1 {
+		t.Fatalf("first alert count = %d, want 1", first.Summary.AlertCount)
+	}
+	if second.Summary.AlertCount != 1 {
+		t.Fatalf("second alert count = %d, want 1", second.Summary.AlertCount)
+	}
+	events, err := store.ListConformanceEvents(ctx, "")
+	if err != nil {
+		t.Fatalf("ListConformanceEvents returned error: %v", err)
+	}
+	matching := 0
+	for _, event := range events {
+		if event.IntentID == intent.ID && event.IntentVersion == intent.Version {
+			matching++
+		}
+	}
+	if matching != 1 {
+		t.Fatalf("matching conformance events = %d, want 1; events=%#v", matching, events)
 	}
 }
 
@@ -424,12 +555,17 @@ func seedWorkflowAircraft(t *testing.T, ctx context.Context, store durable.Store
 
 func seedSubmittedIntentWithVolume(t *testing.T, ctx context.Context, store durable.Store, now time.Time) domain.OperationalIntent {
 	t.Helper()
+	return seedSubmittedIntentWithVolumeRequest(t, ctx, store, now, workflowVolumeRequest(now))
+}
+
+func seedSubmittedIntentWithVolumeRequest(t *testing.T, ctx context.Context, store durable.Store, now time.Time, volumeReq AddOperationalVolumeRequest) domain.OperationalIntent {
+	t.Helper()
 	intents := NewIntentServiceWithClock(store, fixedClock(now))
 	intent, err := intents.CreateIntent(ctx, workflowIntentRequest(now))
 	if err != nil {
 		t.Fatalf("CreateIntent returned error: %v", err)
 	}
-	if _, err = intents.AddOperationalVolume(ctx, intent.ID, workflowVolumeRequest(now)); err != nil {
+	if _, err = intents.AddOperationalVolume(ctx, intent.ID, volumeReq); err != nil {
 		t.Fatalf("AddOperationalVolume returned error: %v", err)
 	}
 	intent, err = intents.SubmitIntent(ctx, intent.ID)
@@ -441,7 +577,12 @@ func seedSubmittedIntentWithVolume(t *testing.T, ctx context.Context, store dura
 
 func seedActiveIntentWithVolume(t *testing.T, ctx context.Context, store durable.Store, now time.Time) domain.OperationalIntent {
 	t.Helper()
-	intent := seedSubmittedIntentWithVolume(t, ctx, store, now)
+	return seedActiveIntentWithVolumeRequest(t, ctx, store, now, workflowVolumeRequest(now))
+}
+
+func seedActiveIntentWithVolumeRequest(t *testing.T, ctx context.Context, store durable.Store, now time.Time, volumeReq AddOperationalVolumeRequest) domain.OperationalIntent {
+	t.Helper()
+	intent := seedSubmittedIntentWithVolumeRequest(t, ctx, store, now, volumeReq)
 	if evaluation, err := NewPreflightServiceWithClock(store, fixedClock(now)).EvaluateIntent(ctx, intent.ID); err != nil {
 		t.Fatalf("EvaluateIntent returned error: %v", err)
 	} else if evaluation.Blocked {
@@ -490,6 +631,10 @@ func workflowVolumeRequest(now time.Time) AddOperationalVolumeRequest {
 
 func squareGeoJSON() string {
 	return `{"type":"Polygon","coordinates":[[[-98,35],[-97,35],[-97,36],[-98,36],[-98,35]]]}`
+}
+
+func polygonWithHoleGeoJSON() string {
+	return `{"type":"Polygon","coordinates":[[[-98,35],[-97,35],[-97,36],[-98,36],[-98,35]],[[-97.75,35.25],[-97.25,35.25],[-97.25,35.75],[-97.75,35.75],[-97.75,35.25]]]}`
 }
 
 func hasFinding(findings []domain.ComplianceFinding, requirementCode string) bool {

--- a/internal/service/workflow_service_test.go
+++ b/internal/service/workflow_service_test.go
@@ -82,6 +82,32 @@ func TestActivationBlockedWhenNoOperationalVolumeExists(t *testing.T) {
 	}
 }
 
+func TestActivationBlockedWhenNoPreflightChecksExist(t *testing.T) {
+	ctx := context.Background()
+	store := durablememory.NewStore()
+	now := fixedWorkflowTime()
+	seedWorkflowAircraft(t, ctx, store, now, float64Ptr(95))
+
+	intents := NewIntentServiceWithClock(store, fixedClock(now))
+	intent, err := intents.CreateIntent(ctx, workflowIntentRequest(now))
+	if err != nil {
+		t.Fatalf("CreateIntent returned error: %v", err)
+	}
+	if _, err = intents.AddOperationalVolume(ctx, intent.ID, workflowVolumeRequest(now)); err != nil {
+		t.Fatalf("AddOperationalVolume returned error: %v", err)
+	}
+	if _, err = intents.SubmitIntent(ctx, intent.ID); err != nil {
+		t.Fatalf("SubmitIntent returned error: %v", err)
+	}
+	if _, err = intents.AcceptIntent(ctx, intent.ID); err != nil {
+		t.Fatalf("AcceptIntent returned error: %v", err)
+	}
+
+	if _, err = intents.ActivateIntent(ctx, intent.ID); !errors.Is(err, ErrActivationBlocked) {
+		t.Fatalf("ActivateIntent error = %v, want ErrActivationBlocked", err)
+	}
+}
+
 func TestPreflightBlockedWhenBatterySOHMissing(t *testing.T) {
 	ctx := context.Background()
 	store := durablememory.NewStore()
@@ -98,6 +124,55 @@ func TestPreflightBlockedWhenBatterySOHMissing(t *testing.T) {
 	}
 	if !hasFinding(evaluation.Findings, "BATTERY-SOH-KNOWN") {
 		t.Fatalf("findings = %#v, want BATTERY-SOH-KNOWN", evaluation.Findings)
+	}
+}
+
+func TestPreflightClearOverwritesStaleBlockingFinding(t *testing.T) {
+	ctx := context.Background()
+	store := durablememory.NewStore()
+	now := fixedWorkflowTime()
+	seedWorkflowAircraft(t, ctx, store, now, nil)
+	intent := seedSubmittedIntentWithVolume(t, ctx, store, now)
+	preflight := NewPreflightServiceWithClock(store, fixedClock(now))
+
+	evaluation, err := preflight.EvaluateIntent(ctx, intent.ID)
+	if err != nil {
+		t.Fatalf("EvaluateIntent returned error: %v", err)
+	}
+	if !evaluation.Blocked || !hasFinding(evaluation.Findings, "BATTERY-SOH-KNOWN") {
+		t.Fatalf("initial evaluation = %#v, want blocked battery SOH finding", evaluation)
+	}
+
+	must(t, store.CreateBattery(ctx, domain.Battery{
+		ID:            "battery-1",
+		OperatorID:    "operator-1",
+		SerialNumber:  "B101",
+		StateOfHealth: float64Ptr(95),
+		Status:        domain.MaintenanceStatusCurrent,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}))
+	evaluation, err = preflight.EvaluateIntent(ctx, intent.ID)
+	if err != nil {
+		t.Fatalf("EvaluateIntent after remediation returned error: %v", err)
+	}
+	if evaluation.Blocked {
+		t.Fatalf("remediated evaluation blocked unexpectedly: %#v", evaluation.Findings)
+	}
+	findings, err := store.ListComplianceFindingsForIntent(ctx, intent.ID)
+	if err != nil {
+		t.Fatalf("ListComplianceFindingsForIntent returned error: %v", err)
+	}
+	if hasBlockingFinding(findings, "BATTERY-SOH-KNOWN") {
+		t.Fatalf("stale blocking battery SOH finding remained: %#v", findings)
+	}
+
+	intents := NewIntentServiceWithClock(store, fixedClock(now))
+	if _, err = intents.AcceptIntent(ctx, intent.ID); err != nil {
+		t.Fatalf("AcceptIntent returned error: %v", err)
+	}
+	if _, err = intents.ActivateIntent(ctx, intent.ID); err != nil {
+		t.Fatalf("ActivateIntent after remediation returned error: %v", err)
 	}
 }
 
@@ -192,6 +267,48 @@ func TestConformanceTelemetryOutsideVolumeCreatesIntentExit(t *testing.T) {
 	}
 	if evaluation.Events[0].EventCode != domain.ConformanceEventIntentExit {
 		t.Fatalf("event code = %q, want intent_exit", evaluation.Events[0].EventCode)
+	}
+}
+
+func TestConformanceTelemetryInsideAfterExitPreservesPriorAlerts(t *testing.T) {
+	ctx := context.Background()
+	store := durablememory.NewStore()
+	telemetry := telemetrymemory.NewStore()
+	now := fixedWorkflowTime()
+	seedWorkflowAircraft(t, ctx, store, now, float64Ptr(95))
+	seedActiveIntentWithVolume(t, ctx, store, now)
+	conformance := NewConformanceServiceWithClock(store, telemetry, fixedClock(now))
+
+	if _, err := conformance.EvaluateTelemetry(ctx, domain.TelemetrySample{
+		ID:         "sample-outside",
+		AircraftID: "aircraft-1",
+		RecordedAt: now.Add(30 * time.Minute),
+		Latitude:   36.5,
+		Longitude:  -98.5,
+		AltitudeM:  60,
+	}); err != nil {
+		t.Fatalf("outside EvaluateTelemetry returned error: %v", err)
+	}
+
+	evaluation, err := conformance.EvaluateTelemetry(ctx, domain.TelemetrySample{
+		ID:         "sample-inside-after-exit",
+		AircraftID: "aircraft-1",
+		RecordedAt: now.Add(31 * time.Minute),
+		Latitude:   35.5,
+		Longitude:  -97.5,
+		AltitudeM:  60,
+	})
+	if err != nil {
+		t.Fatalf("inside EvaluateTelemetry returned error: %v", err)
+	}
+	if evaluation.Summary.Status != domain.ConformanceStatusConforming {
+		t.Fatalf("summary status = %q, want conforming", evaluation.Summary.Status)
+	}
+	if evaluation.Summary.AlertCount != 1 {
+		t.Fatalf("alert count = %d, want 1", evaluation.Summary.AlertCount)
+	}
+	if evaluation.Summary.ReportabilityStatus != domain.ReportabilityStatusReview {
+		t.Fatalf("reportability = %q, want review", evaluation.Summary.ReportabilityStatus)
 	}
 }
 
@@ -306,6 +423,15 @@ func squareGeoJSON() string {
 func hasFinding(findings []domain.ComplianceFinding, requirementCode string) bool {
 	for _, finding := range findings {
 		if finding.RequirementCode == requirementCode {
+			return true
+		}
+	}
+	return false
+}
+
+func hasBlockingFinding(findings []domain.ComplianceFinding, requirementCode string) bool {
+	for _, finding := range findings {
+		if finding.RequirementCode == requirementCode && finding.Blocking && (finding.Status == domain.ComplianceFindingFail || finding.Status == domain.ComplianceFindingReview) {
 			return true
 		}
 	}

--- a/internal/service/workflow_service_test.go
+++ b/internal/service/workflow_service_test.go
@@ -341,6 +341,118 @@ func TestConformanceTelemetryInsideVolumeConforming(t *testing.T) {
 	}
 }
 
+func TestConformanceTelemetryHonorsSampleIntentID(t *testing.T) {
+	ctx := context.Background()
+	store := durablememory.NewStore()
+	telemetry := telemetrymemory.NewStore()
+	now := fixedWorkflowTime()
+	seedWorkflowAircraft(t, ctx, store, now, float64Ptr(95))
+	createActiveIntentWithVolume(t, ctx, store, now, "intent-a", "volume-a", squareGeoJSON(), now)
+	createActiveIntentWithVolume(t, ctx, store, now, "intent-b", "volume-b", eastSquareGeoJSON(), now.Add(10*time.Minute))
+
+	evaluation, err := NewConformanceServiceWithClock(store, telemetry, fixedClock(now)).EvaluateTelemetry(ctx, domain.TelemetrySample{
+		ID:         "sample-intent-b",
+		IntentID:   "intent-b",
+		AircraftID: "aircraft-1",
+		RecordedAt: now.Add(30 * time.Minute),
+		Latitude:   35.5,
+		Longitude:  -96.25,
+		AltitudeM:  60,
+	})
+	if err != nil {
+		t.Fatalf("EvaluateTelemetry returned error: %v", err)
+	}
+	if evaluation.Intent.ID != "intent-b" {
+		t.Fatalf("evaluated intent = %q, want intent-b", evaluation.Intent.ID)
+	}
+	if evaluation.Summary.Status != domain.ConformanceStatusConforming {
+		t.Fatalf("summary status = %q, want conforming", evaluation.Summary.Status)
+	}
+}
+
+func TestConformanceTelemetryIntentIDWrongAircraftFails(t *testing.T) {
+	ctx := context.Background()
+	store := durablememory.NewStore()
+	telemetry := telemetrymemory.NewStore()
+	now := fixedWorkflowTime()
+	seedWorkflowAircraft(t, ctx, store, now, float64Ptr(95))
+	createActiveIntentWithVolume(t, ctx, store, now, "intent-1", "volume-1", squareGeoJSON(), now)
+
+	_, err := NewConformanceServiceWithClock(store, telemetry, fixedClock(now)).EvaluateTelemetry(ctx, domain.TelemetrySample{
+		ID:         "sample-wrong-aircraft",
+		IntentID:   "intent-1",
+		AircraftID: "aircraft-2",
+		RecordedAt: now.Add(30 * time.Minute),
+		Latitude:   35.5,
+		Longitude:  -97.5,
+		AltitudeM:  60,
+	})
+	if !errors.Is(err, ErrValidation) {
+		t.Fatalf("EvaluateTelemetry error = %v, want ErrValidation", err)
+	}
+}
+
+func TestConformanceTelemetryActiveIntentWithoutVolumesProducesUnknownNoEvent(t *testing.T) {
+	ctx := context.Background()
+	store := durablememory.NewStore()
+	telemetry := telemetrymemory.NewStore()
+	now := fixedWorkflowTime()
+	seedWorkflowAircraft(t, ctx, store, now, float64Ptr(95))
+	must(t, store.CreateOperationalIntent(ctx, domain.OperationalIntent{
+		ID:             "intent-no-volumes",
+		OperatorID:     "operator-1",
+		AircraftID:     "aircraft-1",
+		Version:        1,
+		Status:         domain.IntentStatusActive,
+		PlannedStartAt: now,
+		PlannedEndAt:   now.Add(time.Hour),
+		UpdatedAt:      now,
+	}))
+	must(t, store.UpsertConformanceSummary(ctx, domain.ConformanceSummary{
+		ID:                  "conformance-intent-no-volumes",
+		OperatorID:          "operator-1",
+		IntentID:            "intent-no-volumes",
+		IntentVersion:       1,
+		AircraftID:          "aircraft-1",
+		Status:              domain.ConformanceStatusNonConforming,
+		AlertCount:          2,
+		ReportabilityStatus: domain.ReportabilityStatusReview,
+		UpdatedAt:           now,
+	}))
+
+	evaluation, err := NewConformanceServiceWithClock(store, telemetry, fixedClock(now)).EvaluateTelemetry(ctx, domain.TelemetrySample{
+		ID:         "sample-no-volumes",
+		IntentID:   "intent-no-volumes",
+		AircraftID: "aircraft-1",
+		RecordedAt: now.Add(30 * time.Minute),
+		Latitude:   35.5,
+		Longitude:  -97.5,
+		AltitudeM:  60,
+	})
+	if err != nil {
+		t.Fatalf("EvaluateTelemetry returned error: %v", err)
+	}
+	if evaluation.Summary.Status != domain.ConformanceStatusUnknown {
+		t.Fatalf("summary status = %q, want unknown", evaluation.Summary.Status)
+	}
+	if evaluation.Summary.AlertCount != 2 {
+		t.Fatalf("alert count = %d, want preserved count 2", evaluation.Summary.AlertCount)
+	}
+	if evaluation.Summary.ReportabilityStatus != domain.ReportabilityStatusReview {
+		t.Fatalf("reportability = %q, want review", evaluation.Summary.ReportabilityStatus)
+	}
+	if len(evaluation.Events) != 0 {
+		t.Fatalf("events = %#v, want none", evaluation.Events)
+	}
+	events, err := store.ListConformanceEvents(ctx, "")
+	if err != nil {
+		t.Fatalf("ListConformanceEvents returned error: %v", err)
+	}
+	if len(events) != 0 {
+		t.Fatalf("stored events = %#v, want none", events)
+	}
+}
+
 func TestConformanceTelemetryRespectsPolygonInteriorRing(t *testing.T) {
 	ctx := context.Background()
 	store := durablememory.NewStore()
@@ -600,6 +712,54 @@ func seedActiveIntentWithVolumeRequest(t *testing.T, ctx context.Context, store 
 	return intent
 }
 
+func createActiveIntentWithVolume(t *testing.T, ctx context.Context, store durable.Store, now time.Time, intentID string, volumeID string, geoJSON string, plannedStart time.Time) domain.OperationalIntent {
+	t.Helper()
+	intents := NewIntentServiceWithClock(store, fixedClock(now))
+	intent, err := intents.CreateIntent(ctx, CreateIntentRequest{
+		ID:                  intentID,
+		OperatorID:          "operator-1",
+		AircraftID:          "aircraft-1",
+		Name:                intentID,
+		Summary:             "test intent",
+		AuthorizationPath:   domain.AuthorizationPathDemo,
+		PopulationCategory:  domain.PopulationCategoryOne,
+		ConformanceRequired: true,
+		PlannedStartAt:      plannedStart,
+		PlannedEndAt:        plannedStart.Add(time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("CreateIntent returned error: %v", err)
+	}
+	if _, err = intents.AddOperationalVolume(ctx, intent.ID, AddOperationalVolumeRequest{
+		ID:           volumeID,
+		Sequence:     1,
+		GeoJSON:      geoJSON,
+		MinAltitudeM: 10,
+		MaxAltitudeM: 120,
+		AltitudeRef:  domain.AltitudeReferenceAGL,
+		StartsAt:     plannedStart,
+		EndsAt:       plannedStart.Add(time.Hour),
+		VolumeType:   domain.OperationalVolumeLoiter,
+	}); err != nil {
+		t.Fatalf("AddOperationalVolume returned error: %v", err)
+	}
+	if intent, err = intents.SubmitIntent(ctx, intent.ID); err != nil {
+		t.Fatalf("SubmitIntent returned error: %v", err)
+	}
+	if evaluation, err := NewPreflightServiceWithClock(store, fixedClock(now)).EvaluateIntent(ctx, intent.ID); err != nil {
+		t.Fatalf("EvaluateIntent returned error: %v", err)
+	} else if evaluation.Blocked {
+		t.Fatalf("preflight blocked unexpectedly: %#v", evaluation.Findings)
+	}
+	if intent, err = intents.AcceptIntent(ctx, intent.ID); err != nil {
+		t.Fatalf("AcceptIntent returned error: %v", err)
+	}
+	if intent, err = intents.ActivateIntent(ctx, intent.ID); err != nil {
+		t.Fatalf("ActivateIntent returned error: %v", err)
+	}
+	return intent
+}
+
 func workflowIntentRequest(now time.Time) CreateIntentRequest {
 	return CreateIntentRequest{
 		ID:                  "intent-1",
@@ -635,6 +795,10 @@ func squareGeoJSON() string {
 
 func polygonWithHoleGeoJSON() string {
 	return `{"type":"Polygon","coordinates":[[[-98,35],[-97,35],[-97,36],[-98,36],[-98,35]],[[-97.75,35.25],[-97.25,35.25],[-97.25,35.75],[-97.75,35.75],[-97.75,35.25]]]}`
+}
+
+func eastSquareGeoJSON() string {
+	return `{"type":"Polygon","coordinates":[[[-96.5,35],[-96,35],[-96,36],[-96.5,36],[-96.5,35]]]}`
 }
 
 func hasFinding(findings []domain.ComplianceFinding, requirementCode string) bool {

--- a/internal/service/workflow_service_test.go
+++ b/internal/service/workflow_service_test.go
@@ -1,0 +1,313 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/Aero-Arc/aero-arc-api/internal/domain"
+	"github.com/Aero-Arc/aero-arc-api/internal/store/durable"
+	durablememory "github.com/Aero-Arc/aero-arc-api/internal/store/durable/memory"
+	telemetrymemory "github.com/Aero-Arc/aero-arc-api/internal/store/telemetry/memory"
+)
+
+func TestIntentLifecycleHappyPath(t *testing.T) {
+	ctx := context.Background()
+	store := durablememory.NewStore()
+	now := fixedWorkflowTime()
+	seedWorkflowAircraft(t, ctx, store, now, float64Ptr(95))
+
+	intents := NewIntentServiceWithClock(store, fixedClock(now))
+	preflight := NewPreflightServiceWithClock(store, fixedClock(now))
+
+	intent, err := intents.CreateIntent(ctx, workflowIntentRequest(now))
+	if err != nil {
+		t.Fatalf("CreateIntent returned error: %v", err)
+	}
+	if intent.Status != domain.IntentStatusDraft {
+		t.Fatalf("created status = %q, want draft", intent.Status)
+	}
+
+	_, err = intents.AddOperationalVolume(ctx, intent.ID, workflowVolumeRequest(now))
+	if err != nil {
+		t.Fatalf("AddOperationalVolume returned error: %v", err)
+	}
+	if intent, err = intents.SubmitIntent(ctx, intent.ID); err != nil {
+		t.Fatalf("SubmitIntent returned error: %v", err)
+	}
+	if intent.Status != domain.IntentStatusSubmitted {
+		t.Fatalf("submitted status = %q, want submitted", intent.Status)
+	}
+
+	evaluation, err := preflight.EvaluateIntent(ctx, intent.ID)
+	if err != nil {
+		t.Fatalf("EvaluateIntent returned error: %v", err)
+	}
+	if evaluation.Blocked {
+		t.Fatalf("preflight blocked unexpectedly: %#v", evaluation.Findings)
+	}
+
+	if intent, err = intents.AcceptIntent(ctx, intent.ID); err != nil {
+		t.Fatalf("AcceptIntent returned error: %v", err)
+	}
+	if intent, err = intents.ActivateIntent(ctx, intent.ID); err != nil {
+		t.Fatalf("ActivateIntent returned error: %v", err)
+	}
+	if intent.Status != domain.IntentStatusActive {
+		t.Fatalf("activated status = %q, want active", intent.Status)
+	}
+}
+
+func TestActivationBlockedWhenNoOperationalVolumeExists(t *testing.T) {
+	ctx := context.Background()
+	store := durablememory.NewStore()
+	now := fixedWorkflowTime()
+	seedWorkflowAircraft(t, ctx, store, now, float64Ptr(95))
+
+	intents := NewIntentServiceWithClock(store, fixedClock(now))
+	intent, err := intents.CreateIntent(ctx, workflowIntentRequest(now))
+	if err != nil {
+		t.Fatalf("CreateIntent returned error: %v", err)
+	}
+	if _, err = intents.SubmitIntent(ctx, intent.ID); err != nil {
+		t.Fatalf("SubmitIntent returned error: %v", err)
+	}
+	if _, err = intents.AcceptIntent(ctx, intent.ID); err != nil {
+		t.Fatalf("AcceptIntent returned error: %v", err)
+	}
+
+	if _, err = intents.ActivateIntent(ctx, intent.ID); !errors.Is(err, ErrActivationBlocked) {
+		t.Fatalf("ActivateIntent error = %v, want ErrActivationBlocked", err)
+	}
+}
+
+func TestPreflightBlockedWhenBatterySOHMissing(t *testing.T) {
+	ctx := context.Background()
+	store := durablememory.NewStore()
+	now := fixedWorkflowTime()
+	seedWorkflowAircraft(t, ctx, store, now, nil)
+	intent := seedSubmittedIntentWithVolume(t, ctx, store, now)
+
+	evaluation, err := NewPreflightServiceWithClock(store, fixedClock(now)).EvaluateIntent(ctx, intent.ID)
+	if err != nil {
+		t.Fatalf("EvaluateIntent returned error: %v", err)
+	}
+	if !evaluation.Blocked {
+		t.Fatal("preflight should be blocked")
+	}
+	if !hasFinding(evaluation.Findings, "BATTERY-SOH-KNOWN") {
+		t.Fatalf("findings = %#v, want BATTERY-SOH-KNOWN", evaluation.Findings)
+	}
+}
+
+func TestPreflightBlockedWhenCriticalMaintenanceOpen(t *testing.T) {
+	ctx := context.Background()
+	store := durablememory.NewStore()
+	now := fixedWorkflowTime()
+	seedWorkflowAircraft(t, ctx, store, now, float64Ptr(95))
+	must(t, store.RecordMaintenanceEvent(ctx, domain.MaintenanceEvent{
+		ID:         "mx-critical",
+		AircraftID: "aircraft-1",
+		Severity:   domain.SeverityCritical,
+		Status:     domain.MaintenanceStatusOpen,
+		Title:      "critical item",
+		OpenedAt:   now.Add(-time.Hour),
+	}))
+	intent := seedSubmittedIntentWithVolume(t, ctx, store, now)
+
+	evaluation, err := NewPreflightServiceWithClock(store, fixedClock(now)).EvaluateIntent(ctx, intent.ID)
+	if err != nil {
+		t.Fatalf("EvaluateIntent returned error: %v", err)
+	}
+	if !evaluation.Blocked {
+		t.Fatal("preflight should be blocked")
+	}
+	if !hasFinding(evaluation.Findings, "MX-CRITICAL-OPEN") {
+		t.Fatalf("findings = %#v, want MX-CRITICAL-OPEN", evaluation.Findings)
+	}
+}
+
+func TestConformanceTelemetryInsideVolumeConforming(t *testing.T) {
+	ctx := context.Background()
+	store := durablememory.NewStore()
+	telemetry := telemetrymemory.NewStore()
+	now := fixedWorkflowTime()
+	seedWorkflowAircraft(t, ctx, store, now, float64Ptr(95))
+	intent := seedActiveIntentWithVolume(t, ctx, store, now)
+
+	evaluation, err := NewConformanceServiceWithClock(store, telemetry, fixedClock(now)).EvaluateTelemetry(ctx, domain.TelemetrySample{
+		ID:         "sample-inside",
+		AircraftID: "aircraft-1",
+		RecordedAt: now.Add(30 * time.Minute),
+		Latitude:   35.5,
+		Longitude:  -97.5,
+		AltitudeM:  60,
+	})
+	if err != nil {
+		t.Fatalf("EvaluateTelemetry returned error: %v", err)
+	}
+	if evaluation.Intent.ID != intent.ID {
+		t.Fatalf("intent = %q, want %q", evaluation.Intent.ID, intent.ID)
+	}
+	if evaluation.Summary.Status != domain.ConformanceStatusConforming {
+		t.Fatalf("summary status = %q, want conforming", evaluation.Summary.Status)
+	}
+	if len(evaluation.Events) != 0 {
+		t.Fatalf("events = %#v, want none", evaluation.Events)
+	}
+	events, err := store.ListConformanceEvents(ctx, "")
+	if err != nil {
+		t.Fatalf("ListConformanceEvents returned error: %v", err)
+	}
+	if len(events) != 0 {
+		t.Fatalf("stored events = %#v, want none", events)
+	}
+}
+
+func TestConformanceTelemetryOutsideVolumeCreatesIntentExit(t *testing.T) {
+	ctx := context.Background()
+	store := durablememory.NewStore()
+	telemetry := telemetrymemory.NewStore()
+	now := fixedWorkflowTime()
+	seedWorkflowAircraft(t, ctx, store, now, float64Ptr(95))
+	seedActiveIntentWithVolume(t, ctx, store, now)
+
+	evaluation, err := NewConformanceServiceWithClock(store, telemetry, fixedClock(now)).EvaluateTelemetry(ctx, domain.TelemetrySample{
+		ID:         "sample-outside",
+		AircraftID: "aircraft-1",
+		RecordedAt: now.Add(30 * time.Minute),
+		Latitude:   36.5,
+		Longitude:  -98.5,
+		AltitudeM:  60,
+	})
+	if err != nil {
+		t.Fatalf("EvaluateTelemetry returned error: %v", err)
+	}
+	if evaluation.Summary.Status != domain.ConformanceStatusNonConforming {
+		t.Fatalf("summary status = %q, want non_conforming", evaluation.Summary.Status)
+	}
+	if len(evaluation.Events) != 1 {
+		t.Fatalf("events len = %d, want 1", len(evaluation.Events))
+	}
+	if evaluation.Events[0].EventCode != domain.ConformanceEventIntentExit {
+		t.Fatalf("event code = %q, want intent_exit", evaluation.Events[0].EventCode)
+	}
+}
+
+func fixedWorkflowTime() time.Time {
+	return time.Date(2026, 6, 15, 15, 0, 0, 0, time.UTC)
+}
+
+func fixedClock(now time.Time) func() time.Time {
+	return func() time.Time { return now }
+}
+
+func seedWorkflowAircraft(t *testing.T, ctx context.Context, store durable.Store, now time.Time, soh *float64) {
+	t.Helper()
+	must(t, store.CreateAircraft(ctx, domain.Aircraft{
+		ID:               "aircraft-1",
+		OperatorID:       "operator-1",
+		TailNumber:       "N101AA",
+		Status:           domain.AircraftStatusActive,
+		AcceptanceStatus: domain.AcceptanceStatusAccepted,
+		RemoteIDStatus:   domain.RemoteIDStatusBroadcasting,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}))
+	must(t, store.CreateBattery(ctx, domain.Battery{
+		ID:            "battery-1",
+		OperatorID:    "operator-1",
+		SerialNumber:  "B101",
+		StateOfHealth: soh,
+		Status:        domain.MaintenanceStatusCurrent,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}))
+	must(t, store.RecordBatteryInstallation(ctx, domain.BatteryInstallation{
+		ID:          "install-1",
+		OperatorID:  "operator-1",
+		AircraftID:  "aircraft-1",
+		BatteryID:   "battery-1",
+		InstalledAt: now.Add(-24 * time.Hour),
+	}))
+}
+
+func seedSubmittedIntentWithVolume(t *testing.T, ctx context.Context, store durable.Store, now time.Time) domain.OperationalIntent {
+	t.Helper()
+	intents := NewIntentServiceWithClock(store, fixedClock(now))
+	intent, err := intents.CreateIntent(ctx, workflowIntentRequest(now))
+	if err != nil {
+		t.Fatalf("CreateIntent returned error: %v", err)
+	}
+	if _, err = intents.AddOperationalVolume(ctx, intent.ID, workflowVolumeRequest(now)); err != nil {
+		t.Fatalf("AddOperationalVolume returned error: %v", err)
+	}
+	intent, err = intents.SubmitIntent(ctx, intent.ID)
+	if err != nil {
+		t.Fatalf("SubmitIntent returned error: %v", err)
+	}
+	return intent
+}
+
+func seedActiveIntentWithVolume(t *testing.T, ctx context.Context, store durable.Store, now time.Time) domain.OperationalIntent {
+	t.Helper()
+	intent := seedSubmittedIntentWithVolume(t, ctx, store, now)
+	if evaluation, err := NewPreflightServiceWithClock(store, fixedClock(now)).EvaluateIntent(ctx, intent.ID); err != nil {
+		t.Fatalf("EvaluateIntent returned error: %v", err)
+	} else if evaluation.Blocked {
+		t.Fatalf("preflight blocked unexpectedly: %#v", evaluation.Findings)
+	}
+	intents := NewIntentServiceWithClock(store, fixedClock(now))
+	intent, err := intents.AcceptIntent(ctx, intent.ID)
+	if err != nil {
+		t.Fatalf("AcceptIntent returned error: %v", err)
+	}
+	intent, err = intents.ActivateIntent(ctx, intent.ID)
+	if err != nil {
+		t.Fatalf("ActivateIntent returned error: %v", err)
+	}
+	return intent
+}
+
+func workflowIntentRequest(now time.Time) CreateIntentRequest {
+	return CreateIntentRequest{
+		ID:                  "intent-1",
+		OperatorID:          "operator-1",
+		AircraftID:          "aircraft-1",
+		Name:                "Demo intent",
+		Summary:             "Manual operational volume test intent",
+		AuthorizationPath:   domain.AuthorizationPathDemo,
+		PopulationCategory:  domain.PopulationCategoryOne,
+		ConformanceRequired: true,
+		PlannedStartAt:      now,
+		PlannedEndAt:        now.Add(time.Hour),
+	}
+}
+
+func workflowVolumeRequest(now time.Time) AddOperationalVolumeRequest {
+	return AddOperationalVolumeRequest{
+		ID:           "volume-1",
+		Sequence:     1,
+		GeoJSON:      squareGeoJSON(),
+		MinAltitudeM: 10,
+		MaxAltitudeM: 120,
+		AltitudeRef:  domain.AltitudeReferenceAGL,
+		StartsAt:     now,
+		EndsAt:       now.Add(time.Hour),
+		VolumeType:   domain.OperationalVolumeLoiter,
+	}
+}
+
+func squareGeoJSON() string {
+	return `{"type":"Polygon","coordinates":[[[-98,35],[-97,35],[-97,36],[-98,36],[-98,35]]]}`
+}
+
+func hasFinding(findings []domain.ComplianceFinding, requirementCode string) bool {
+	for _, finding := range findings {
+		if finding.RequirementCode == requirementCode {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/store/durable/durable.go
+++ b/internal/store/durable/durable.go
@@ -42,6 +42,7 @@ type Store interface {
 	ListMaintenanceEvents(ctx context.Context, aircraftID string) ([]domain.MaintenanceEvent, error)
 
 	CreateOperationalIntent(ctx context.Context, intent domain.OperationalIntent) error
+	UpdateOperationalIntent(ctx context.Context, intent domain.OperationalIntent) error
 	GetOperationalIntent(ctx context.Context, intentID string) (domain.OperationalIntent, error)
 	ListOperationalIntents(ctx context.Context, aircraftID string) ([]domain.OperationalIntent, error)
 	RecordOperationalVolume(ctx context.Context, volume domain.OperationalVolume) error

--- a/internal/store/durable/durable.go
+++ b/internal/store/durable/durable.go
@@ -71,6 +71,7 @@ type Store interface {
 	ListReportabilityReviews(ctx context.Context, intentID string) ([]domain.ReportabilityReview, error)
 	RecordComplianceFinding(ctx context.Context, finding domain.ComplianceFinding) error
 	ListComplianceFindings(ctx context.Context, subjectType string, subjectID string) ([]domain.ComplianceFinding, error)
+	ListComplianceFindingsForIntent(ctx context.Context, intentID string) ([]domain.ComplianceFinding, error)
 
 	UpsertOperationsPersonnel(ctx context.Context, person domain.OperationsPersonnel) error
 	GetOperationsPersonnel(ctx context.Context, personID string) (domain.OperationsPersonnel, error)

--- a/internal/store/durable/memory/durable.go
+++ b/internal/store/durable/memory/durable.go
@@ -220,6 +220,16 @@ func (s *Store) CreateOperationalIntent(_ context.Context, intent domain.Operati
 	return nil
 }
 
+func (s *Store) UpdateOperationalIntent(_ context.Context, intent domain.OperationalIntent) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.operationalIntents[intent.ID]; !ok {
+		return durable.ErrNotFound
+	}
+	s.operationalIntents[intent.ID] = intent
+	return nil
+}
+
 func (s *Store) GetOperationalIntent(_ context.Context, intentID string) (domain.OperationalIntent, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -303,6 +313,12 @@ func (s *Store) ListRegulatoryAuthorizations(_ context.Context, operatorID strin
 func (s *Store) RecordPreflightCheck(_ context.Context, check domain.PreflightCheck) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	for i, existing := range s.preflightChecks {
+		if existing.ID == check.ID {
+			s.preflightChecks[i] = check
+			return nil
+		}
+	}
 	s.preflightChecks = append(s.preflightChecks, check)
 	return nil
 }
@@ -353,6 +369,12 @@ func (s *Store) ListFlightRecords(_ context.Context, aircraftID string) ([]domai
 func (s *Store) RecordConformanceEvent(_ context.Context, event domain.ConformanceEvent) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	for i, existing := range s.conformanceEvents {
+		if existing.ID == event.ID {
+			s.conformanceEvents[i] = event
+			return nil
+		}
+	}
 	s.conformanceEvents = append(s.conformanceEvents, event)
 	return nil
 }
@@ -443,6 +465,12 @@ func (s *Store) ListReportabilityReviews(_ context.Context, intentID string) ([]
 func (s *Store) RecordComplianceFinding(_ context.Context, finding domain.ComplianceFinding) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	for i, existing := range s.complianceFindings {
+		if existing.ID == finding.ID {
+			s.complianceFindings[i] = finding
+			return nil
+		}
+	}
 	s.complianceFindings = append(s.complianceFindings, finding)
 	return nil
 }

--- a/internal/store/durable/memory/durable.go
+++ b/internal/store/durable/memory/durable.go
@@ -492,6 +492,19 @@ func (s *Store) ListComplianceFindings(_ context.Context, subjectType string, su
 	return findings, nil
 }
 
+func (s *Store) ListComplianceFindingsForIntent(_ context.Context, intentID string) ([]domain.ComplianceFinding, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	findings := make([]domain.ComplianceFinding, 0)
+	for _, finding := range s.complianceFindings {
+		if finding.IntentID == intentID || (finding.SubjectType == "operational_intent" && finding.SubjectID == intentID) {
+			findings = append(findings, finding)
+		}
+	}
+	sort.Slice(findings, func(i, j int) bool { return findings[i].EvaluatedAt.After(findings[j].EvaluatedAt) })
+	return findings, nil
+}
+
 func (s *Store) UpsertOperationsPersonnel(_ context.Context, person domain.OperationsPersonnel) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()


### PR DESCRIPTION
## Summary

  Add in-process workflow services for operational intent lifecycle, preflight evaluation, and conformance monitoring while keeping FleetService
  focused on dashboard/read-side composition.

  ## Changes

  - Added IntentService for operational intent lifecycle transitions and operational volume management.
  - Added PreflightService for deterministic local pre-activation checks and compliance findings.
  - Added ConformanceService for telemetry-vs-operational-volume evaluation.
  - Added minimal HTTP workflow endpoints for intents, volumes, preflight evaluation, activation, telemetry, and conformance lookup.
  - Added durable store support for updating intents and intent-scoped compliance finding lookup.
  - Made preflight evaluations idempotent enough for demos/tests by overwriting stable check/finding IDs.
  - Blocked activation when:
      - no operational volume exists,
      - no preflight checks exist,
      - blocking preflight checks or compliance findings exist.

  - Made HTTP activation run preflight before activating.
  - Locked operational volume edits after an intent leaves draft.
  - Fixed FleetService readiness so batteries with unknown state of health do not report ready.
  - Tightened conformance geometry behavior:
      - geometry URI-only volumes no longer count as conforming,
      - preflight blocks volumes without inline GeoJSON,
      - polygon holes are respected,
      - duplicate outside telemetry samples do not double-count alerts.

  - Preserved conformance alert/reportability state when telemetry returns to conforming.

  ## Tests

  Added deterministic in-memory tests covering:

  - intent lifecycle happy path,
  - activation blocked without volumes,
  - activation blocked without preflight,
  - preflight blocks missing battery SOH,
  - preflight blocks critical open maintenance,
  - stale blocking findings are cleared by later pass findings,
  - draft-only operational volume edits,
  - HTTP volume endpoint rejecting non-draft edits,
  - HTTP activation running preflight,
  - conforming telemetry inside volume,
  - non-conforming telemetry outside volume,
  - polygon holes,
  - geometry URI-only volume handling,
  - duplicate telemetry retry idempotency,
  - FleetService readiness with unknown battery SOH.

  ## Verification

  - go fmt ./...
  - env GOCACHE=/tmp/aero-arc-go-build go test ./...