### PR TITLE
Add relay operation context client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.3
 toolchain go1.24.9
 
 require (
-	github.com/aero-arc/aero-arc-protos v0.0.0-20260125174309-0c449726339e
+	github.com/aero-arc/aero-arc-protos v0.0.0-20260712235411-7691110ca7e7
 	github.com/mrshabel/mach v0.0.0-20260228220151-4e628ab47ff3
 	github.com/urfave/cli/v3 v3.9.0
 	google.golang.org/grpc v1.78.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/aero-arc/aero-arc-protos v0.0.0-20260125174309-0c449726339e h1:p8DoXz0mOt52NmYM0/mnwKp+6LWVkariHbYqseuB0PA=
-github.com/aero-arc/aero-arc-protos v0.0.0-20260125174309-0c449726339e/go.mod h1:fILW3Dz6auXllS5ABRFTt0FTnNC4Mtw3ukvGrJa7zLo=
+github.com/aero-arc/aero-arc-protos v0.0.0-20260712235411-7691110ca7e7 h1:Ex8lT3tkVP902PfjJiRU2E4Q4L4H7eyfzgwSUu+WiGw=
+github.com/aero-arc/aero-arc-protos v0.0.0-20260712235411-7691110ca7e7/go.mod h1:fILW3Dz6auXllS5ABRFTt0FTnNC4Mtw3ukvGrJa7zLo=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=

--- a/internal/relaycontrol/grpc_pool.go
+++ b/internal/relaycontrol/grpc_pool.go
@@ -6,14 +6,15 @@ import (
 
 	relayv1 "github.com/aero-arc/aero-arc-protos/gen/go/aeroarc/relay/v1"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/credentials"
 )
 
 // grpcPool owns and reuses the API's connections to relay instances discovered
 // through the Registry service.
 type grpcPool struct {
-	mu    sync.Mutex
-	conns map[string]pooledConnection
+	mu                   sync.Mutex
+	transportCredentials credentials.TransportCredentials
+	conns                map[string]pooledConnection
 }
 
 type pooledConnection struct {
@@ -21,8 +22,11 @@ type pooledConnection struct {
 	conn    *grpc.ClientConn
 }
 
-func newGRPCPool() *grpcPool {
-	return &grpcPool{conns: map[string]pooledConnection{}}
+func newGRPCPool(transportCredentials credentials.TransportCredentials) *grpcPool {
+	return &grpcPool{
+		transportCredentials: transportCredentials,
+		conns:                map[string]pooledConnection{},
+	}
 }
 
 func (p *grpcPool) Client(ctx context.Context, relayID, address string) (relayv1.RelayControlClient, error) {
@@ -35,7 +39,7 @@ func (p *grpcPool) Client(ctx context.Context, relayID, address string) (relayv1
 		_ = existing.conn.Close()
 		delete(p.conns, relayID)
 	}
-	conn, err := grpc.DialContext(ctx, address, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.DialContext(ctx, address, grpc.WithTransportCredentials(p.transportCredentials))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/relaycontrol/grpc_pool.go
+++ b/internal/relaycontrol/grpc_pool.go
@@ -1,0 +1,66 @@
+package relaycontrol
+
+import (
+	"context"
+	"sync"
+
+	relayv1 "github.com/aero-arc/aero-arc-protos/gen/go/aeroarc/relay/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+// grpcPool owns and reuses the API's connections to relay instances discovered
+// through the Registry service.
+type grpcPool struct {
+	mu    sync.Mutex
+	conns map[string]pooledConnection
+}
+
+type pooledConnection struct {
+	address string
+	conn    *grpc.ClientConn
+}
+
+func newGRPCPool() *grpcPool {
+	return &grpcPool{conns: map[string]pooledConnection{}}
+}
+
+func (p *grpcPool) Client(ctx context.Context, relayID, address string) (relayv1.RelayControlClient, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if existing, ok := p.conns[relayID]; ok {
+		if existing.address == address {
+			return relayv1.NewRelayControlClient(existing.conn), nil
+		}
+		_ = existing.conn.Close()
+		delete(p.conns, relayID)
+	}
+	conn, err := grpc.DialContext(ctx, address, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return nil, err
+	}
+	p.conns[relayID] = pooledConnection{address: address, conn: conn}
+	return relayv1.NewRelayControlClient(conn), nil
+}
+
+func (p *grpcPool) Invalidate(relayID string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if existing, ok := p.conns[relayID]; ok {
+		_ = existing.conn.Close()
+		delete(p.conns, relayID)
+	}
+}
+
+func (p *grpcPool) Close() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	var first error
+	for id, existing := range p.conns {
+		if err := existing.conn.Close(); err != nil && first == nil {
+			first = err
+		}
+		delete(p.conns, id)
+	}
+	return first
+}

--- a/internal/relaycontrol/grpc_pool_test.go
+++ b/internal/relaycontrol/grpc_pool_test.go
@@ -3,10 +3,12 @@ package relaycontrol
 import (
 	"context"
 	"testing"
+
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 func TestGRPCPoolReusesConnectionOnlyWhileRelayAddressMatches(t *testing.T) {
-	pool := newGRPCPool()
+	pool := newGRPCPool(insecure.NewCredentials())
 	t.Cleanup(func() {
 		if err := pool.Close(); err != nil {
 			t.Errorf("close pool: %v", err)

--- a/internal/relaycontrol/grpc_pool_test.go
+++ b/internal/relaycontrol/grpc_pool_test.go
@@ -1,0 +1,39 @@
+package relaycontrol
+
+import (
+	"context"
+	"testing"
+)
+
+func TestGRPCPoolReusesConnectionOnlyWhileRelayAddressMatches(t *testing.T) {
+	pool := newGRPCPool()
+	t.Cleanup(func() {
+		if err := pool.Close(); err != nil {
+			t.Errorf("close pool: %v", err)
+		}
+	})
+
+	ctx := context.Background()
+	if _, err := pool.Client(ctx, "relay-1", "127.0.0.1:50051"); err != nil {
+		t.Fatalf("create first client: %v", err)
+	}
+	first := pool.conns["relay-1"]
+
+	if _, err := pool.Client(ctx, "relay-1", "127.0.0.1:50051"); err != nil {
+		t.Fatalf("reuse client: %v", err)
+	}
+	if reused := pool.conns["relay-1"]; reused.conn != first.conn {
+		t.Fatal("same relay address replaced the pooled connection")
+	}
+
+	if _, err := pool.Client(ctx, "relay-1", "127.0.0.1:50052"); err != nil {
+		t.Fatalf("replace client: %v", err)
+	}
+	replaced := pool.conns["relay-1"]
+	if replaced.address != "127.0.0.1:50052" {
+		t.Fatalf("pooled address = %q, want %q", replaced.address, "127.0.0.1:50052")
+	}
+	if replaced.conn == first.conn {
+		t.Fatal("changed relay address reused the stale pooled connection")
+	}
+}

--- a/internal/relaycontrol/interfaces.go
+++ b/internal/relaycontrol/interfaces.go
@@ -1,0 +1,20 @@
+package relaycontrol
+
+import (
+	"context"
+
+	registryv1 "github.com/aero-arc/aero-arc-protos/gen/go/aeroarc/registry/v1"
+	relayv1 "github.com/aero-arc/aero-arc-protos/gen/go/aeroarc/relay/v1"
+	"google.golang.org/grpc"
+)
+
+type registryClient interface {
+	GetAgentPlacement(context.Context, *registryv1.GetAgentPlacementRequest, ...grpc.CallOption) (*registryv1.GetAgentPlacementResponse, error)
+	ListRelays(context.Context, *registryv1.ListRelaysRequest, ...grpc.CallOption) (*registryv1.ListRelaysResponse, error)
+}
+
+type clientPool interface {
+	Client(context.Context, string, string) (relayv1.RelayControlClient, error)
+	Invalidate(string)
+	Close() error
+}

--- a/internal/relaycontrol/service.go
+++ b/internal/relaycontrol/service.go
@@ -15,6 +15,7 @@ import (
 	registryv1 "github.com/aero-arc/aero-arc-protos/gen/go/aeroarc/registry/v1"
 	relayv1 "github.com/aero-arc/aero-arc-protos/gen/go/aeroarc/relay/v1"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/status"
 )
 
@@ -44,14 +45,17 @@ type cachedPlacement struct {
 	expiresAt        time.Time
 }
 
-func New(registry registryClient, timeout, placementTTL time.Duration) *Service {
+func New(registry registryClient, transportCredentials credentials.TransportCredentials, timeout, placementTTL time.Duration) (*Service, error) {
+	if transportCredentials == nil {
+		return nil, fmt.Errorf("relay transport credentials are required")
+	}
 	if timeout <= 0 {
 		timeout = defaultTimeout
 	}
 	if placementTTL <= 0 {
 		placementTTL = 30 * time.Second
 	}
-	return newWithPool(registry, newGRPCPool(), timeout, placementTTL)
+	return newWithPool(registry, newGRPCPool(transportCredentials), timeout, placementTTL), nil
 }
 
 func newWithPool(registry registryClient, pool clientPool, timeout, ttl time.Duration) *Service {

--- a/internal/relaycontrol/service.go
+++ b/internal/relaycontrol/service.go
@@ -14,24 +14,11 @@ import (
 	agentv1 "github.com/aero-arc/aero-arc-protos/gen/go/aeroarc/agent/v1"
 	registryv1 "github.com/aero-arc/aero-arc-protos/gen/go/aeroarc/registry/v1"
 	relayv1 "github.com/aero-arc/aero-arc-protos/gen/go/aeroarc/relay/v1"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 )
 
 const defaultTimeout = 5 * time.Second
-
-type registryClient interface {
-	GetAgentPlacement(context.Context, *registryv1.GetAgentPlacementRequest, ...grpc.CallOption) (*registryv1.GetAgentPlacementResponse, error)
-	ListRelays(context.Context, *registryv1.ListRelaysRequest, ...grpc.CallOption) (*registryv1.ListRelaysResponse, error)
-}
-
-type clientPool interface {
-	Client(context.Context, string, string) (relayv1.RelayControlClient, error)
-	Invalidate(string)
-	Close() error
-}
 
 type SetRequest struct {
 	AgentID       string
@@ -193,6 +180,7 @@ func validateAck(ack *agentv1.OperationContextCommandAck, commandID string) erro
 		return fmt.Errorf("agent rejected operation context: %s: %s", ack.GetStatus(), ack.GetError())
 	}
 }
+
 func ensureCommandID(id string) (string, error) {
 	if id != "" {
 		return id, nil
@@ -203,6 +191,7 @@ func ensureCommandID(id string) (string, error) {
 	}
 	return hex.EncodeToString(b), nil
 }
+
 func relayAddress(relay *registryv1.Relay) string {
 	address := strings.TrimSpace(relay.GetAddress())
 	if address == "" {
@@ -214,44 +203,4 @@ func relayAddress(relay *registryv1.Relay) string {
 		}
 	}
 	return address
-}
-
-type grpcPool struct {
-	mu    sync.Mutex
-	conns map[string]*grpc.ClientConn
-}
-
-func newGRPCPool() *grpcPool { return &grpcPool{conns: map[string]*grpc.ClientConn{}} }
-func (p *grpcPool) Client(ctx context.Context, relayID, address string) (relayv1.RelayControlClient, error) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	if conn := p.conns[relayID]; conn != nil {
-		return relayv1.NewRelayControlClient(conn), nil
-	}
-	conn, err := grpc.DialContext(ctx, address, grpc.WithTransportCredentials(insecure.NewCredentials()))
-	if err != nil {
-		return nil, err
-	}
-	p.conns[relayID] = conn
-	return relayv1.NewRelayControlClient(conn), nil
-}
-func (p *grpcPool) Invalidate(relayID string) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	if conn := p.conns[relayID]; conn != nil {
-		_ = conn.Close()
-		delete(p.conns, relayID)
-	}
-}
-func (p *grpcPool) Close() error {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	var first error
-	for id, conn := range p.conns {
-		if err := conn.Close(); err != nil && first == nil {
-			first = err
-		}
-		delete(p.conns, id)
-	}
-	return first
 }

--- a/internal/relaycontrol/service.go
+++ b/internal/relaycontrol/service.go
@@ -1,0 +1,257 @@
+package relaycontrol
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	agentv1 "github.com/aero-arc/aero-arc-protos/gen/go/aeroarc/agent/v1"
+	registryv1 "github.com/aero-arc/aero-arc-protos/gen/go/aeroarc/registry/v1"
+	relayv1 "github.com/aero-arc/aero-arc-protos/gen/go/aeroarc/relay/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+)
+
+const defaultTimeout = 5 * time.Second
+
+type registryClient interface {
+	GetAgentPlacement(context.Context, *registryv1.GetAgentPlacementRequest, ...grpc.CallOption) (*registryv1.GetAgentPlacementResponse, error)
+	ListRelays(context.Context, *registryv1.ListRelaysRequest, ...grpc.CallOption) (*registryv1.ListRelaysResponse, error)
+}
+
+type clientPool interface {
+	Client(context.Context, string, string) (relayv1.RelayControlClient, error)
+	Invalidate(string)
+	Close() error
+}
+
+type SetRequest struct {
+	AgentID       string
+	FlightID      string
+	IntentID      string
+	IntentVersion uint32
+	CommandID     string
+}
+
+type ClearRequest struct{ AgentID, FlightID, CommandID string }
+
+type Service struct {
+	registry              registryClient
+	pool                  clientPool
+	timeout, placementTTL time.Duration
+	now                   func() time.Time
+	mu                    sync.Mutex
+	placements            map[string]cachedPlacement
+}
+
+type cachedPlacement struct {
+	relayID, address string
+	expiresAt        time.Time
+}
+
+func New(registry registryClient, timeout, placementTTL time.Duration) *Service {
+	if timeout <= 0 {
+		timeout = defaultTimeout
+	}
+	if placementTTL <= 0 {
+		placementTTL = 30 * time.Second
+	}
+	return newWithPool(registry, newGRPCPool(), timeout, placementTTL)
+}
+
+func newWithPool(registry registryClient, pool clientPool, timeout, ttl time.Duration) *Service {
+	return &Service{registry: registry, pool: pool, timeout: timeout, placementTTL: ttl, now: time.Now, placements: map[string]cachedPlacement{}}
+}
+
+func (s *Service) Close() error { return s.pool.Close() }
+
+func (s *Service) SetOperationContext(ctx context.Context, req SetRequest) (string, error) {
+	if req.AgentID == "" || req.FlightID == "" {
+		return "", fmt.Errorf("agent_id and flight_id are required")
+	}
+	commandID, err := ensureCommandID(req.CommandID)
+	if err != nil {
+		return "", err
+	}
+	command := &agentv1.SetOperationContextCommand{CommandId: commandID, Context: &agentv1.OperationContext{FlightId: req.FlightID, IntentId: req.IntentID, IntentVersion: req.IntentVersion}}
+	err = s.call(ctx, req.AgentID, func(callCtx context.Context, client relayv1.RelayControlClient) error {
+		response, err := client.SetOperationContext(callCtx, &relayv1.SetOperationContextRequest{AgentId: req.AgentID, Command: command})
+		if err != nil {
+			return err
+		}
+		return validateAck(response.GetResult(), commandID)
+	})
+	return commandID, err
+}
+
+func (s *Service) ClearOperationContext(ctx context.Context, req ClearRequest) (string, error) {
+	if req.AgentID == "" || req.FlightID == "" {
+		return "", fmt.Errorf("agent_id and flight_id are required")
+	}
+	commandID, err := ensureCommandID(req.CommandID)
+	if err != nil {
+		return "", err
+	}
+	command := &agentv1.ClearOperationContextCommand{CommandId: commandID, FlightId: req.FlightID}
+	err = s.call(ctx, req.AgentID, func(callCtx context.Context, client relayv1.RelayControlClient) error {
+		response, err := client.ClearOperationContext(callCtx, &relayv1.ClearOperationContextRequest{AgentId: req.AgentID, Command: command})
+		if err != nil {
+			return err
+		}
+		return validateAck(response.GetResult(), commandID)
+	})
+	return commandID, err
+}
+
+func (s *Service) call(ctx context.Context, agentID string, invoke func(context.Context, relayv1.RelayControlClient) error) error {
+	for attempt := 0; attempt < 2; attempt++ {
+		placement, err := s.resolve(ctx, agentID, attempt > 0)
+		if err != nil {
+			return err
+		}
+		client, err := s.pool.Client(ctx, placement.relayID, placement.address)
+		if err != nil {
+			return fmt.Errorf("connect relay %s: %w", placement.relayID, err)
+		}
+		callCtx, cancel := context.WithTimeout(ctx, s.timeout)
+		err = invoke(callCtx, client)
+		cancel()
+		if status.Code(err) != codes.Unavailable || attempt == 1 {
+			if err != nil {
+				return fmt.Errorf("deliver operation context: %w", err)
+			}
+			return nil
+		}
+		s.invalidate(agentID, placement.relayID)
+	}
+	return nil
+}
+
+func (s *Service) resolve(ctx context.Context, agentID string, refresh bool) (cachedPlacement, error) {
+	s.mu.Lock()
+	cached, ok := s.placements[agentID]
+	s.mu.Unlock()
+	if !refresh && ok && s.now().Before(cached.expiresAt) {
+		return cached, nil
+	}
+	lookupCtx, cancel := context.WithTimeout(ctx, s.timeout)
+	defer cancel()
+	response, err := s.registry.GetAgentPlacement(lookupCtx, &registryv1.GetAgentPlacementRequest{AgentId: agentID})
+	if err != nil {
+		return cachedPlacement{}, fmt.Errorf("resolve agent placement: %w", err)
+	}
+	placement := response.GetPlacement()
+	if placement == nil || placement.GetRelayId() == "" {
+		return cachedPlacement{}, fmt.Errorf("agent %s has no relay placement", agentID)
+	}
+	relays, err := s.registry.ListRelays(lookupCtx, &registryv1.ListRelaysRequest{})
+	if err != nil {
+		return cachedPlacement{}, fmt.Errorf("list relays: %w", err)
+	}
+	for _, relay := range relays.GetRelays() {
+		if relay.GetRelayId() == placement.GetRelayId() {
+			address := relayAddress(relay)
+			if address == "" {
+				break
+			}
+			resolved := cachedPlacement{relayID: relay.GetRelayId(), address: address, expiresAt: s.now().Add(s.placementTTL)}
+			s.mu.Lock()
+			s.placements[agentID] = resolved
+			s.mu.Unlock()
+			return resolved, nil
+		}
+	}
+	return cachedPlacement{}, fmt.Errorf("relay %s has no routable address", placement.GetRelayId())
+}
+
+func (s *Service) invalidate(agentID, relayID string) {
+	s.mu.Lock()
+	delete(s.placements, agentID)
+	s.mu.Unlock()
+	s.pool.Invalidate(relayID)
+}
+
+func validateAck(ack *agentv1.OperationContextCommandAck, commandID string) error {
+	if ack == nil {
+		return fmt.Errorf("relay returned no agent acknowledgement")
+	}
+	if ack.GetCommandId() != commandID {
+		return fmt.Errorf("agent acknowledgement command_id %q does not match %q", ack.GetCommandId(), commandID)
+	}
+	switch ack.GetStatus() {
+	case agentv1.OperationContextCommandAck_STATUS_APPLIED, agentv1.OperationContextCommandAck_STATUS_ALREADY_APPLIED:
+		return nil
+	default:
+		return fmt.Errorf("agent rejected operation context: %s: %s", ack.GetStatus(), ack.GetError())
+	}
+}
+func ensureCommandID(id string) (string, error) {
+	if id != "" {
+		return id, nil
+	}
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("generate command id: %w", err)
+	}
+	return hex.EncodeToString(b), nil
+}
+func relayAddress(relay *registryv1.Relay) string {
+	address := strings.TrimSpace(relay.GetAddress())
+	if address == "" {
+		return ""
+	}
+	if relay.GetGrpcPort() > 0 {
+		if _, _, err := net.SplitHostPort(address); err != nil {
+			return net.JoinHostPort(address, strconv.Itoa(int(relay.GetGrpcPort())))
+		}
+	}
+	return address
+}
+
+type grpcPool struct {
+	mu    sync.Mutex
+	conns map[string]*grpc.ClientConn
+}
+
+func newGRPCPool() *grpcPool { return &grpcPool{conns: map[string]*grpc.ClientConn{}} }
+func (p *grpcPool) Client(ctx context.Context, relayID, address string) (relayv1.RelayControlClient, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if conn := p.conns[relayID]; conn != nil {
+		return relayv1.NewRelayControlClient(conn), nil
+	}
+	conn, err := grpc.DialContext(ctx, address, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return nil, err
+	}
+	p.conns[relayID] = conn
+	return relayv1.NewRelayControlClient(conn), nil
+}
+func (p *grpcPool) Invalidate(relayID string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if conn := p.conns[relayID]; conn != nil {
+		_ = conn.Close()
+		delete(p.conns, relayID)
+	}
+}
+func (p *grpcPool) Close() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	var first error
+	for id, conn := range p.conns {
+		if err := conn.Close(); err != nil && first == nil {
+			first = err
+		}
+		delete(p.conns, id)
+	}
+	return first
+}

--- a/internal/relaycontrol/service_test.go
+++ b/internal/relaycontrol/service_test.go
@@ -1,0 +1,143 @@
+package relaycontrol
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	agentv1 "github.com/aero-arc/aero-arc-protos/gen/go/aeroarc/agent/v1"
+	registryv1 "github.com/aero-arc/aero-arc-protos/gen/go/aeroarc/registry/v1"
+	relayv1 "github.com/aero-arc/aero-arc-protos/gen/go/aeroarc/relay/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+type fakeRegistry struct {
+	relayIDs []string
+	calls    int
+}
+
+func (f *fakeRegistry) GetAgentPlacement(_ context.Context, _ *registryv1.GetAgentPlacementRequest, _ ...grpc.CallOption) (*registryv1.GetAgentPlacementResponse, error) {
+	i := f.calls
+	if i >= len(f.relayIDs) {
+		i = len(f.relayIDs) - 1
+	}
+	f.calls++
+	return &registryv1.GetAgentPlacementResponse{Placement: &registryv1.AgentPlacement{AgentId: "agent-1", RelayId: f.relayIDs[i]}}, nil
+}
+func (f *fakeRegistry) ListRelays(context.Context, *registryv1.ListRelaysRequest, ...grpc.CallOption) (*registryv1.ListRelaysResponse, error) {
+	return &registryv1.ListRelaysResponse{Relays: []*registryv1.Relay{{RelayId: "relay-1", Address: "relay-one", GrpcPort: 50051}, {RelayId: "relay-2", Address: "relay-two:50052"}}}, nil
+}
+
+type fakePool struct {
+	clients     map[string]*fakeRelayClient
+	invalidated []string
+}
+
+func (f *fakePool) Client(_ context.Context, id, _ string) (relayv1.RelayControlClient, error) {
+	return f.clients[id], nil
+}
+func (f *fakePool) Invalidate(id string) { f.invalidated = append(f.invalidated, id) }
+func (f *fakePool) Close() error         { return nil }
+
+type fakeRelayClient struct {
+	setRequests   []*relayv1.SetOperationContextRequest
+	clearRequests []*relayv1.ClearOperationContextRequest
+	setErrors     []error
+	block         bool
+}
+
+func (f *fakeRelayClient) ListActiveDrones(context.Context, *relayv1.ListActiveDronesRequest, ...grpc.CallOption) (*relayv1.ListActiveDronesResponse, error) {
+	return nil, errors.New("unused")
+}
+func (f *fakeRelayClient) GetDroneStatus(context.Context, *relayv1.GetDroneStatusRequest, ...grpc.CallOption) (*relayv1.GetDroneStatusResponse, error) {
+	return nil, errors.New("unused")
+}
+func (f *fakeRelayClient) SetOperationContext(ctx context.Context, r *relayv1.SetOperationContextRequest, _ ...grpc.CallOption) (*relayv1.SetOperationContextResponse, error) {
+	f.setRequests = append(f.setRequests, r)
+	if f.block {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	if len(f.setErrors) > 0 {
+		err := f.setErrors[0]
+		f.setErrors = f.setErrors[1:]
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &relayv1.SetOperationContextResponse{Result: &agentv1.OperationContextCommandAck{CommandId: r.Command.GetCommandId(), Status: agentv1.OperationContextCommandAck_STATUS_APPLIED}}, nil
+}
+func (f *fakeRelayClient) ClearOperationContext(_ context.Context, r *relayv1.ClearOperationContextRequest, _ ...grpc.CallOption) (*relayv1.ClearOperationContextResponse, error) {
+	f.clearRequests = append(f.clearRequests, r)
+	return &relayv1.ClearOperationContextResponse{Result: &agentv1.OperationContextCommandAck{CommandId: r.Command.GetCommandId(), Status: agentv1.OperationContextCommandAck_STATUS_ALREADY_APPLIED}}, nil
+}
+
+func TestSetOperationContextCachesPlacementAndPreservesCommandID(t *testing.T) {
+	registry := &fakeRegistry{relayIDs: []string{"relay-1"}}
+	client := &fakeRelayClient{}
+	service := newWithPool(registry, &fakePool{clients: map[string]*fakeRelayClient{"relay-1": client}}, time.Second, time.Minute)
+	for i := 0; i < 2; i++ {
+		id, err := service.SetOperationContext(context.Background(), SetRequest{AgentID: "agent-1", FlightID: "flight-1", IntentID: "intent-1", IntentVersion: 3, CommandID: "command-1"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if id != "command-1" {
+			t.Fatalf("id=%q", id)
+		}
+	}
+	if registry.calls != 1 {
+		t.Fatalf("registry calls=%d", registry.calls)
+	}
+	if len(client.setRequests) != 2 {
+		t.Fatalf("requests=%d", len(client.setRequests))
+	}
+	context := client.setRequests[0].Command.GetContext()
+	if context.GetFlightId() != "flight-1" || context.GetIntentId() != "intent-1" || context.GetIntentVersion() != 3 {
+		t.Fatalf("context=%v", context)
+	}
+}
+
+func TestUnavailableInvalidatesPlacementAndRetriesSameCommand(t *testing.T) {
+	registry := &fakeRegistry{relayIDs: []string{"relay-1", "relay-2"}}
+	first := &fakeRelayClient{setErrors: []error{status.Error(codes.Unavailable, "moved")}}
+	second := &fakeRelayClient{}
+	pool := &fakePool{clients: map[string]*fakeRelayClient{"relay-1": first, "relay-2": second}}
+	service := newWithPool(registry, pool, time.Second, time.Minute)
+	_, err := service.SetOperationContext(context.Background(), SetRequest{AgentID: "agent-1", FlightID: "flight-1", CommandID: "stable"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if registry.calls != 2 || len(pool.invalidated) != 1 || pool.invalidated[0] != "relay-1" {
+		t.Fatalf("calls=%d invalidated=%v", registry.calls, pool.invalidated)
+	}
+	if second.setRequests[0].Command.GetCommandId() != "stable" {
+		t.Fatalf("command changed: %v", second.setRequests[0].Command)
+	}
+}
+
+func TestClearOperationContext(t *testing.T) {
+	client := &fakeRelayClient{}
+	service := newWithPool(&fakeRegistry{relayIDs: []string{"relay-1"}}, &fakePool{clients: map[string]*fakeRelayClient{"relay-1": client}}, time.Second, time.Minute)
+	id, err := service.ClearOperationContext(context.Background(), ClearRequest{AgentID: "agent-1", FlightID: "flight-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(id) != 32 {
+		t.Fatalf("generated id=%q", id)
+	}
+	if client.clearRequests[0].Command.GetFlightId() != "flight-1" {
+		t.Fatalf("request=%v", client.clearRequests[0])
+	}
+}
+
+func TestTimeout(t *testing.T) {
+	client := &fakeRelayClient{block: true}
+	service := newWithPool(&fakeRegistry{relayIDs: []string{"relay-1"}}, &fakePool{clients: map[string]*fakeRelayClient{"relay-1": client}}, 10*time.Millisecond, time.Minute)
+	_, err := service.SetOperationContext(context.Background(), SetRequest{AgentID: "agent-1", FlightID: "flight-1", CommandID: "command"})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("err=%v", err)
+	}
+}

--- a/internal/relaycontrol/service_test.go
+++ b/internal/relaycontrol/service_test.go
@@ -11,6 +11,7 @@ import (
 	relayv1 "github.com/aero-arc/aero-arc-protos/gen/go/aeroarc/relay/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 )
 
@@ -47,6 +48,19 @@ type fakeRelayClient struct {
 	clearRequests []*relayv1.ClearOperationContextRequest
 	setErrors     []error
 	block         bool
+}
+
+func TestNewRequiresRelayTransportCredentials(t *testing.T) {
+	if _, err := New(&fakeRegistry{relayIDs: []string{"relay-1"}}, nil, time.Second, time.Minute); err == nil {
+		t.Fatal("New returned nil error without relay transport credentials")
+	}
+	service, err := New(&fakeRegistry{relayIDs: []string{"relay-1"}}, insecure.NewCredentials(), time.Second, time.Minute)
+	if err != nil {
+		t.Fatalf("New returned error with relay transport credentials: %v", err)
+	}
+	if err := service.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
 }
 
 func (f *fakeRelayClient) ListActiveDrones(context.Context, *relayv1.ListActiveDronesRequest, ...grpc.CallOption) (*relayv1.ListActiveDronesResponse, error) {


### PR DESCRIPTION
## What changed

- update to the protobuf release that exposes relay operation-context RPCs
- add an API-side service for setting and clearing an agent's active flight/intent context
- generate command IDs when absent and preserve them across a safe retry
- enforce per-call timeouts and validate durable agent acknowledgements
- cache agent placement briefly, pool relay gRPC connections, and invalidate/refetch placement once on `Unavailable`
- add focused tests for request mapping, idempotency, cache reuse, failover refresh, clear semantics, and deadlines
-  address-aware connection replacement;
- follow-up issues #14, #15, #16, Relay #49, and Registry #14.

## Why

Flight and intent attribution must reach the agent before telemetry enters its WAL. This client provides the API-to-relay delivery seam needed at the future authoritative flight start/end workflow boundary.

The service is intentionally not invoked from intent activation: the current API has no flight-start/flight-end mutation, and an active intent alone does not provide an authoritative flight ID.

## Validation

- `go test ./...`
- `git diff --check`