### PR TITLE
Split airspace candidate discovery

### DIFF
--- a/internal/domain/deconfliction.go
+++ b/internal/domain/deconfliction.go
@@ -36,6 +36,15 @@ type ConflictFinding struct {
 	EvaluatedAt         time.Time                 `json:"evaluated_at"`
 }
 
+// OperationalIntentConflictCandidate is a broad-phase airspace awareness
+// result: a peer intent plus the subset of its operational volumes that could
+// plausibly conflict with a target intent. Narrow-phase overlap evaluation
+// makes the final determination.
+type OperationalIntentConflictCandidate struct {
+	Intent  OperationalIntent   `json:"intent"`
+	Volumes []OperationalVolume `json:"volumes"`
+}
+
 type DeconflictionResult struct {
 	Intent      OperationalIntent    `json:"intent"`
 	Posture     DeconflictionPosture `json:"posture"`

--- a/internal/service/airspace_provider.go
+++ b/internal/service/airspace_provider.go
@@ -1,0 +1,106 @@
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Aero-Arc/aero-arc-api/internal/domain"
+	"github.com/Aero-Arc/aero-arc-api/internal/store/durable"
+)
+
+// AirspaceAwarenessProvider performs broad-phase candidate discovery for
+// deconfliction: given a target intent and its operational volumes, it returns
+// the peer intents (and the subset of their volumes) that could plausibly
+// conflict. Narrow-phase overlap evaluation remains the responsibility of the
+// DeconflictionService, so providers may over-include candidates but must
+// never exclude a volume that could produce a finding.
+//
+// This is the seam for future DSS/USS-backed discovery (for example a
+// DSSAirspaceProvider or a CompositeAirspaceProvider).
+type AirspaceAwarenessProvider interface {
+	QueryConflictCandidates(
+		ctx context.Context,
+		intent domain.OperationalIntent,
+		volumes []domain.OperationalVolume,
+	) ([]domain.OperationalIntentConflictCandidate, error)
+}
+
+// LocalStoreAirspaceProvider discovers conflict candidates from the local
+// durable store. It filters by intent lifecycle status, current intent
+// version, time overlap, and altitude band before any geometry is parsed.
+type LocalStoreAirspaceProvider struct {
+	durable durable.Store
+}
+
+func NewLocalStoreAirspaceProvider(durableStore durable.Store) *LocalStoreAirspaceProvider {
+	return &LocalStoreAirspaceProvider{durable: durableStore}
+}
+
+func (p *LocalStoreAirspaceProvider) QueryConflictCandidates(
+	ctx context.Context,
+	intent domain.OperationalIntent,
+	volumes []domain.OperationalVolume,
+) ([]domain.OperationalIntentConflictCandidate, error) {
+	peers, err := p.durable.ListOperationalIntents(ctx, "")
+	if err != nil {
+		return nil, fmt.Errorf("list operational intents: %w", err)
+	}
+	allVolumes, err := p.durable.ListOperationalVolumes(ctx, "")
+	if err != nil {
+		return nil, fmt.Errorf("list candidate operational volumes: %w", err)
+	}
+	volumesByIntent := make(map[string][]domain.OperationalVolume)
+	for _, volume := range allVolumes {
+		volumesByIntent[volume.IntentID] = append(volumesByIntent[volume.IntentID], volume)
+	}
+
+	candidates := make([]domain.OperationalIntentConflictCandidate, 0)
+	for _, peer := range peers {
+		if peer.ID == intent.ID || !candidateConflictEligible(peer.Status) {
+			continue
+		}
+		peerVolumes := make([]domain.OperationalVolume, 0)
+		for _, peerVolume := range volumesForVersion(volumesByIntent[peer.ID], peer.Version) {
+			if peerVolumeCouldConflict(volumes, peerVolume) {
+				peerVolumes = append(peerVolumes, peerVolume)
+			}
+		}
+		if len(peerVolumes) == 0 {
+			continue
+		}
+		candidates = append(candidates, domain.OperationalIntentConflictCandidate{
+			Intent:  peer,
+			Volumes: peerVolumes,
+		})
+	}
+	return candidates, nil
+}
+
+// peerVolumeCouldConflict is the broad-phase 1D prefilter applied before any
+// geometry parsing. It may only drop a peer volume when narrow-phase
+// evaluation could not produce a finding against any target volume:
+//
+//   - A peer volume with unusable dimensions always fails closed to an
+//     indeterminate finding downstream, so it is always kept.
+//   - A peer volume with a mismatched altitude reference can still yield an
+//     indeterminate finding, so altitude bands are only compared when the
+//     references match.
+func peerVolumeCouldConflict(targetVolumes []domain.OperationalVolume, peerVolume domain.OperationalVolume) bool {
+	if !peerVolumeDimensionsUsable(peerVolume) {
+		return true
+	}
+	for _, target := range targetVolumes {
+		if !timeWindowsOverlap(target.StartsAt, target.EndsAt, peerVolume.StartsAt, peerVolume.EndsAt) {
+			continue
+		}
+		if target.AltitudeRef != peerVolume.AltitudeRef ||
+			altitudeBandsOverlap(target.MinAltitudeM, target.MaxAltitudeM, peerVolume.MinAltitudeM, peerVolume.MaxAltitudeM) {
+			return true
+		}
+	}
+	return false
+}
+
+func candidateConflictEligible(status domain.IntentStatus) bool {
+	return status == domain.IntentStatusAccepted || status == domain.IntentStatusActive
+}

