### PR TITLE
Add contribution and CI controls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - run: go test ./...
+      - run: go vet ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -15,6 +16,30 @@ concurrency:
 
 jobs:
   test:
+    name: Unit Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+          persist-credentials: false
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - run: mkdir -p coverage
+      - run: go test -coverprofile=coverage/coverage.out -covermode=atomic ./...
+      - run: go vet ./...
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          fail_ci_if_error: true
+          files: ./coverage/coverage.out
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+  lint:
+    name: Lint
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -24,5 +49,7 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
-      - run: go test ./...
-      - run: go vet ./...
+      - uses: golangci/golangci-lint-action@v9
+        with:
+          only-new-issues: true
+          version: v2.12

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,37 @@
+# Contributing to Aero Arc API
+
+Thank you for contributing to Aero Arc. Keep pull requests focused, add tests
+for behavior changes, and discuss substantial architectural changes in an issue
+before implementation.
+
+## Development
+
+Create a branch from `main`, then run the project checks before opening a pull
+request:
+
+```sh
+go test ./...
+go vet ./...
+```
+
+External pull request workflows require maintainer approval before they run.
+Do not include secrets or credentials in code, tests, logs, or workflow files.
+
+## Developer Certificate of Origin
+
+Every commit must include a `Signed-off-by` trailer certifying the
+[Developer Certificate of Origin](https://developercertificate.org/).
+
+Create signed-off commits with:
+
+```sh
+git commit -s
+```
+
+The name and email in the trailer must identify the contributor. Pull requests
+cannot merge until every commit passes the repository's DCO check.
+
+## Pull Requests
+
+Explain what changed, why it changed, and how it was tested. Address review
+feedback constructively and ensure all required checks pass before merge.


### PR DESCRIPTION
## Summary

This gives Aero Arc API a documented contribution contract and a standard pull-request validation path. Contributors are asked to keep changes focused, add behavioral tests, protect credentials, and sign every commit under the Developer Certificate of Origin.

The CI workflow exposes `Unit Test` and `Lint` checks. Unit tests generate an atomic Go coverage profile, run vet, and upload coverage through Codecov. golangci-lint v2.12 runs only for pull requests and blocks newly introduced findings without allowing an existing lint baseline to affect default-branch CI.

The workflow uses read-only permissions, disabled checkout credentials, and concurrency cancellation. External pull-request execution remains controlled by GitHub's maintainer-approval setting.

## Validation

- `go test -coverprofile=coverage/coverage.out -covermode=atomic ./...`
- `go vet ./...`
- `git diff --check`