### PR TITLE
Document Go packages

### DIFF
--- a/cmd/aero-arc-api/doc.go
+++ b/cmd/aero-arc-api/doc.go
@@ -1,0 +1,2 @@
+// Package main provides the command-line entry point for the Aero Arc API.
+package main

--- a/internal/airspaceprovider/doc.go
+++ b/internal/airspaceprovider/doc.go
@@ -1,0 +1,2 @@
+// Package airspaceprovider defines normalized airspace-query records and provider interfaces.
+package airspaceprovider

--- a/internal/airspaceprovider/interuss/doc.go
+++ b/internal/airspaceprovider/interuss/doc.go
@@ -1,0 +1,2 @@
+// Package interussprovider queries operational intents through an InterUSS DSS and managing USS peers.
+package interussprovider

--- a/internal/airspaceprovider/local/doc.go
+++ b/internal/airspaceprovider/local/doc.go
@@ -1,0 +1,2 @@
+// Package localprovider queries operational intents from Aero Arc's authoritative durable store.
+package localprovider

--- a/internal/config/doc.go
+++ b/internal/config/doc.go
@@ -1,0 +1,2 @@
+// Package config loads and validates runtime configuration for the Aero Arc API.
+package config

--- a/internal/domain/doc.go
+++ b/internal/domain/doc.go
@@ -1,0 +1,2 @@
+// Package domain defines the core operational, fleet, compliance, and telemetry models.
+package domain

--- a/internal/httpapi/doc.go
+++ b/internal/httpapi/doc.go
@@ -1,0 +1,2 @@
+// Package httpapi exposes Aero Arc application services over HTTP.
+package httpapi

--- a/internal/readmodel/doc.go
+++ b/internal/readmodel/doc.go
@@ -1,0 +1,2 @@
+// Package readmodel assembles query-focused projections for maps and dashboards.
+package readmodel

--- a/internal/registry/doc.go
+++ b/internal/registry/doc.go
@@ -1,0 +1,2 @@
+// Package registry provides service registration and discovery for Aero Arc components.
+package registry

--- a/internal/relaycontrol/doc.go
+++ b/internal/relaycontrol/doc.go
@@ -1,0 +1,2 @@
+// Package relaycontrol manages connections and control commands for Aero Arc relays.
+package relaycontrol

--- a/internal/seed/doc.go
+++ b/internal/seed/doc.go
@@ -1,0 +1,2 @@
+// Package seed populates stores with development and demonstration data.
+package seed

--- a/internal/service/deconfliction/doc.go
+++ b/internal/service/deconfliction/doc.go
@@ -1,0 +1,2 @@
+// Package deconfliction evaluates operational intents for conflicts across airspace providers.
+package deconfliction

--- a/internal/service/doc.go
+++ b/internal/service/doc.go
@@ -1,0 +1,2 @@
+// Package service implements Aero Arc application workflows and business operations.
+package service

--- a/internal/store/durable/memory/doc.go
+++ b/internal/store/durable/memory/doc.go
@@ -1,0 +1,2 @@
+// Package memory provides an in-process implementation of the durable store for development and tests.
+package memory

--- a/internal/store/durable/postgres/doc.go
+++ b/internal/store/durable/postgres/doc.go
@@ -1,0 +1,2 @@
+// Package postgres persists operational intent and deconfliction data in PostgreSQL and PostGIS.
+package postgres

--- a/internal/store/replay/memory/doc.go
+++ b/internal/store/replay/memory/doc.go
@@ -1,0 +1,2 @@
+// Package memory provides an in-process implementation of the replay store.
+package memory

--- a/internal/store/telemetry/influxdb/doc.go
+++ b/internal/store/telemetry/influxdb/doc.go
@@ -1,0 +1,2 @@
+// Package influxdb persists and queries telemetry samples in InfluxDB 3.
+package influxdb

--- a/internal/store/telemetry/memory/doc.go
+++ b/internal/store/telemetry/memory/doc.go
@@ -1,0 +1,2 @@
+// Package memory provides an in-process implementation of the telemetry store.
+package memory

--- a/internal/version/doc.go
+++ b/internal/version/doc.go
@@ -1,0 +1,2 @@
+// Package version reports build and release version information for the API.
+package version


### PR DESCRIPTION
## What changed

- add idiomatic `doc.go` files for every previously undocumented tracked Go package
- describe each package's responsibility immediately above its package declaration
- leave the existing documented store boundary packages unchanged

## Why

Package documentation makes generated Go documentation clearer and satisfies documentation-oriented linters such as `golint` and `revive` when package-comment checks are enabled.

## Impact

This is documentation-only and does not change runtime behavior or public API contracts.

## Validation

- `go test ./...`
- `go vet ./...`
- `git diff --check`