--- a/internal/service/airspace_provider_test.go
+++ b/internal/service/airspace_provider_test.go
@@ -1,0 +1,280 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Aero-Arc/aero-arc-api/internal/domain"
+	durablememory "github.com/Aero-Arc/aero-arc-api/internal/store/durable/memory"
+)
+
+func TestAirspaceProviderFiltersCandidatesByLifecycleStatus(t *testing.T) {
+	ctx := context.Background()
+	store := durablememory.NewStore()
+	now := fixedWorkflowTime()
+	seedDeconflictionAircraft(t, ctx, store, now)
+	target, targetVolumes := providerTargetIntent(t, ctx, store, now)
+
+	for _, tc := range []struct {
+		id     string
+		status domain.IntentStatus
+	}{
+		{id: "intent-draft", status: domain.IntentStatusDraft},
+		{id: "intent-submitted", status: domain.IntentStatusSubmitted},
+		{id: "intent-review", status: domain.IntentStatusReview},
+		{id: "intent-rejected", status: domain.IntentStatusRejected},
+		{id: "intent-canceled", status: domain.IntentStatusCanceled},
+		{id: "intent-complete", status: domain.IntentStatusComplete},
+		{id: "intent-superseded", status: domain.IntentStatusSuperseded},
+		{id: "intent-accepted", status: domain.IntentStatusAccepted},
+		{id: "intent-active", status: domain.IntentStatusActive},
+	} {
+		intent := createAcceptedIntentWithVolume(t, ctx, store, now, tc.id, "aircraft-2", "volume-"+tc.id, squareGeoJSON(), 10, 120, now)
+		intent.Status = tc.status
+		must(t, store.UpdateOperationalIntent(ctx, intent))
+	}
+
+	candidates, err := NewLocalStoreAirspaceProvider(store).QueryConflictCandidates(ctx, target, targetVolumes)
+	if err != nil {
+		t.Fatalf("QueryConflictCandidates returned error: %v", err)
+	}
+	got := candidateIntentIDs(candidates)
+	if len(got) != 2 || !got["intent-accepted"] || !got["intent-active"] {
+		t.Fatalf("candidate intents = %v, want only accepted and active peers", got)
+	}
+}
+
+func TestAirspaceProviderExcludesTargetIntent(t *testing.T) {
+	ctx := context.Background()
+	store := durablememory.NewStore()
+	now := fixedWorkflowTime()
+	seedDeconflictionAircraft(t, ctx, store, now)
+	target := createAcceptedIntentWithVolume(t, ctx, store, now, "intent-target", "aircraft-1", "volume-target", squareGeoJSON(), 10, 120, now)
+	targetVolumes, err := store.ListOperationalVolumes(ctx, target.ID)
+	must(t, err)
+
+	candidates, err := NewLocalStoreAirspaceProvider(store).QueryConflictCandidates(ctx, target, volumesForVersion(targetVolumes, target.Version))
+	if err != nil {
+		t.Fatalf("QueryConflictCandidates returned error: %v", err)
+	}
+	if len(candidates) != 0 {
+		t.Fatalf("candidates = %#v, want target intent excluded from its own candidate set", candidates)
+	}
+}
+
+func TestAirspaceProviderFiltersPeerVolumesByIntentVersion(t *testing.T) {
+	ctx := context.Background()
+	store := durablememory.NewStore()
+	now := fixedWorkflowTime()
+	seedDeconflictionAircraft(t, ctx, store, now)
+	target, targetVolumes := providerTargetIntent(t, ctx, store, now)
+	peer := createAcceptedIntentWithVolume(t, ctx, store, now, "intent-peer", "aircraft-2", "volume-peer-v1", squareGeoJSON(), 10, 120, now)
+	peer.Version = 2
+	must(t, store.UpdateOperationalIntent(ctx, peer))
+	must(t, store.RecordOperationalVolume(ctx, domain.OperationalVolume{
+		ID:            "volume-peer-v2",
+		OperatorID:    "operator-1",
+		IntentID:      peer.ID,
+		IntentVersion: 2,
+		Sequence:      1,
+		GeoJSON:       squareGeoJSON(),
+		MinAltitudeM:  10,
+		MaxAltitudeM:  120,
+		AltitudeRef:   domain.AltitudeReferenceAGL,
+		StartsAt:      now,
+		EndsAt:        now.Add(time.Hour),
+		VolumeType:    domain.OperationalVolumeLoiter,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}))
+
+	candidates, err := NewLocalStoreAirspaceProvider(store).QueryConflictCandidates(ctx, target, targetVolumes)
+	if err != nil {
+		t.Fatalf("QueryConflictCandidates returned error: %v", err)
+	}
+	if len(candidates) != 1 || len(candidates[0].Volumes) != 1 || candidates[0].Volumes[0].ID != "volume-peer-v2" {
+		t.Fatalf("candidates = %#v, want only the current-version peer volume", candidates)
+	}
+}
+
+func TestAirspaceProviderFiltersPeerVolumesByTimeWindow(t *testing.T) {
+	ctx := context.Background()
+	store := durablememory.NewStore()
+	now := fixedWorkflowTime()
+	seedDeconflictionAircraft(t, ctx, store, now)
+	target, targetVolumes := providerTargetIntent(t, ctx, store, now)
+	// Target occupies [now, now+1h); the peer starts exactly when the target
+	// ends, so the half-open windows do not overlap.
+	createAcceptedIntentWithVolume(t, ctx, store, now, "intent-peer", "aircraft-2", "volume-peer", squareGeoJSON(), 10, 120, now.Add(time.Hour))
+
+	candidates, err := NewLocalStoreAirspaceProvider(store).QueryConflictCandidates(ctx, target, targetVolumes)
+	if err != nil {
+		t.Fatalf("QueryConflictCandidates returned error: %v", err)
+	}
+	if len(candidates) != 0 {
+		t.Fatalf("candidates = %#v, want time-disjoint peer volume filtered out", candidates)
+	}
+}
+
+func TestAirspaceProviderFiltersPeerVolumesByAltitudeBand(t *testing.T) {
+	ctx := context.Background()
+	store := durablememory.NewStore()
+	now := fixedWorkflowTime()
+	seedDeconflictionAircraft(t, ctx, store, now)
+	target, targetVolumes := providerTargetIntent(t, ctx, store, now)
+	createAcceptedIntentWithVolume(t, ctx, store, now, "intent-peer", "aircraft-2", "volume-peer", squareGeoJSON(), 200, 300, now)
+
+	candidates, err := NewLocalStoreAirspaceProvider(store).QueryConflictCandidates(ctx, target, targetVolumes)
+	if err != nil {
+		t.Fatalf("QueryConflictCandidates returned error: %v", err)
+	}
+	if len(candidates) != 0 {
+		t.Fatalf("candidates = %#v, want altitude-separated peer volume filtered out", candidates)
+	}
+}
+
+func TestAirspaceProviderKeepsPeerVolumesWithMismatchedAltitudeReference(t *testing.T) {
+	ctx := context.Background()
+	store := durablememory.NewStore()
+	now := fixedWorkflowTime()
+	seedDeconflictionAircraft(t, ctx, store, now)
+	target, targetVolumes := providerTargetIntent(t, ctx, store, now)
+	// Altitude bands are disjoint, but the references differ (target is AGL),
+	// so the bands cannot be compared locally and narrow-phase evaluation must
+	// still see this volume to fail closed.
+	createAcceptedIntentWithVolume(t, ctx, store, now, "intent-peer", "aircraft-2", "volume-peer", squareGeoJSON(), 200, 300, now)
+	peerVolumes, err := store.ListOperationalVolumes(ctx, "intent-peer")
+	must(t, err)
+	peerVolume := peerVolumes[0]
+	peerVolume.AltitudeRef = domain.AltitudeReferenceMSL
+	must(t, store.RecordOperationalVolume(ctx, peerVolume))
+
+	candidates, err := NewLocalStoreAirspaceProvider(store).QueryConflictCandidates(ctx, target, targetVolumes)
+	if err != nil {
+		t.Fatalf("QueryConflictCandidates returned error: %v", err)
+	}
+	if len(candidates) != 1 || len(candidates[0].Volumes) != 1 {
+		t.Fatalf("candidates = %#v, want mismatched-reference peer volume kept", candidates)
+	}
+}
+
+func TestAirspaceProviderKeepsPeerVolumesWithUnusableDimensions(t *testing.T) {
+	ctx := context.Background()
+	store := durablememory.NewStore()
+	now := fixedWorkflowTime()
+	seedDeconflictionAircraft(t, ctx, store, now)
+	target, targetVolumes := providerTargetIntent(t, ctx, store, now)
+	// The peer volume is time-disjoint from the target, but its missing
+	// altitude band means deconfliction must fail closed rather than filter.
+	peer := createAcceptedIntentWithVolume(t, ctx, store, now, "intent-peer", "aircraft-2", "volume-peer", squareGeoJSON(), 10, 120, now.Add(2*time.Hour))
+	must(t, store.RecordOperationalVolume(ctx, domain.OperationalVolume{
+		ID:            "volume-peer",
+		OperatorID:    "operator-1",
+		IntentID:      peer.ID,
+		IntentVersion: peer.Version,
+		Sequence:      1,
+		GeoJSON:       squareGeoJSON(),
+		MinAltitudeM:  0,
+		MaxAltitudeM:  0,
+		AltitudeRef:   domain.AltitudeReferenceAGL,
+		StartsAt:      now.Add(2 * time.Hour),
+		EndsAt:        now.Add(3 * time.Hour),
+		VolumeType:    domain.OperationalVolumeLoiter,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}))
+
+	candidates, err := NewLocalStoreAirspaceProvider(store).QueryConflictCandidates(ctx, target, targetVolumes)
+	if err != nil {
+		t.Fatalf("QueryConflictCandidates returned error: %v", err)
+	}
+	if len(candidates) != 1 || len(candidates[0].Volumes) != 1 {
+		t.Fatalf("candidates = %#v, want unusable-dimension peer volume kept for fail-closed evaluation", candidates)
+	}
+}
+
+type stubAirspaceProvider struct {
+	candidates []domain.OperationalIntentConflictCandidate
+	calls      int
+}
+
+func (p *stubAirspaceProvider) QueryConflictCandidates(_ context.Context, _ domain.OperationalIntent, _ []domain.OperationalVolume) ([]domain.OperationalIntentConflictCandidate, error) {
+	p.calls++
+	return p.candidates, nil
+}
+
+func TestDeconflictionUsesInjectedAirspaceProvider(t *testing.T) {
+	ctx := context.Background()
+	store := durablememory.NewStore()
+	now := fixedWorkflowTime()
+	seedDeconflictionAircraft(t, ctx, store, now)
+	target := createDraftIntentWithVolume(t, ctx, store, now, "intent-target", "aircraft-1", "volume-target", squareGeoJSON(), 10, 120)
+	// This peer fully overlaps the target in the store, but the injected
+	// provider does not surface it, proving CheckIntent no longer scans the
+	// durable store for candidates.
+	createAcceptedIntentWithVolume(t, ctx, store, now, "intent-peer", "aircraft-2", "volume-peer", squareGeoJSON(), 10, 120, now)
+	provider := &stubAirspaceProvider{}
+
+	result, err := NewDeconflictionServiceWithClock(store, fixedClock(now), provider).CheckIntent(ctx, target.ID)
+	if err != nil {
+		t.Fatalf("CheckIntent returned error: %v", err)
+	}
+	if provider.calls != 1 {
+		t.Fatalf("provider calls = %d, want candidate discovery delegated once", provider.calls)
+	}
+	if result.Posture != domain.DeconflictionPostureClear {
+		t.Fatalf("posture = %q, want clear when provider returns no candidates; findings=%#v", result.Posture, result.Findings)
+	}
+}
+
+func TestDeconflictionEvaluatesProviderSuppliedCandidates(t *testing.T) {
+	ctx := context.Background()
+	store := durablememory.NewStore()
+	now := fixedWorkflowTime()
+	seedDeconflictionAircraft(t, ctx, store, now)
+	target := createDraftIntentWithVolume(t, ctx, store, now, "intent-target", "aircraft-1", "volume-target", squareGeoJSON(), 10, 120)
+	provider := &stubAirspaceProvider{
+		candidates: []domain.OperationalIntentConflictCandidate{{
+			Intent: domain.OperationalIntent{ID: "intent-remote", Version: 1, Status: domain.IntentStatusAccepted},
+			Volumes: []domain.OperationalVolume{{
+				ID:            "volume-remote",
+				IntentID:      "intent-remote",
+				IntentVersion: 1,
+				GeoJSON:       squareGeoJSON(),
+				MinAltitudeM:  10,
+				MaxAltitudeM:  120,
+				AltitudeRef:   domain.AltitudeReferenceAGL,
+				StartsAt:      now,
+				EndsAt:        now.Add(time.Hour),
+			}},
+		}},
+	}
+
+	result, err := NewDeconflictionServiceWithClock(store, fixedClock(now), provider).CheckIntent(ctx, target.ID)
+	if err != nil {
+		t.Fatalf("CheckIntent returned error: %v", err)
+	}
+	if result.Posture != domain.DeconflictionPosturePotentialConflict {
+		t.Fatalf("posture = %q, want potential_conflict from provider-supplied candidate; findings=%#v", result.Posture, result.Findings)
+	}
+	if len(result.Findings) != 1 || result.Findings[0].ConflictingIntentID != "intent-remote" || result.Findings[0].ConflictingVolumeID != "volume-remote" {
+		t.Fatalf("findings = %#v, want single finding against provider-supplied volume", result.Findings)
+	}
+}
+
+func providerTargetIntent(t *testing.T, ctx context.Context, store *durablememory.Store, now time.Time) (domain.OperationalIntent, []domain.OperationalVolume) {
+	t.Helper()
+	target := createDraftIntentWithVolume(t, ctx, store, now, "intent-target", "aircraft-1", "volume-target", squareGeoJSON(), 10, 120)
+	volumes, err := store.ListOperationalVolumes(ctx, target.ID)
+	must(t, err)
+	return target, volumesForVersion(volumes, target.Version)
+}
+
+func candidateIntentIDs(candidates []domain.OperationalIntentConflictCandidate) map[string]bool {
+	ids := make(map[string]bool, len(candidates))
+	for _, candidate := range candidates {
+		ids[candidate.Intent.ID] = true
+	}
+	return ids
+}

--- a/internal/service/deconfliction_service.go
+++ b/internal/service/deconfliction_service.go
@@ -15,19 +15,28 @@ import (
 const deconflictionRuleVersion = "local-dss-shaped-v1"
 
 type DeconflictionService struct {
-	durable durable.Store
-	now     func() time.Time
+	durable  durable.Store
+	airspace AirspaceAwarenessProvider
+	now      func() time.Time
 }
 
-func NewDeconflictionService(durableStore durable.Store) *DeconflictionService {
-	return NewDeconflictionServiceWithClock(durableStore, nil)
+func NewDeconflictionService(durableStore durable.Store, airspace ...AirspaceAwarenessProvider) *DeconflictionService {
+	return NewDeconflictionServiceWithClock(durableStore, nil, airspace...)
 }
 
-func NewDeconflictionServiceWithClock(durableStore durable.Store, now func() time.Time) *DeconflictionService {
+func NewDeconflictionServiceWithClock(durableStore durable.Store, now func() time.Time, airspace ...AirspaceAwarenessProvider) *DeconflictionService {
 	if now == nil {
 		now = func() time.Time { return time.Now().UTC() }
 	}
-	return &DeconflictionService{durable: durableStore, now: now}
+	service := &DeconflictionService{
+		durable:  durableStore,
+		airspace: NewLocalStoreAirspaceProvider(durableStore),
+		now:      now,
+	}
+	if len(airspace) > 0 && airspace[0] != nil {
+		service.airspace = airspace[0]
+	}
+	return service
 }
 
 func (s *DeconflictionService) CheckIntent(ctx context.Context, intentID string) (domain.DeconflictionResult, error) {
@@ -60,18 +69,15 @@ func (s *DeconflictionService) CheckIntent(ctx context.Context, intentID string)
 		return result, nil
 	}
 
-	intents, err := s.durable.ListOperationalIntents(ctx, "")
+	candidates, err := s.airspace.QueryConflictCandidates(ctx, intent, volumes)
 	if err != nil {
-		return domain.DeconflictionResult{}, fmt.Errorf("list operational intents: %w", err)
+		return domain.DeconflictionResult{}, fmt.Errorf("query conflict candidates: %w", err)
 	}
-	allVolumes, err := s.durable.ListOperationalVolumes(ctx, "")
-	if err != nil {
-		return domain.DeconflictionResult{}, fmt.Errorf("list candidate operational volumes: %w", err)
-	}
-	volumesByIntent := make(map[string][]domain.OperationalVolume)
-	for _, volume := range allVolumes {
-		volumesByIntent[volume.IntentID] = append(volumesByIntent[volume.IntentID], volume)
-	}
+
+	// Validate and parse each unique peer volume once before the cross-product
+	// loop. GeoJSON parsing is the expensive step; doing it here avoids repeated
+	// map lookups and string-key allocation in the hot path.
+	peerEvaluations := preparePeerEvaluations(candidates)
 
 	for _, volume := range volumes {
 		ownBounds, finding, ok := s.evaluableVolume(intent, volume, checkedAt)
@@ -81,14 +87,12 @@ func (s *DeconflictionService) CheckIntent(ctx context.Context, intentID string)
 			continue
 		}
 
-		for _, candidate := range intents {
-			if candidate.ID == intent.ID || !candidateConflictEligible(candidate.Status) {
-				continue
-			}
-			for _, candidateVolume := range volumesForVersion(volumesByIntent[candidate.ID], candidate.Version) {
-				peerBounds, peerFinding, ok := s.evaluableVolumeForPeer(intent, volume.ID, candidate, candidateVolume, checkedAt)
-				if !ok {
-					if peerFinding.Status == domain.ConflictFindingStatusIndeterminate && !peerVolumeDimensionsUsable(candidateVolume) {
+		for _, candidate := range candidates {
+			for _, candidateVolume := range candidate.Volumes {
+				peer := peerEvaluations[peerVolumeKeyFrom(candidateVolume)]
+				if !peer.ok {
+					peerFinding := s.finding(intent, peer.status, volume.ID, candidate.Intent.ID, candidate.Intent.Version, candidateVolume.ID, peer.message, checkedAt)
+					if peerFinding.Status == domain.ConflictFindingStatusIndeterminate && !peer.dimensionsUsable {
 						result.Findings = append(result.Findings, peerFinding)
 						result.Posture = maxPosture(result.Posture, peerFinding.Status)
 						continue
@@ -101,11 +105,11 @@ func (s *DeconflictionService) CheckIntent(ctx context.Context, intentID string)
 					continue
 				}
 				if !timeWindowsOverlap(volume.StartsAt, volume.EndsAt, candidateVolume.StartsAt, candidateVolume.EndsAt) ||
-					!ownBounds.overlaps(peerBounds) {
+					!ownBounds.overlaps(peer.bounds) {
 					continue
 				}
 				if volume.AltitudeRef != candidateVolume.AltitudeRef {
-					finding := s.finding(intent, domain.ConflictFindingStatusIndeterminate, volume.ID, candidate.ID, candidate.Version, candidateVolume.ID, "operational volume altitude references differ and cannot be compared locally", checkedAt)
+					finding := s.finding(intent, domain.ConflictFindingStatusIndeterminate, volume.ID, candidate.Intent.ID, candidate.Intent.Version, candidateVolume.ID, "operational volume altitude references differ and cannot be compared locally", checkedAt)
 					result.Findings = append(result.Findings, finding)
 					result.Posture = maxPosture(result.Posture, finding.Status)
 					continue
@@ -116,13 +120,13 @@ func (s *DeconflictionService) CheckIntent(ctx context.Context, intentID string)
 
 				start, end := timeOverlap(volume.StartsAt, volume.EndsAt, candidateVolume.StartsAt, candidateVolume.EndsAt)
 				minAlt, maxAlt := altitudeOverlap(volume.MinAltitudeM, volume.MaxAltitudeM, candidateVolume.MinAltitudeM, candidateVolume.MaxAltitudeM)
-				finding := s.finding(intent, domain.ConflictFindingStatusPotentialConflict, volume.ID, candidate.ID, candidate.Version, candidateVolume.ID, "local 4D operational volume bounding boxes overlap; exact polygon intersection is not evaluated in v1", checkedAt)
+				finding := s.finding(intent, domain.ConflictFindingStatusPotentialConflict, volume.ID, candidate.Intent.ID, candidate.Intent.Version, candidateVolume.ID, "local 4D operational volume bounding boxes overlap; exact polygon intersection is not evaluated in v1", checkedAt)
 				finding.TimeOverlapStart = &start
 				finding.TimeOverlapEnd = &end
 				finding.AltitudeOverlapMin = &minAlt
 				finding.AltitudeOverlapMax = &maxAlt
 				finding.OwnBounds = ownBounds.domainBounds()
-				finding.ConflictingBounds = peerBounds.domainBounds()
+				finding.ConflictingBounds = peer.bounds.domainBounds()
 				result.Findings = append(result.Findings, finding)
 				result.Posture = maxPosture(result.Posture, finding.Status)
 			}
@@ -168,18 +172,71 @@ func (s *DeconflictionService) evaluableVolume(intent domain.OperationalIntent, 
 	return bounds, domain.ConflictFinding{}, true
 }
 
-func (s *DeconflictionService) evaluableVolumeForPeer(target domain.OperationalIntent, volumeID string, peer domain.OperationalIntent, peerVolume domain.OperationalVolume, checkedAt time.Time) (geoBounds, domain.ConflictFinding, bool) {
-	status, message := validateVolume(peerVolume)
-	if status != domain.ConflictFindingStatusClear {
-		finding := s.finding(target, status, volumeID, peer.ID, peer.Version, peerVolume.ID, message, checkedAt)
-		return geoBounds{}, finding, false
+// peerVolumeKey identifies a peer operational volume without string allocation.
+type peerVolumeKey struct {
+	intentID string
+	version  int
+	volumeID string
+}
+
+func peerVolumeKeyFrom(volume domain.OperationalVolume) peerVolumeKey {
+	return peerVolumeKey{
+		intentID: volume.IntentID,
+		version:  volume.IntentVersion,
+		volumeID: volume.ID,
 	}
-	bounds, err := geoJSONBounds(peerVolume.GeoJSON)
+}
+
+// peerVolumeEvaluation is the outcome of validating and parsing a peer
+// operational volume. When ok is false, status and message describe the
+// finding the failure should produce.
+type peerVolumeEvaluation struct {
+	bounds           geoBounds
+	status           domain.ConflictFindingStatus
+	message          string
+	ok               bool
+	dimensionsUsable bool
+}
+
+func preparePeerEvaluations(candidates []domain.OperationalIntentConflictCandidate) map[peerVolumeKey]peerVolumeEvaluation {
+	evaluations := make(map[peerVolumeKey]peerVolumeEvaluation)
+	for _, candidate := range candidates {
+		for _, volume := range candidate.Volumes {
+			key := peerVolumeKeyFrom(volume)
+			if _, seen := evaluations[key]; seen {
+				continue
+			}
+			evaluations[key] = evaluatePeerVolume(volume)
+		}
+	}
+	return evaluations
+}
+
+func evaluatePeerVolume(volume domain.OperationalVolume) peerVolumeEvaluation {
+	issue := classifyVolumeDimensions(volume)
+	if issue != volumeDimensionsOK {
+		return peerVolumeEvaluation{
+			status:           domain.ConflictFindingStatusIndeterminate,
+			message:          volumeDimensionMessage(issue),
+			dimensionsUsable: false,
+		}
+	}
+	if status, message := validateVolumeGeometry(volume); status != domain.ConflictFindingStatusClear {
+		return peerVolumeEvaluation{
+			status:           status,
+			message:          message,
+			dimensionsUsable: true,
+		}
+	}
+	bounds, err := geoJSONBounds(volume.GeoJSON)
 	if err != nil {
-		finding := s.finding(target, domain.ConflictFindingStatusIndeterminate, volumeID, peer.ID, peer.Version, peerVolume.ID, err.Error(), checkedAt)
-		return geoBounds{}, finding, false
+		return peerVolumeEvaluation{
+			status:           domain.ConflictFindingStatusIndeterminate,
+			message:          err.Error(),
+			dimensionsUsable: true,
+		}
 	}
-	return bounds, domain.ConflictFinding{}, true
+	return peerVolumeEvaluation{bounds: bounds, ok: true, dimensionsUsable: true}
 }
 
 func (s *DeconflictionService) finding(intent domain.OperationalIntent, status domain.ConflictFindingStatus, volumeID, conflictingIntentID string, conflictingVersion int, conflictingVolumeID, message string, checkedAt time.Time) domain.ConflictFinding {
@@ -206,50 +263,70 @@ func (s *DeconflictionService) finding(intent domain.OperationalIntent, status d
 	}
 }
 
-func validateVolume(volume domain.OperationalVolume) (domain.ConflictFindingStatus, string) {
+type volumeDimensionIssue int
+
+const (
+	volumeDimensionsOK volumeDimensionIssue = iota
+	volumeDimensionInvalidTimeWindow
+	volumeDimensionMissingOrInvalidAltitudeBand
+	volumeDimensionInvalidAltitudeBand
+	volumeDimensionMissingAltitudeRef
+)
+
+func classifyVolumeDimensions(volume domain.OperationalVolume) volumeDimensionIssue {
 	if volume.StartsAt.IsZero() || volume.EndsAt.IsZero() || !volume.StartsAt.Before(volume.EndsAt) {
-		return domain.ConflictFindingStatusIndeterminate, "operational volume has an invalid time window"
+		return volumeDimensionInvalidTimeWindow
 	}
 	if volume.MinAltitudeM < 0 || volume.MaxAltitudeM <= 0 {
-		return domain.ConflictFindingStatusIndeterminate, "operational volume has a missing or invalid altitude band"
+		return volumeDimensionMissingOrInvalidAltitudeBand
 	}
 	if volume.MinAltitudeM > volume.MaxAltitudeM {
-		return domain.ConflictFindingStatusIndeterminate, "operational volume has an invalid altitude band"
+		return volumeDimensionInvalidAltitudeBand
 	}
 	if volume.AltitudeRef == "" {
-		return domain.ConflictFindingStatusIndeterminate, "operational volume has no altitude reference"
+		return volumeDimensionMissingAltitudeRef
 	}
-	if strings.TrimSpace(volume.GeoJSON) == "" {
-		if strings.TrimSpace(volume.GeometryURI) != "" {
-			return domain.ConflictFindingStatusPotentialConflict, "operational volume references external geometry that is not resolved locally"
-		}
-		return domain.ConflictFindingStatusIndeterminate, "operational volume has no inline GeoJSON geometry"
+	return volumeDimensionsOK
+}
+
+func volumeDimensionMessage(issue volumeDimensionIssue) string {
+	switch issue {
+	case volumeDimensionInvalidTimeWindow:
+		return "operational volume has an invalid time window"
+	case volumeDimensionMissingOrInvalidAltitudeBand:
+		return "operational volume has a missing or invalid altitude band"
+	case volumeDimensionInvalidAltitudeBand:
+		return "operational volume has an invalid altitude band"
+	case volumeDimensionMissingAltitudeRef:
+		return "operational volume has no altitude reference"
+	default:
+		return ""
 	}
-	return domain.ConflictFindingStatusClear, ""
+}
+
+func volumeDimensionsUsable(volume domain.OperationalVolume) bool {
+	return classifyVolumeDimensions(volume) == volumeDimensionsOK
+}
+
+func validateVolume(volume domain.OperationalVolume) (domain.ConflictFindingStatus, string) {
+	if issue := classifyVolumeDimensions(volume); issue != volumeDimensionsOK {
+		return domain.ConflictFindingStatusIndeterminate, volumeDimensionMessage(issue)
+	}
+	return validateVolumeGeometry(volume)
+}
+
+func validateVolumeGeometry(volume domain.OperationalVolume) (domain.ConflictFindingStatus, string) {
+	if strings.TrimSpace(volume.GeoJSON) != "" {
+		return domain.ConflictFindingStatusClear, ""
+	}
+	if strings.TrimSpace(volume.GeometryURI) != "" {
+		return domain.ConflictFindingStatusPotentialConflict, "operational volume references external geometry that is not resolved locally"
+	}
+	return domain.ConflictFindingStatusIndeterminate, "operational volume has no inline GeoJSON geometry"
 }
 
 func peerVolumeDimensionsUsable(volume domain.OperationalVolume) bool {
-	return !volume.StartsAt.IsZero() &&
-		!volume.EndsAt.IsZero() &&
-		volume.StartsAt.Before(volume.EndsAt) &&
-		volume.MinAltitudeM >= 0 &&
-		volume.MaxAltitudeM > 0 &&
-		volume.MinAltitudeM <= volume.MaxAltitudeM &&
-		volume.AltitudeRef != ""
-}
-
-func candidateConflictEligible(status domain.IntentStatus) bool {
-	return status == domain.IntentStatusAccepted || status == domain.IntentStatusActive
-}
-
-func volumesForVersion(volumes []domain.OperationalVolume, version int) []domain.OperationalVolume {
-	filtered := make([]domain.OperationalVolume, 0, len(volumes))
-	for _, volume := range volumes {
-		if volume.IntentVersion == version {
-			filtered = append(filtered, volume)
-		}
-	}
-	return filtered
+	return volumeDimensionsUsable(volume)
 }
 
 func conflictSeverity(status domain.ConflictFindingStatus) domain.Severity {

--- a/internal/service/version_helpers.go
+++ b/internal/service/version_helpers.go
@@ -28,6 +28,16 @@ func complianceFindingsForVersion(findings []domain.ComplianceFinding, version i
 	return filtered
 }
 
+func volumesForVersion(volumes []domain.OperationalVolume, version int) []domain.OperationalVolume {
+	filtered := make([]domain.OperationalVolume, 0, len(volumes))
+	for _, volume := range volumes {
+		if volume.IntentVersion == version {
+			filtered = append(filtered, volume)
+		}
+	}
+	return filtered
+}
+
 func conformanceSummaryForVersion(ctx context.Context, store durable.Store, intent domain.OperationalIntent) (*domain.ConformanceSummary, error) {
 	summaries, err := store.ListConformanceSummaries(ctx, intent.ID)
 	if err != nil {


### PR DESCRIPTION
## Summary
- introduce an AirspaceAwarenessProvider seam for broad-phase conflict candidate discovery
- add a local durable-store provider with lifecycle, version, time, and altitude prefilters
- keep DeconflictionService focused on narrow-phase evaluation and cache peer volume parsing per check

Closes #10

## Tests
- go test ./internal/service
- go test ./...