### PR TITLE
Document exported Go APIs and service boundaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,3 +52,16 @@ and keep DSS integration tests explicitly configured against an external DSS.
 Before handing off changes, run `gofmt`, `go test ./...`,
 `go test -tags=integration ./...`, `go vet ./...`, and `staticcheck ./...` when
 the tool is installed.
+
+## Go documentation
+
+- Every exported handwritten Go function or method must have a lint-valid Go
+  doc comment beginning with its exact identifier.
+- Write for editor hover help: describe observable behavior, parameter meaning,
+  return values, and important validation, persistence, concurrency, or
+  dependency errors. Do not merely translate the signature into prose.
+- Use `Parameters:` and `Returns:` sections for service workflows, store
+  operations, RPC adapters, and other non-trivial APIs. Concise identifier-led
+  comments remain appropriate for simple accessors.
+- Generated protobuf and OpenAPI code retains generator-owned documentation and
+  must not be edited to satisfy this convention.

--- a/internal/airspaceprovider/interuss/details.go
+++ b/internal/airspaceprovider/interuss/details.go
@@ -9,6 +9,16 @@ import (
 	"github.com/Aero-Arc/aero-arc-api/internal/domain"
 )
 
+// PublishedOperationalIntent builds a DSS details payload from a stored
+// reference and its authorized operational volumes.
+//
+// Parameters:
+//   - referenceJSON: is the []byte value supplied to PublishedOperationalIntent.
+//   - volumes: is the []domain.OperationalVolume value supplied to PublishedOperationalIntent.
+//
+// Returns:
+//   - result: is the scdv1.OperationalIntent value produced by PublishedOperationalIntent.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func PublishedOperationalIntent(referenceJSON []byte, volumes []domain.OperationalVolume) (scdv1.OperationalIntent, error) {
 	var reference scdv1.OperationalIntentReference
 	if len(referenceJSON) == 0 {

--- a/internal/airspaceprovider/interuss/provider.go
+++ b/internal/airspaceprovider/interuss/provider.go
@@ -169,10 +169,23 @@ func newPeerHTTPClient(timeout time.Duration, allowInsecurePeerURLs bool) *http.
 	}
 }
 
+// ID returns the stable identifier for the InterUSS airspace provider.
+//
+// Returns:
+//   - result: is the string value produced by ID.
 func (p *Provider) ID() string {
 	return providerID
 }
 
+// FindOperationalIntents finds Provider records matching the supplied criteria.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - query: is the airspaceprovider.Query value supplied to FindOperationalIntents.
+//
+// Returns:
+//   - result: is the []airspaceprovider.OperationalIntent value produced by FindOperationalIntents.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (p *Provider) FindOperationalIntents(ctx context.Context, query airspaceprovider.Query) ([]airspaceprovider.OperationalIntent, error) {
 	if p.reader == nil {
 		return nil, fmt.Errorf("InterUSS client is not configured")
@@ -236,6 +249,15 @@ type scdClient struct {
 	allowInsecurePeerURLs bool
 }
 
+// QueryOperationalIntentReferences queries scdClient with the supplied statement and parameters.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - area: is the scdv1.Volume4D value supplied to QueryOperationalIntentReferences.
+//
+// Returns:
+//   - result: is the []scdv1.OperationalIntentReference value produced by QueryOperationalIntentReferences.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (c *scdClient) QueryOperationalIntentReferences(ctx context.Context, area scdv1.Volume4D) ([]scdv1.OperationalIntentReference, error) {
 	response, err := c.dssClient.SCDv1.QueryOperationalIntentReferencesWithResponse(
 		ctx,
@@ -257,6 +279,15 @@ func (c *scdClient) QueryOperationalIntentReferences(ctx context.Context, area s
 	return response.JSON200.OperationalIntentReferences, nil
 }
 
+// GetOperationalIntent fetches one DSS operational-intent detail record by reference.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - reference: is the scdv1.OperationalIntentReference value supplied to GetOperationalIntent.
+//
+// Returns:
+//   - result: is the *scdv1.OperationalIntent value produced by GetOperationalIntent.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (c *scdClient) GetOperationalIntent(ctx context.Context, reference scdv1.OperationalIntentReference) (*scdv1.OperationalIntent, error) {
 	baseURL, err := reference.UssBaseUrl.AsUssBaseURL()
 	if err != nil {

--- a/internal/airspaceprovider/interuss/publisher.go
+++ b/internal/airspaceprovider/interuss/publisher.go
@@ -32,15 +32,17 @@ func (p *Provider) ValidateOperationalIntent(request airspaceprovider.Publicatio
 	return err
 }
 
-// CreateOperationalIntent creates and stores the supplied Provider record.
+// CreateOperationalIntent validates the publication request, creates its
+// operational-intent reference in the external DSS, and returns the DSS receipt.
 //
 // Parameters:
 //   - ctx: controls cancellation and deadlines for the operation.
-//   - request: contains the validated request payload.
+//   - request: contains the intent, volumes, and USS publication metadata.
 //
 // Returns:
-//   - result: is the airspaceprovider.PublicationReceipt value produced by CreateOperationalIntent.
-//   - error: reports validation, dependency, cancellation, or persistence failures.
+//   - receipt: identifies the DSS-managed reference and its current version.
+//   - error: reports disabled publication, invalid UUID/volume data, transport
+//     failure, or a non-success DSS response.
 func (p *Provider) CreateOperationalIntent(ctx context.Context, request airspaceprovider.PublicationRequest) (airspaceprovider.PublicationReceipt, error) {
 	if p.dssClient == nil || p.ussBaseURL == "" {
 		return airspaceprovider.PublicationReceipt{}, fmt.Errorf("InterUSS publication is not configured")

--- a/internal/airspaceprovider/interuss/publisher.go
+++ b/internal/airspaceprovider/interuss/publisher.go
@@ -14,13 +14,33 @@ import (
 	"github.com/Aero-Arc/aero-arc-api/internal/domain"
 )
 
+// PublicationEnabled reports whether the InterUSS provider is configured for DSS mutation.
+//
+// Returns:
+//   - bool: reports whether the requested condition was satisfied.
 func (p *Provider) PublicationEnabled() bool { return p.dssClient != nil && p.ussBaseURL != "" }
 
+// ValidateOperationalIntent validates Provider for required fields, supported values, and safety constraints.
+//
+// Parameters:
+//   - request: contains the validated request payload.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (p *Provider) ValidateOperationalIntent(request airspaceprovider.PublicationRequest) error {
 	_, err := p.publicationParameters(request)
 	return err
 }
 
+// CreateOperationalIntent creates and stores the supplied Provider record.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - request: contains the validated request payload.
+//
+// Returns:
+//   - result: is the airspaceprovider.PublicationReceipt value produced by CreateOperationalIntent.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (p *Provider) CreateOperationalIntent(ctx context.Context, request airspaceprovider.PublicationRequest) (airspaceprovider.PublicationReceipt, error) {
 	if p.dssClient == nil || p.ussBaseURL == "" {
 		return airspaceprovider.PublicationReceipt{}, fmt.Errorf("InterUSS publication is not configured")
@@ -43,6 +63,15 @@ func (p *Provider) CreateOperationalIntent(ctx context.Context, request airspace
 	return publicationReceipt(*response.JSON201)
 }
 
+// UpdateOperationalIntent updates the selected Provider state while enforcing its consistency checks.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - request: contains the validated request payload.
+//
+// Returns:
+//   - result: is the airspaceprovider.PublicationReceipt value produced by UpdateOperationalIntent.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (p *Provider) UpdateOperationalIntent(ctx context.Context, request airspaceprovider.PublicationRequest) (airspaceprovider.PublicationReceipt, error) {
 	if p.dssClient == nil || p.ussBaseURL == "" {
 		return airspaceprovider.PublicationReceipt{}, fmt.Errorf("InterUSS publication is not configured")
@@ -66,6 +95,16 @@ func (p *Provider) UpdateOperationalIntent(ctx context.Context, request airspace
 	return publicationReceipt(*response.JSON200)
 }
 
+// DeleteOperationalIntent deletes the selected Provider records.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - intentID: identifies the target intent.
+//   - ovn: is the string value supplied to DeleteOperationalIntent.
+//
+// Returns:
+//   - result: is the airspaceprovider.PublicationReceipt value produced by DeleteOperationalIntent.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (p *Provider) DeleteOperationalIntent(ctx context.Context, intentID, ovn string) (airspaceprovider.PublicationReceipt, error) {
 	if p.dssClient == nil {
 		return airspaceprovider.PublicationReceipt{}, fmt.Errorf("InterUSS publication is not configured")
@@ -84,6 +123,15 @@ func (p *Provider) DeleteOperationalIntent(ctx context.Context, intentID, ovn st
 	return publicationReceipt(*response.JSON200)
 }
 
+// GetOperationalIntentReference fetches the DSS reference for one operational intent.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - intentID: identifies the target intent.
+//
+// Returns:
+//   - result: is the airspaceprovider.PublicationReceipt value produced by GetOperationalIntentReference.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (p *Provider) GetOperationalIntentReference(ctx context.Context, intentID string) (airspaceprovider.PublicationReceipt, error) {
 	if p.dssClient == nil {
 		return airspaceprovider.PublicationReceipt{}, fmt.Errorf("InterUSS publication is not configured")
@@ -102,6 +150,15 @@ func (p *Provider) GetOperationalIntentReference(ctx context.Context, intentID s
 	return referenceReceipt(response.JSON200.OperationalIntentReference)
 }
 
+// FindSubscribers finds Provider records matching the supplied criteria.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - volumes: is the []domain.OperationalVolume value supplied to FindSubscribers.
+//
+// Returns:
+//   - result: is the []airspaceprovider.Subscriber value produced by FindSubscribers.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (p *Provider) FindSubscribers(ctx context.Context, volumes []domain.OperationalVolume) ([]airspaceprovider.Subscriber, error) {
 	if p.dssClient == nil {
 		return nil, fmt.Errorf("InterUSS publication is not configured")
@@ -289,6 +346,17 @@ func responseError(statusCode int, status string, body []byte) error {
 	return &dss.SCDResponseError{StatusCode: statusCode, Status: status, Body: body}
 }
 
+// BuildPeerNotification builds a Provider value from the supplied inputs.
+//
+// Parameters:
+//   - request: contains the validated request payload.
+//   - receipt: is the airspaceprovider.PublicationReceipt value supplied to BuildPeerNotification.
+//   - subscriber: is the airspaceprovider.Subscriber value supplied to BuildPeerNotification.
+//   - deleted: is the bool value supplied to BuildPeerNotification.
+//
+// Returns:
+//   - result: is the []byte value produced by BuildPeerNotification.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (p *Provider) BuildPeerNotification(request airspaceprovider.PublicationRequest, receipt airspaceprovider.PublicationReceipt, subscriber airspaceprovider.Subscriber, deleted bool) ([]byte, error) {
 	entityID, err := dss.SCDEntityID(request.Intent.ID)
 	if err != nil {
@@ -324,6 +392,15 @@ func (p *Provider) BuildPeerNotification(request airspaceprovider.PublicationReq
 	return json.Marshal(body)
 }
 
+// DeliverPeerNotification delivers due Provider work and records each delivery outcome.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - baseURL: is the string value supplied to DeliverPeerNotification.
+//   - payload: is the []byte value supplied to DeliverPeerNotification.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (p *Provider) DeliverPeerNotification(ctx context.Context, baseURL string, payload []byte) error {
 	if err := validatePeerURL(baseURL, p.allowInsecurePeerURLs); err != nil {
 		return err

--- a/internal/airspaceprovider/interuss/publisher.go
+++ b/internal/airspaceprovider/interuss/publisher.go
@@ -20,13 +20,14 @@ import (
 //   - bool: reports whether the requested condition was satisfied.
 func (p *Provider) PublicationEnabled() bool { return p.dssClient != nil && p.ussBaseURL != "" }
 
-// ValidateOperationalIntent validates Provider for required fields, supported values, and safety constraints.
+// ValidateOperationalIntent validates an InterUSS publication request by
+// constructing its DSS mutation parameters without sending a network request.
 //
 // Parameters:
-//   - request: contains the validated request payload.
+//   - request: contains the intent, volumes, and USS publication metadata to validate.
 //
 // Returns:
-//   - error: reports validation, dependency, cancellation, or persistence failures.
+//   - error: reports invalid identity, state, time/geometry, or publication metadata.
 func (p *Provider) ValidateOperationalIntent(request airspaceprovider.PublicationRequest) error {
 	_, err := p.publicationParameters(request)
 	return err
@@ -65,15 +66,17 @@ func (p *Provider) CreateOperationalIntent(ctx context.Context, request airspace
 	return publicationReceipt(*response.JSON201)
 }
 
-// UpdateOperationalIntent updates the selected Provider state while enforcing its consistency checks.
+// UpdateOperationalIntent validates the request and OVN, mutates its existing
+// operational-intent reference in the external DSS, and returns the DSS receipt.
 //
 // Parameters:
 //   - ctx: controls cancellation and deadlines for the operation.
-//   - request: contains the validated request payload.
+//   - request: contains intent, volumes, publication metadata, and the current OVN.
 //
 // Returns:
-//   - result: is the airspaceprovider.PublicationReceipt value produced by UpdateOperationalIntent.
-//   - error: reports validation, dependency, cancellation, or persistence failures.
+//   - receipt: identifies the updated DSS reference and its new version/OVN.
+//   - error: reports disabled publication, invalid request/OVN, transport failure,
+//     or a non-success DSS response.
 func (p *Provider) UpdateOperationalIntent(ctx context.Context, request airspaceprovider.PublicationRequest) (airspaceprovider.PublicationReceipt, error) {
 	if p.dssClient == nil || p.ussBaseURL == "" {
 		return airspaceprovider.PublicationReceipt{}, fmt.Errorf("InterUSS publication is not configured")
@@ -97,7 +100,8 @@ func (p *Provider) UpdateOperationalIntent(ctx context.Context, request airspace
 	return publicationReceipt(*response.JSON200)
 }
 
-// DeleteOperationalIntent deletes the selected Provider records.
+// DeleteOperationalIntent deletes an operational-intent reference from the
+// external DSS using its current OVN and returns the DSS receipt.
 //
 // Parameters:
 //   - ctx: controls cancellation and deadlines for the operation.
@@ -105,8 +109,9 @@ func (p *Provider) UpdateOperationalIntent(ctx context.Context, request airspace
 //   - ovn: is the string value supplied to DeleteOperationalIntent.
 //
 // Returns:
-//   - result: is the airspaceprovider.PublicationReceipt value produced by DeleteOperationalIntent.
-//   - error: reports validation, dependency, cancellation, or persistence failures.
+//   - receipt: describes the DSS deletion result.
+//   - error: reports disabled publication, invalid identity/OVN, transport
+//     failure, or a non-success DSS response.
 func (p *Provider) DeleteOperationalIntent(ctx context.Context, intentID, ovn string) (airspaceprovider.PublicationReceipt, error) {
 	if p.dssClient == nil {
 		return airspaceprovider.PublicationReceipt{}, fmt.Errorf("InterUSS publication is not configured")
@@ -348,17 +353,18 @@ func responseError(statusCode int, status string, body []byte) error {
 	return &dss.SCDResponseError{StatusCode: statusCode, Status: status, Body: body}
 }
 
-// BuildPeerNotification builds a Provider value from the supplied inputs.
+// BuildPeerNotification JSON-encodes the InterUSS peer-notification body with
+// subscriber states. Published intent details are omitted for deletion notices.
 //
 // Parameters:
-//   - request: contains the validated request payload.
-//   - receipt: is the airspaceprovider.PublicationReceipt value supplied to BuildPeerNotification.
-//   - subscriber: is the airspaceprovider.Subscriber value supplied to BuildPeerNotification.
-//   - deleted: is the bool value supplied to BuildPeerNotification.
+//   - request: supplies the intent ID and authorized volumes.
+//   - receipt: supplies the published DSS reference JSON.
+//   - subscriber: supplies subscription IDs and notification indexes.
+//   - deleted: omits operational-intent details when true.
 //
 // Returns:
-//   - result: is the []byte value produced by BuildPeerNotification.
-//   - error: reports validation, dependency, cancellation, or persistence failures.
+//   - payload: is a JSON PutOperationalIntentDetailsParameters body.
+//   - error: reports invalid IDs, malformed published details, or JSON encoding failure.
 func (p *Provider) BuildPeerNotification(request airspaceprovider.PublicationRequest, receipt airspaceprovider.PublicationReceipt, subscriber airspaceprovider.Subscriber, deleted bool) ([]byte, error) {
 	entityID, err := dss.SCDEntityID(request.Intent.ID)
 	if err != nil {
@@ -394,7 +400,9 @@ func (p *Provider) BuildPeerNotification(request airspaceprovider.PublicationReq
 	return json.Marshal(body)
 }
 
-// DeliverPeerNotification delivers due Provider work and records each delivery outcome.
+// DeliverPeerNotification validates a peer URL, decodes one queued payload, and
+// performs one InterUSS notification request. The caller owns retry scheduling
+// and durable outcome recording.
 //
 // Parameters:
 //   - ctx: controls cancellation and deadlines for the operation.
@@ -402,7 +410,8 @@ func (p *Provider) BuildPeerNotification(request airspaceprovider.PublicationReq
 //   - payload: is the []byte value supplied to DeliverPeerNotification.
 //
 // Returns:
-//   - error: reports validation, dependency, cancellation, or persistence failures.
+//   - error: reports an unsafe URL, invalid payload, client/transport failure, or
+//     a peer response other than HTTP 204.
 func (p *Provider) DeliverPeerNotification(ctx context.Context, baseURL string, payload []byte) error {
 	if err := validatePeerURL(baseURL, p.allowInsecurePeerURLs); err != nil {
 		return err

--- a/internal/airspaceprovider/local/provider.go
+++ b/internal/airspaceprovider/local/provider.go
@@ -17,14 +17,34 @@ type Provider struct {
 	store durable.OperationalStore
 }
 
+// New constructs local from the supplied configuration and dependencies.
+//
+// Parameters:
+//   - store: is the durable.OperationalStore value supplied to New.
+//
+// Returns:
+//   - result: is the *Provider value produced by New.
 func New(store durable.OperationalStore) *Provider {
 	return &Provider{store: store}
 }
 
+// ID returns the stable identifier for the local airspace provider.
+//
+// Returns:
+//   - result: is the string value produced by ID.
 func (p *Provider) ID() string {
 	return airspaceprovider.ProviderLocal
 }
 
+// FindOperationalIntents finds Provider records matching the supplied criteria.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - query: is the airspaceprovider.Query value supplied to FindOperationalIntents.
+//
+// Returns:
+//   - result: is the []airspaceprovider.OperationalIntent value produced by FindOperationalIntents.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (p *Provider) FindOperationalIntents(
 	ctx context.Context,
 	query airspaceprovider.Query,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -70,6 +70,10 @@ type Config struct {
 	Debug                    bool
 }
 
+// Defaults returns the API's baseline development configuration.
+//
+// Returns:
+//   - result: is the *Config value produced by Defaults.
 func Defaults() *Config {
 	return &Config{
 		Addr:                    defaultAddr,
@@ -92,6 +96,11 @@ func Defaults() *Config {
 	}
 }
 
+// Load resolves API configuration from environment variables and validates the result.
+//
+// Returns:
+//   - result: is the *Config value produced by Load.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func Load() (*Config, error) {
 	cfg := Defaults()
 
@@ -146,6 +155,10 @@ func Load() (*Config, error) {
 	return cfg, nil
 }
 
+// Validate validates Config for required fields, supported values, and safety constraints.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (cfg *Config) Validate() error {
 	if cfg.Addr == "" {
 		return fmt.Errorf("AERO_API_ADDR cannot be empty")

--- a/internal/domain/telemetry.go
+++ b/internal/domain/telemetry.go
@@ -54,6 +54,11 @@ type LiveAircraftState struct {
 	PlacementLastUpdatedAt time.Time        `json:"placement_last_updated_at,omitempty"`
 }
 
+// MarshalJSON encodes the telemetry value using its stable JSON representation.
+//
+// Returns:
+//   - result: is the []byte value produced by MarshalJSON.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s LiveAircraftState) MarshalJSON() ([]byte, error) {
 	type wireState struct {
 		AircraftID             string           `json:"aircraft_id"`

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -21,10 +21,30 @@ type Server struct {
 	ussAuthorizer  USSAuthorizer
 }
 
+// New constructs httpapi from the supplied configuration and dependencies.
+//
+// Parameters:
+//   - fleet: is the *service.FleetService value supplied to New.
+//   - requestTimeout: defines the time bound applied by the operation.
+//
+// Returns:
+//   - result: is the *Server value produced by New.
 func New(fleet *service.FleetService, requestTimeout time.Duration) *Server {
 	return &Server{fleet: fleet, requestTimeout: requestTimeout}
 }
 
+// NewWithWorkflows constructs httpapi from the supplied configuration and dependencies.
+//
+// Parameters:
+//   - fleet: is the *service.FleetService value supplied to NewWithWorkflows.
+//   - intents: is the *service.IntentService value supplied to NewWithWorkflows.
+//   - preflight: is the *service.PreflightService value supplied to NewWithWorkflows.
+//   - conformance: is the *service.ConformanceService value supplied to NewWithWorkflows.
+//   - requestTimeout: defines the time bound applied by the operation.
+//   - deconflictionServices: is the ...*deconfliction.DeconflictionService value supplied to NewWithWorkflows.
+//
+// Returns:
+//   - result: is the *Server value produced by NewWithWorkflows.
 func NewWithWorkflows(fleet *service.FleetService, intents *service.IntentService, preflight *service.PreflightService, conformance *service.ConformanceService, requestTimeout time.Duration, deconflictionServices ...*deconfliction.DeconflictionService) *Server {
 	server := &Server{
 		fleet:          fleet,
@@ -39,16 +59,34 @@ func NewWithWorkflows(fleet *service.FleetService, intents *service.IntentServic
 	return server
 }
 
+// WithDebug enables or disables debug-only HTTP behavior on the server.
+//
+// Parameters:
+//   - debug: is the bool value supplied to WithDebug.
+//
+// Returns:
+//   - result: is the *Server value produced by WithDebug.
 func (s *Server) WithDebug(debug bool) *Server {
 	s.debug = debug
 	return s
 }
 
+// WithUSSAuthorizer installs the authorization policy used by USS routes.
+//
+// Parameters:
+//   - authorizer: is the USSAuthorizer value supplied to WithUSSAuthorizer.
+//
+// Returns:
+//   - result: is the *Server value produced by WithUSSAuthorizer.
 func (s *Server) WithUSSAuthorizer(authorizer USSAuthorizer) *Server {
 	s.ussAuthorizer = authorizer
 	return s
 }
 
+// Handler returns the fully configured HTTP route handler.
+//
+// Returns:
+//   - result: is the http.Handler value produced by Handler.
 func (s *Server) Handler() http.Handler {
 	app := mach.New()
 	app.Use(mach.CORSWithConfig(mach.CORSConfig{
@@ -114,6 +152,10 @@ type statusRecorder struct {
 	status int
 }
 
+// WriteHeader records the first HTTP status code written by the wrapped response writer.
+//
+// Parameters:
+//   - status: is the int value supplied to WriteHeader.
 func (r *statusRecorder) WriteHeader(status int) {
 	r.status = status
 	r.ResponseWriter.WriteHeader(status)

--- a/internal/httpapi/uss_auth.go
+++ b/internal/httpapi/uss_auth.go
@@ -33,6 +33,16 @@ type ussClaims struct {
 	jwt.RegisteredClaims
 }
 
+// NewUSSJWTAuthorizer constructs httpapi from the supplied configuration and dependencies.
+//
+// Parameters:
+//   - publicKeyFile: is the string value supplied to NewUSSJWTAuthorizer.
+//   - issuer: is the string value supplied to NewUSSJWTAuthorizer.
+//   - audience: is the string value supplied to NewUSSJWTAuthorizer.
+//
+// Returns:
+//   - result: is the *USSJWTAuthorizer value produced by NewUSSJWTAuthorizer.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func NewUSSJWTAuthorizer(publicKeyFile, issuer, audience string) (*USSJWTAuthorizer, error) {
 	raw, err := os.ReadFile(publicKeyFile)
 	if err != nil {
@@ -59,6 +69,16 @@ func NewUSSJWTAuthorizer(publicKeyFile, issuer, audience string) (*USSJWTAuthori
 	return &USSJWTAuthorizer{publicKey: publicKey, issuer: issuer, audience: audience}, nil
 }
 
+// Authorize verifies the request's bearer JWT and required USS scope before
+// allowing a protected interoperability route to execute.
+//
+// Parameters:
+//   - request: contains the validated request payload.
+//   - requiredScope: is the string value supplied to Authorize.
+//
+// Returns:
+//   - result: is the string value produced by Authorize.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (a *USSJWTAuthorizer) Authorize(request *http.Request, requiredScope string) (string, error) {
 	header := strings.TrimSpace(request.Header.Get("Authorization"))
 	if !strings.HasPrefix(header, "Bearer ") || strings.TrimSpace(strings.TrimPrefix(header, "Bearer ")) == "" {

--- a/internal/registry/client.go
+++ b/internal/registry/client.go
@@ -8,7 +8,8 @@ import (
 	registryv1 "github.com/aero-arc/aero-arc-protos/gen/go/aeroarc/registry/v1"
 )
 
-// New constructs registry from the supplied configuration and dependencies.
+// New constructs the configured in-memory or gRPC Registry client and returns
+// the cleanup function that owns any underlying client connection.
 //
 // Parameters:
 //   - ctx: controls cancellation and deadlines for the operation.
@@ -17,9 +18,9 @@ import (
 //   - dialTimeout: defines the time bound applied by the operation.
 //
 // Returns:
-//   - result: is the registryv1.AeroRegistryClient value produced by New.
-//   - result: is the func() error value produced by New.
-//   - error: reports validation, dependency, cancellation, or persistence failures.
+//   - client: implements Registry liveness and placement reads for the API.
+//   - closeClient: closes the gRPC connection; memory mode returns a no-op closer.
+//   - error: reports an unsupported mode or gRPC client construction failure.
 func New(ctx context.Context, mode string, address string, dialTimeout time.Duration) (registryv1.AeroRegistryClient, func() error, error) {
 	switch mode {
 	case "memory":

--- a/internal/registry/client.go
+++ b/internal/registry/client.go
@@ -8,6 +8,18 @@ import (
 	registryv1 "github.com/aero-arc/aero-arc-protos/gen/go/aeroarc/registry/v1"
 )
 
+// New constructs registry from the supplied configuration and dependencies.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - mode: is the string value supplied to New.
+//   - address: locates the external dependency used by the operation.
+//   - dialTimeout: defines the time bound applied by the operation.
+//
+// Returns:
+//   - result: is the registryv1.AeroRegistryClient value produced by New.
+//   - result: is the func() error value produced by New.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func New(ctx context.Context, mode string, address string, dialTimeout time.Duration) (registryv1.AeroRegistryClient, func() error, error) {
 	switch mode {
 	case "memory":

--- a/internal/registry/grpc.go
+++ b/internal/registry/grpc.go
@@ -10,6 +10,17 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
+// NewGRPCClient constructs registry from the supplied configuration and dependencies.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - address: locates the external dependency used by the operation.
+//   - dialTimeout: defines the time bound applied by the operation.
+//
+// Returns:
+//   - result: is the registryv1.AeroRegistryClient value produced by NewGRPCClient.
+//   - result: is the func() error value produced by NewGRPCClient.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func NewGRPCClient(ctx context.Context, address string, dialTimeout time.Duration) (registryv1.AeroRegistryClient, func() error, error) {
 	dialCtx, cancel := context.WithTimeout(ctx, dialTimeout)
 	defer cancel()

--- a/internal/registry/memory.go
+++ b/internal/registry/memory.go
@@ -20,6 +20,10 @@ type MemoryClient struct {
 	placements map[string]*registryv1.AgentPlacement
 }
 
+// NewMemoryClient constructs registry from the supplied configuration and dependencies.
+//
+// Returns:
+//   - result: is the *MemoryClient value produced by NewMemoryClient.
 func NewMemoryClient() *MemoryClient {
 	return &MemoryClient{
 		relays:     make(map[string]*registryv1.Relay),
@@ -30,6 +34,14 @@ func NewMemoryClient() *MemoryClient {
 
 var _ registryv1.AeroRegistryClient = (*MemoryClient)(nil)
 
+// SetLiveAircraftState sets the selected MemoryClient state to the supplied value.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to SetLiveAircraftState.
+//   - state: is the domain.LiveAircraftState value supplied to SetLiveAircraftState.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (c *MemoryClient) SetLiveAircraftState(_ context.Context, state domain.LiveAircraftState) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -62,6 +74,16 @@ func (c *MemoryClient) SetLiveAircraftState(_ context.Context, state domain.Live
 	return nil
 }
 
+// RegisterRelay registers the supplied MemoryClient identity or handler.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to RegisterRelay.
+//   - req: contains the validated request payload.
+//   - value: is the ...grpc.CallOption value supplied to RegisterRelay.
+//
+// Returns:
+//   - result: is the *registryv1.RegisterRelayResponse value produced by RegisterRelay.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (c *MemoryClient) RegisterRelay(_ context.Context, req *registryv1.RegisterRelayRequest, _ ...grpc.CallOption) (*registryv1.RegisterRelayResponse, error) {
 	relay := req.GetRelay()
 	if relay == nil || relay.GetRelayId() == "" {
@@ -74,6 +96,16 @@ func (c *MemoryClient) RegisterRelay(_ context.Context, req *registryv1.Register
 	return &registryv1.RegisterRelayResponse{}, nil
 }
 
+// HeartbeatRelay renews liveness for the supplied MemoryClient identity without changing ownership.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to HeartbeatRelay.
+//   - req: contains the validated request payload.
+//   - value: is the ...grpc.CallOption value supplied to HeartbeatRelay.
+//
+// Returns:
+//   - result: is the *registryv1.HeartbeatRelayResponse value produced by HeartbeatRelay.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (c *MemoryClient) HeartbeatRelay(_ context.Context, req *registryv1.HeartbeatRelayRequest, _ ...grpc.CallOption) (*registryv1.HeartbeatRelayResponse, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -86,6 +118,16 @@ func (c *MemoryClient) HeartbeatRelay(_ context.Context, req *registryv1.Heartbe
 	return &registryv1.HeartbeatRelayResponse{}, nil
 }
 
+// ListRelays returns MemoryClient records matching the supplied scope and filters.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to ListRelays.
+//   - value: is the *registryv1.ListRelaysRequest value supplied to ListRelays.
+//   - value: is the ...grpc.CallOption value supplied to ListRelays.
+//
+// Returns:
+//   - result: is the *registryv1.ListRelaysResponse value produced by ListRelays.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (c *MemoryClient) ListRelays(context.Context, *registryv1.ListRelaysRequest, ...grpc.CallOption) (*registryv1.ListRelaysResponse, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
@@ -104,6 +146,16 @@ func (c *MemoryClient) ListRelays(context.Context, *registryv1.ListRelaysRequest
 	return &registryv1.ListRelaysResponse{Relays: relays}, nil
 }
 
+// RegisterAgent registers the supplied MemoryClient identity or handler.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to RegisterAgent.
+//   - req: contains the validated request payload.
+//   - value: is the ...grpc.CallOption value supplied to RegisterAgent.
+//
+// Returns:
+//   - result: is the *registryv1.RegisterAgentResponse value produced by RegisterAgent.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (c *MemoryClient) RegisterAgent(_ context.Context, req *registryv1.RegisterAgentRequest, _ ...grpc.CallOption) (*registryv1.RegisterAgentResponse, error) {
 	agent := req.GetAgent()
 	if agent == nil || agent.GetAgentId() == "" {
@@ -123,6 +175,16 @@ func (c *MemoryClient) RegisterAgent(_ context.Context, req *registryv1.Register
 	return &registryv1.RegisterAgentResponse{}, nil
 }
 
+// HeartbeatAgent renews liveness for the supplied MemoryClient identity without changing ownership.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to HeartbeatAgent.
+//   - req: contains the validated request payload.
+//   - value: is the ...grpc.CallOption value supplied to HeartbeatAgent.
+//
+// Returns:
+//   - result: is the *registryv1.HeartbeatAgentResponse value produced by HeartbeatAgent.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (c *MemoryClient) HeartbeatAgent(_ context.Context, req *registryv1.HeartbeatAgentRequest, _ ...grpc.CallOption) (*registryv1.HeartbeatAgentResponse, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -135,6 +197,16 @@ func (c *MemoryClient) HeartbeatAgent(_ context.Context, req *registryv1.Heartbe
 	return &registryv1.HeartbeatAgentResponse{}, nil
 }
 
+// ListAgents returns MemoryClient records matching the supplied scope and filters.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to ListAgents.
+//   - value: is the *registryv1.ListAgentsRequest value supplied to ListAgents.
+//   - value: is the ...grpc.CallOption value supplied to ListAgents.
+//
+// Returns:
+//   - result: is the *registryv1.ListAgentsResponse value produced by ListAgents.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (c *MemoryClient) ListAgents(context.Context, *registryv1.ListAgentsRequest, ...grpc.CallOption) (*registryv1.ListAgentsResponse, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
@@ -153,6 +225,16 @@ func (c *MemoryClient) ListAgents(context.Context, *registryv1.ListAgentsRequest
 	return &registryv1.ListAgentsResponse{Agents: agents}, nil
 }
 
+// GetAgentPlacement returns an Agent's current in-process Relay placement.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to GetAgentPlacement.
+//   - req: contains the validated request payload.
+//   - value: is the ...grpc.CallOption value supplied to GetAgentPlacement.
+//
+// Returns:
+//   - result: is the *registryv1.GetAgentPlacementResponse value produced by GetAgentPlacement.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (c *MemoryClient) GetAgentPlacement(_ context.Context, req *registryv1.GetAgentPlacementRequest, _ ...grpc.CallOption) (*registryv1.GetAgentPlacementResponse, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()

--- a/internal/registry/memory.go
+++ b/internal/registry/memory.go
@@ -20,10 +20,11 @@ type MemoryClient struct {
 	placements map[string]*registryv1.AgentPlacement
 }
 
-// NewMemoryClient constructs registry from the supplied configuration and dependencies.
+// NewMemoryClient constructs an empty, concurrency-safe Registry client for
+// development and service tests.
 //
 // Returns:
-//   - result: is the *MemoryClient value produced by NewMemoryClient.
+//   - client: stores cloned Relay, Agent, and placement records in process memory.
 func NewMemoryClient() *MemoryClient {
 	return &MemoryClient{
 		relays:     make(map[string]*registryv1.Relay),
@@ -37,7 +38,7 @@ var _ registryv1.AeroRegistryClient = (*MemoryClient)(nil)
 // SetLiveAircraftState sets the selected MemoryClient state to the supplied value.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to SetLiveAircraftState.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - state: is the domain.LiveAircraftState value supplied to SetLiveAircraftState.
 //
 // Returns:
@@ -74,16 +75,16 @@ func (c *MemoryClient) SetLiveAircraftState(_ context.Context, state domain.Live
 	return nil
 }
 
-// RegisterRelay registers the supplied MemoryClient identity or handler.
+// RegisterRelay validates and stores a cloned Relay record by identity.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to RegisterRelay.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - req: contains the validated request payload.
-//   - value: is the ...grpc.CallOption value supplied to RegisterRelay.
+//   - options: are accepted for gRPC client compatibility and are not used by the in-memory implementation.
 //
 // Returns:
 //   - result: is the *registryv1.RegisterRelayResponse value produced by RegisterRelay.
-//   - error: reports validation, dependency, cancellation, or persistence failures.
+//   - error: reports a missing Relay payload or identifier.
 func (c *MemoryClient) RegisterRelay(_ context.Context, req *registryv1.RegisterRelayRequest, _ ...grpc.CallOption) (*registryv1.RegisterRelayResponse, error) {
 	relay := req.GetRelay()
 	if relay == nil || relay.GetRelayId() == "" {
@@ -96,16 +97,16 @@ func (c *MemoryClient) RegisterRelay(_ context.Context, req *registryv1.Register
 	return &registryv1.RegisterRelayResponse{}, nil
 }
 
-// HeartbeatRelay renews liveness for the supplied MemoryClient identity without changing ownership.
+// HeartbeatRelay replaces the heartbeat timestamp of an existing in-memory Relay.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to HeartbeatRelay.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - req: contains the validated request payload.
-//   - value: is the ...grpc.CallOption value supplied to HeartbeatRelay.
+//   - options: are accepted for gRPC client compatibility and are not used by the in-memory implementation.
 //
 // Returns:
 //   - result: is the *registryv1.HeartbeatRelayResponse value produced by HeartbeatRelay.
-//   - error: reports validation, dependency, cancellation, or persistence failures.
+//   - error: reports an unknown Relay identifier.
 func (c *MemoryClient) HeartbeatRelay(_ context.Context, req *registryv1.HeartbeatRelayRequest, _ ...grpc.CallOption) (*registryv1.HeartbeatRelayResponse, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -118,16 +119,16 @@ func (c *MemoryClient) HeartbeatRelay(_ context.Context, req *registryv1.Heartbe
 	return &registryv1.HeartbeatRelayResponse{}, nil
 }
 
-// ListRelays returns MemoryClient records matching the supplied scope and filters.
+// ListRelays returns cloned in-memory Relay records in stable identifier order.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to ListRelays.
-//   - value: is the *registryv1.ListRelaysRequest value supplied to ListRelays.
-//   - value: is the ...grpc.CallOption value supplied to ListRelays.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
+//   - request: carries no filters in the current Registry contract.
+//   - options: are accepted for gRPC client compatibility and are not used by the in-memory implementation.
 //
 // Returns:
-//   - result: is the *registryv1.ListRelaysResponse value produced by ListRelays.
-//   - error: reports validation, dependency, cancellation, or persistence failures.
+//   - response: contains the sorted Relay snapshot.
+//   - error: is always nil.
 func (c *MemoryClient) ListRelays(context.Context, *registryv1.ListRelaysRequest, ...grpc.CallOption) (*registryv1.ListRelaysResponse, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
@@ -146,16 +147,17 @@ func (c *MemoryClient) ListRelays(context.Context, *registryv1.ListRelaysRequest
 	return &registryv1.ListRelaysResponse{Relays: relays}, nil
 }
 
-// RegisterAgent registers the supplied MemoryClient identity or handler.
+// RegisterAgent validates and stores a cloned Agent and, when supplied, its
+// Relay placement.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to RegisterAgent.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - req: contains the validated request payload.
-//   - value: is the ...grpc.CallOption value supplied to RegisterAgent.
+//   - options: are accepted for gRPC client compatibility and are not used by the in-memory implementation.
 //
 // Returns:
 //   - result: is the *registryv1.RegisterAgentResponse value produced by RegisterAgent.
-//   - error: reports validation, dependency, cancellation, or persistence failures.
+//   - error: reports a missing Agent payload or identifier.
 func (c *MemoryClient) RegisterAgent(_ context.Context, req *registryv1.RegisterAgentRequest, _ ...grpc.CallOption) (*registryv1.RegisterAgentResponse, error) {
 	agent := req.GetAgent()
 	if agent == nil || agent.GetAgentId() == "" {
@@ -175,16 +177,16 @@ func (c *MemoryClient) RegisterAgent(_ context.Context, req *registryv1.Register
 	return &registryv1.RegisterAgentResponse{}, nil
 }
 
-// HeartbeatAgent renews liveness for the supplied MemoryClient identity without changing ownership.
+// HeartbeatAgent replaces the heartbeat timestamp of an existing in-memory Agent.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to HeartbeatAgent.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - req: contains the validated request payload.
-//   - value: is the ...grpc.CallOption value supplied to HeartbeatAgent.
+//   - options: are accepted for gRPC client compatibility and are not used by the in-memory implementation.
 //
 // Returns:
 //   - result: is the *registryv1.HeartbeatAgentResponse value produced by HeartbeatAgent.
-//   - error: reports validation, dependency, cancellation, or persistence failures.
+//   - error: reports an unknown Agent identifier.
 func (c *MemoryClient) HeartbeatAgent(_ context.Context, req *registryv1.HeartbeatAgentRequest, _ ...grpc.CallOption) (*registryv1.HeartbeatAgentResponse, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -197,16 +199,16 @@ func (c *MemoryClient) HeartbeatAgent(_ context.Context, req *registryv1.Heartbe
 	return &registryv1.HeartbeatAgentResponse{}, nil
 }
 
-// ListAgents returns MemoryClient records matching the supplied scope and filters.
+// ListAgents returns cloned in-memory Agent records in stable identifier order.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to ListAgents.
-//   - value: is the *registryv1.ListAgentsRequest value supplied to ListAgents.
-//   - value: is the ...grpc.CallOption value supplied to ListAgents.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
+//   - request: carries no filters in the current Registry contract.
+//   - options: are accepted for gRPC client compatibility and are not used by the in-memory implementation.
 //
 // Returns:
-//   - result: is the *registryv1.ListAgentsResponse value produced by ListAgents.
-//   - error: reports validation, dependency, cancellation, or persistence failures.
+//   - response: contains the sorted Agent snapshot.
+//   - error: is always nil.
 func (c *MemoryClient) ListAgents(context.Context, *registryv1.ListAgentsRequest, ...grpc.CallOption) (*registryv1.ListAgentsResponse, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
@@ -228,13 +230,13 @@ func (c *MemoryClient) ListAgents(context.Context, *registryv1.ListAgentsRequest
 // GetAgentPlacement returns an Agent's current in-process Relay placement.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to GetAgentPlacement.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - req: contains the validated request payload.
-//   - value: is the ...grpc.CallOption value supplied to GetAgentPlacement.
+//   - options: are accepted for gRPC client compatibility and are not used by the in-memory implementation.
 //
 // Returns:
-//   - result: is the *registryv1.GetAgentPlacementResponse value produced by GetAgentPlacement.
-//   - error: reports validation, dependency, cancellation, or persistence failures.
+//   - response: contains a clone of the current placement.
+//   - error: reports an Agent without a stored placement.
 func (c *MemoryClient) GetAgentPlacement(_ context.Context, req *registryv1.GetAgentPlacementRequest, _ ...grpc.CallOption) (*registryv1.GetAgentPlacementResponse, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()

--- a/internal/relaycontrol/grpc_pool.go
+++ b/internal/relaycontrol/grpc_pool.go
@@ -29,6 +29,17 @@ func newGRPCPool(transportCredentials credentials.TransportCredentials) *grpcPoo
 	}
 }
 
+// Client returns a cached Relay-control client for the target address, dialing
+// and caching a new TLS connection when necessary.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - relayID: identifies the target relay.
+//   - address: locates the external dependency used by the operation.
+//
+// Returns:
+//   - result: is the relayv1.RelayControlClient value produced by Client.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (p *grpcPool) Client(ctx context.Context, relayID, address string) (relayv1.RelayControlClient, error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -47,6 +58,10 @@ func (p *grpcPool) Client(ctx context.Context, relayID, address string) (relayv1
 	return relayv1.NewRelayControlClient(conn), nil
 }
 
+// Invalidate invalidates the selected cached grpcPool resource so it is recreated on demand.
+//
+// Parameters:
+//   - relayID: identifies the target relay.
 func (p *grpcPool) Invalidate(relayID string) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -56,6 +71,10 @@ func (p *grpcPool) Invalidate(relayID string) {
 	}
 }
 
+// Close releases resources owned by grpcPool and completes any required shutdown work.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (p *grpcPool) Close() error {
 	p.mu.Lock()
 	defer p.mu.Unlock()

--- a/internal/relaycontrol/service.go
+++ b/internal/relaycontrol/service.go
@@ -45,6 +45,17 @@ type cachedPlacement struct {
 	expiresAt        time.Time
 }
 
+// New constructs relaycontrol from the supplied configuration and dependencies.
+//
+// Parameters:
+//   - registry: is the registryClient value supplied to New.
+//   - transportCredentials: provides authentication material for the dependency.
+//   - timeout: defines the time bound applied by the operation.
+//   - placementTTL: is the time.Duration value supplied to New.
+//
+// Returns:
+//   - result: is the *Service value produced by New.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func New(registry registryClient, transportCredentials credentials.TransportCredentials, timeout, placementTTL time.Duration) (*Service, error) {
 	if transportCredentials == nil {
 		return nil, fmt.Errorf("relay transport credentials are required")
@@ -62,8 +73,21 @@ func newWithPool(registry registryClient, pool clientPool, timeout, ttl time.Dur
 	return &Service{registry: registry, pool: pool, timeout: timeout, placementTTL: ttl, now: time.Now, placements: map[string]cachedPlacement{}}
 }
 
+// Close releases resources owned by Service and completes any required shutdown work.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Service) Close() error { return s.pool.Close() }
 
+// SetOperationContext sets the selected Service state to the supplied value.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - req: contains the validated request payload.
+//
+// Returns:
+//   - result: is the string value produced by SetOperationContext.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Service) SetOperationContext(ctx context.Context, req SetRequest) (string, error) {
 	if req.AgentID == "" || req.FlightID == "" {
 		return "", fmt.Errorf("agent_id and flight_id are required")
@@ -83,6 +107,15 @@ func (s *Service) SetOperationContext(ctx context.Context, req SetRequest) (stri
 	return commandID, err
 }
 
+// ClearOperationContext clears the selected Service state without changing unrelated records.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - req: contains the validated request payload.
+//
+// Returns:
+//   - result: is the string value produced by ClearOperationContext.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Service) ClearOperationContext(ctx context.Context, req ClearRequest) (string, error) {
 	if req.AgentID == "" || req.FlightID == "" {
 		return "", fmt.Errorf("agent_id and flight_id are required")

--- a/internal/service/conformance_service.go
+++ b/internal/service/conformance_service.go
@@ -27,10 +27,27 @@ type telemetryWriter interface {
 	AddSample(ctx context.Context, sample domain.TelemetrySample) error
 }
 
+// NewConformanceService constructs service from the supplied configuration and dependencies.
+//
+// Parameters:
+//   - durableStore: is the durable.Store value supplied to NewConformanceService.
+//   - telemetryStore: is the telemetry.Store value supplied to NewConformanceService.
+//
+// Returns:
+//   - result: is the *ConformanceService value produced by NewConformanceService.
 func NewConformanceService(durableStore durable.Store, telemetryStore telemetry.Store) *ConformanceService {
 	return NewConformanceServiceWithClock(durableStore, telemetryStore, nil)
 }
 
+// NewConformanceServiceWithClock constructs service from the supplied configuration and dependencies.
+//
+// Parameters:
+//   - durableStore: is the durable.Store value supplied to NewConformanceServiceWithClock.
+//   - telemetryStore: is the telemetry.Store value supplied to NewConformanceServiceWithClock.
+//   - now: supplies the event or wall-clock timestamp used by the operation.
+//
+// Returns:
+//   - result: is the *ConformanceService value produced by NewConformanceServiceWithClock.
 func NewConformanceServiceWithClock(durableStore durable.Store, telemetryStore telemetry.Store, now func() time.Time) *ConformanceService {
 	if now == nil {
 		now = func() time.Time { return time.Now().UTC() }
@@ -38,6 +55,16 @@ func NewConformanceServiceWithClock(durableStore durable.Store, telemetryStore t
 	return &ConformanceService{durable: durableStore, telemetry: telemetryStore, now: now}
 }
 
+// EvaluateTelemetry evaluates one telemetry sample against the applicable
+// active intent and persists its conformance event and summary projection.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - sample: is the domain.TelemetrySample value supplied to EvaluateTelemetry.
+//
+// Returns:
+//   - result: is the ConformanceEvaluation value produced by EvaluateTelemetry.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *ConformanceService) EvaluateTelemetry(ctx context.Context, sample domain.TelemetrySample) (ConformanceEvaluation, error) {
 	if sample.RecordedAt.IsZero() {
 		sample.RecordedAt = s.now().UTC()
@@ -205,6 +232,15 @@ func (s *ConformanceService) alertCount(ctx context.Context, intent domain.Opera
 	return len(unique), nil
 }
 
+// GetIntentConformance returns the summary and events for the current version of one intent.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - intentID: identifies the target intent.
+//
+// Returns:
+//   - result: is the ConformanceEvaluation value produced by GetIntentConformance.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *ConformanceService) GetIntentConformance(ctx context.Context, intentID string) (ConformanceEvaluation, error) {
 	intent, err := s.durable.GetOperationalIntent(ctx, intentID)
 	if err != nil {

--- a/internal/service/deconfliction/deconfliction.go
+++ b/internal/service/deconfliction/deconfliction.go
@@ -26,6 +26,15 @@ type DeconflictionService struct {
 	now              func() time.Time
 }
 
+// NewDeconflictionService constructs deconfliction from the supplied configuration and dependencies.
+//
+// Parameters:
+//   - store: is the durable.Store value supplied to NewDeconflictionService.
+//   - providers: identifies the target providers.
+//
+// Returns:
+//   - result: is the *DeconflictionService value produced by NewDeconflictionService.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func NewDeconflictionService(
 	store durable.Store,
 	providers ...airspaceprovider.Provider,
@@ -33,6 +42,16 @@ func NewDeconflictionService(
 	return newDeconflictionService(store, nil, publicationLease, providers...)
 }
 
+// NewDeconflictionServiceWithPublicationLease constructs deconfliction from the supplied configuration and dependencies.
+//
+// Parameters:
+//   - store: is the durable.Store value supplied to NewDeconflictionServiceWithPublicationLease.
+//   - lease: defines the time bound applied by the operation.
+//   - providers: identifies the target providers.
+//
+// Returns:
+//   - result: is the *DeconflictionService value produced by NewDeconflictionServiceWithPublicationLease.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func NewDeconflictionServiceWithPublicationLease(
 	store durable.Store,
 	lease time.Duration,
@@ -41,6 +60,16 @@ func NewDeconflictionServiceWithPublicationLease(
 	return newDeconflictionService(store, nil, lease, providers...)
 }
 
+// NewDeconflictionServiceWithClock constructs deconfliction from the supplied configuration and dependencies.
+//
+// Parameters:
+//   - store: is the durable.Store value supplied to NewDeconflictionServiceWithClock.
+//   - now: supplies the event or wall-clock timestamp used by the operation.
+//   - providers: identifies the target providers.
+//
+// Returns:
+//   - result: is the *DeconflictionService value produced by NewDeconflictionServiceWithClock.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func NewDeconflictionServiceWithClock(
 	store durable.Store,
 	now func() time.Time,
@@ -82,6 +111,16 @@ func newDeconflictionService(
 	return service, nil
 }
 
+// CheckIntent evaluates an intent version against local and peer operational
+// volumes, then durably replaces that version's conflict findings.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - intentID: identifies the target intent.
+//
+// Returns:
+//   - result: is the domain.DeconflictionResult value produced by CheckIntent.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *DeconflictionService) CheckIntent(ctx context.Context, intentID string) (domain.DeconflictionResult, error) {
 	intent, volumes, err := s.loadIntent(ctx, intentID)
 	if err != nil {
@@ -202,6 +241,15 @@ func sourceKey(source airspaceprovider.Source) string {
 	}, "\x00")
 }
 
+// ListConflictFindings returns DeconflictionService records matching the supplied scope and filters.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - intentID: identifies the target intent.
+//
+// Returns:
+//   - result: is the []domain.ConflictFinding value produced by ListConflictFindings.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *DeconflictionService) ListConflictFindings(ctx context.Context, intentID string) ([]domain.ConflictFinding, error) {
 	if strings.TrimSpace(intentID) == "" {
 		return nil, fmt.Errorf("validation failed: intent_id is required")

--- a/internal/service/deconfliction/publication.go
+++ b/internal/service/deconfliction/publication.go
@@ -23,10 +23,22 @@ const (
 	peerNotificationBatch = 20
 )
 
+// PublishingEnabled reports whether the configured airspace provider supports publication.
+//
+// Returns:
+//   - bool: reports whether the requested condition was satisfied.
 func (s *DeconflictionService) PublishingEnabled() bool {
 	return s.publisher != nil && s.publisher.PublicationEnabled()
 }
 
+// PublicationRequest returns the current durable publication request for an intent.
+//
+// Parameters:
+//   - intent: is the domain.OperationalIntent value supplied to PublicationRequest.
+//   - state: is the domain.OperationalIntentExternalState value supplied to PublicationRequest.
+//
+// Returns:
+//   - result: is the domain.OperationalIntentPublication value produced by PublicationRequest.
 func (s *DeconflictionService) PublicationRequest(intent domain.OperationalIntent, state domain.OperationalIntentExternalState) domain.OperationalIntentPublication {
 	now := s.now().UTC()
 	return domain.OperationalIntentPublication{
@@ -35,6 +47,15 @@ func (s *DeconflictionService) PublicationRequest(intent domain.OperationalInten
 	}
 }
 
+// ValidatePublication validates DeconflictionService for required fields, supported values, and safety constraints.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - intent: is the domain.OperationalIntent value supplied to ValidatePublication.
+//   - state: is the domain.OperationalIntentExternalState value supplied to ValidatePublication.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *DeconflictionService) ValidatePublication(ctx context.Context, intent domain.OperationalIntent, state domain.OperationalIntentExternalState) error {
 	volumes, err := s.durable.ListOperationalVolumes(ctx, intent.ID)
 	if err != nil {
@@ -49,14 +70,42 @@ func (s *DeconflictionService) ValidatePublication(ctx context.Context, intent d
 	})
 }
 
+// GetPublication returns the durable DSS publication state for one intent.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - intentID: identifies the target intent.
+//
+// Returns:
+//   - result: is the domain.OperationalIntentPublication value produced by GetPublication.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *DeconflictionService) GetPublication(ctx context.Context, intentID string) (domain.OperationalIntentPublication, error) {
 	return s.durable.GetOperationalIntentPublication(ctx, intentID)
 }
 
+// RecordReceivedPeerNotification durably records the supplied DeconflictionService data.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - notification: is the domain.ReceivedPeerNotification value supplied to RecordReceivedPeerNotification.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *DeconflictionService) RecordReceivedPeerNotification(ctx context.Context, notification domain.ReceivedPeerNotification) error {
 	return s.durable.RecordReceivedPeerNotification(ctx, notification)
 }
 
+// GetPublishedOperationalIntent fetches the authoritative published intent details from the provider.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - intentID: identifies the target intent.
+//   - dssVersion: is the int value supplied to GetPublishedOperationalIntent.
+//
+// Returns:
+//   - result: is the domain.OperationalIntentPublication value produced by GetPublishedOperationalIntent.
+//   - result: is the []domain.OperationalVolume value produced by GetPublishedOperationalIntent.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *DeconflictionService) GetPublishedOperationalIntent(ctx context.Context, intentID string, dssVersion int) (domain.OperationalIntentPublication, []domain.OperationalVolume, error) {
 	publication, err := s.GetPublication(ctx, intentID)
 	if err != nil {
@@ -74,6 +123,14 @@ func (s *DeconflictionService) GetPublishedOperationalIntent(ctx context.Context
 	return publication, volumesForVersion(volumes, publication.PublishedIntentVersion), nil
 }
 
+// ReconcileIntent reconciles DeconflictionService state with its desired external state.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - intentID: identifies the target intent.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *DeconflictionService) ReconcileIntent(ctx context.Context, intentID string) error {
 	if !s.PublishingEnabled() {
 		return fmt.Errorf("DSS publication is not configured")
@@ -86,6 +143,10 @@ func (s *DeconflictionService) ReconcileIntent(ctx context.Context, intentID str
 	return s.reconcileClaimed(ctx, publication)
 }
 
+// RunPublicationWorker runs DeconflictionService until completion, cancellation, or a terminal error.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
 func (s *DeconflictionService) RunPublicationWorker(ctx context.Context) {
 	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()
@@ -101,6 +162,13 @@ func (s *DeconflictionService) RunPublicationWorker(ctx context.Context) {
 	}
 }
 
+// ReconcileDue reconciles DeconflictionService state with its desired external state.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *DeconflictionService) ReconcileDue(ctx context.Context) error {
 	if !s.PublishingEnabled() {
 		return nil
@@ -330,6 +398,13 @@ func (s *DeconflictionService) buildPeerNotifications(request airspaceprovider.P
 	return notifications, nil
 }
 
+// DeliverDuePeerNotifications delivers due DeconflictionService work and records each delivery outcome.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *DeconflictionService) DeliverDuePeerNotifications(ctx context.Context) error {
 	if !s.PublishingEnabled() {
 		return nil

--- a/internal/service/fleet_service.go
+++ b/internal/service/fleet_service.go
@@ -52,6 +52,18 @@ type ReplayResponse struct {
 	ConformanceEvents []domain.ConformanceEvent `json:"conformance_events"`
 }
 
+// NewFleetService constructs the fleet read/write façade used by HTTP handlers.
+// Dashboard requests are composed from durable business records, time-series
+// telemetry, replay manifests, and ephemeral Registry placement.
+//
+// Parameters:
+//   - durableStore: owns aircraft, intent, maintenance, and compliance records.
+//   - telemetryStore: supplies current and historical aircraft observations.
+//   - replayStore: resolves durable replay manifests for completed flights.
+//   - registry: supplies current Agent placement and Relay liveness.
+//
+// Returns:
+//   - service: uses default Registry and telemetry freshness thresholds.
 func NewFleetService(durableStore durable.Store, telemetryStore telemetry.Store, replayStore replay.Store, registry registryv1.AeroRegistryClient) *FleetService {
 	return &FleetService{
 		durable:            durableStore,
@@ -64,6 +76,17 @@ func NewFleetService(durableStore durable.Store, telemetryStore telemetry.Store,
 	}
 }
 
+// WithLiveStatePolicy overrides live-state freshness thresholds and the clock
+// used to classify observations. Non-positive durations and a nil clock leave
+// the corresponding defaults unchanged.
+//
+// Parameters:
+//   - registryFreshness: bounds how old a Registry heartbeat may be.
+//   - telemetryFreshness: bounds how old each telemetry group may be.
+//   - now: supplies one clock source for deterministic freshness classification.
+//
+// Returns:
+//   - service: is the same receiver, allowing constructor-style chaining.
 func (s *FleetService) WithLiveStatePolicy(registryFreshness, telemetryFreshness time.Duration, now func() time.Time) *FleetService {
 	if registryFreshness > 0 {
 		s.registryFreshness = registryFreshness
@@ -77,18 +100,51 @@ func (s *FleetService) WithLiveStatePolicy(registryFreshness, telemetryFreshness
 	return s
 }
 
+// CreateAircraft delegates durable aircraft creation to the configured store.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - aircraft: is the domain.Aircraft value supplied to CreateAircraft.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *FleetService) CreateAircraft(ctx context.Context, aircraft domain.Aircraft) error {
 	return s.durable.CreateAircraft(ctx, aircraft)
 }
 
+// CreateBattery delegates durable battery creation to the configured store.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - battery: is the domain.Battery value supplied to CreateBattery.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *FleetService) CreateBattery(ctx context.Context, battery domain.Battery) error {
 	return s.durable.CreateBattery(ctx, battery)
 }
 
+// RecordMaintenanceEvent appends a durable aircraft maintenance record.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - event: is the domain.MaintenanceEvent value supplied to RecordMaintenanceEvent.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *FleetService) RecordMaintenanceEvent(ctx context.Context, event domain.MaintenanceEvent) error {
 	return s.durable.RecordMaintenanceEvent(ctx, event)
 }
 
+// GetOverviewDashboard composes fleet readiness, operational intents, evidence,
+// and reportability reviews into the Ops overview read model.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//
+// Returns:
+//   - dashboard: contains metrics and the underlying records used to derive them.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *FleetService) GetOverviewDashboard(ctx context.Context) (readmodel.OverviewDashboard, error) {
 	aircraft, err := s.ListAircraftDashboards(ctx)
 	if err != nil {
@@ -116,6 +172,15 @@ func (s *FleetService) GetOverviewDashboard(ctx context.Context) (readmodel.Over
 	}, nil
 }
 
+// GetOperationsDashboard composes operational intents, conformance summaries,
+// and per-aircraft live Registry/telemetry state for the Ops operations page.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//
+// Returns:
+//   - dashboard: contains operational metrics and independently sourced live state.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *FleetService) GetOperationsDashboard(ctx context.Context) (readmodel.OperationsDashboard, error) {
 	intents, err := s.durable.ListOperationalIntents(ctx, "")
 	if err != nil {
@@ -139,6 +204,14 @@ func (s *FleetService) GetOperationsDashboard(ctx context.Context) (readmodel.Op
 	}, nil
 }
 
+// GetPreflightDashboard composes recorded preflight checks and their aggregate metrics.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//
+// Returns:
+//   - result: is the readmodel.PreflightDashboard value produced by GetPreflightDashboard.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *FleetService) GetPreflightDashboard(ctx context.Context) (readmodel.PreflightDashboard, error) {
 	checks, err := s.durable.ListPreflightChecks(ctx, "")
 	if err != nil {
@@ -151,6 +224,15 @@ func (s *FleetService) GetPreflightDashboard(ctx context.Context) (readmodel.Pre
 	}, nil
 }
 
+// GetConformanceDashboard composes durable conformance summaries, incident
+// events, and aggregate conformance metrics.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//
+// Returns:
+//   - result: is the readmodel.ConformanceDashboard value produced by GetConformanceDashboard.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *FleetService) GetConformanceDashboard(ctx context.Context) (readmodel.ConformanceDashboard, error) {
 	summaries, err := s.durable.ListConformanceSummaries(ctx, "")
 	if err != nil {
@@ -168,6 +250,15 @@ func (s *FleetService) GetConformanceDashboard(ctx context.Context) (readmodel.C
 	}, nil
 }
 
+// GetMaintenanceDashboard composes maintenance history, battery inventory, and
+// their operational metrics.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//
+// Returns:
+//   - result: is the readmodel.MaintenanceDashboard value produced by GetMaintenanceDashboard.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *FleetService) GetMaintenanceDashboard(ctx context.Context) (readmodel.MaintenanceDashboard, error) {
 	events, err := s.durable.ListMaintenanceEvents(ctx, "")
 	if err != nil {
@@ -185,6 +276,14 @@ func (s *FleetService) GetMaintenanceDashboard(ctx context.Context) (readmodel.M
 	}, nil
 }
 
+// GetRecordsDashboard composes evidence and reportability-review records for Ops.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//
+// Returns:
+//   - result: is the readmodel.RecordsDashboard value produced by GetRecordsDashboard.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *FleetService) GetRecordsDashboard(ctx context.Context) (readmodel.RecordsDashboard, error) {
 	evidence, err := s.durable.ListEvidence(ctx, "")
 	if err != nil {
@@ -202,6 +301,16 @@ func (s *FleetService) GetRecordsDashboard(ctx context.Context) (readmodel.Recor
 	}, nil
 }
 
+// ListAircraftDashboards composes one dashboard record per durable aircraft.
+// Registry placement and telemetry are fetched in batches before durable
+// maintenance and battery details are joined per aircraft.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//
+// Returns:
+//   - result: is the []readmodel.AircraftDashboard value produced by ListAircraftDashboards.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *FleetService) ListAircraftDashboards(ctx context.Context) ([]readmodel.AircraftDashboard, error) {
 	aircraft, err := s.durable.ListAircraft(ctx)
 	if err != nil {
@@ -221,6 +330,16 @@ func (s *FleetService) ListAircraftDashboards(ctx context.Context) ([]readmodel.
 	return dashboards, nil
 }
 
+// GetAircraftDashboard composes durable, maintenance, Registry, and telemetry
+// state for one aircraft.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - aircraftID: identifies the target aircraft.
+//
+// Returns:
+//   - result: is the readmodel.AircraftDashboard value produced by GetAircraftDashboard.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *FleetService) GetAircraftDashboard(ctx context.Context, aircraftID string) (readmodel.AircraftDashboard, error) {
 	aircraft, err := s.durable.GetAircraft(ctx, aircraftID)
 	if err != nil {
@@ -230,6 +349,16 @@ func (s *FleetService) GetAircraftDashboard(ctx context.Context, aircraftID stri
 	return s.buildDashboard(ctx, aircraft, live)
 }
 
+// GetAircraftLiveState composes current connection and independently sampled
+// telemetry groups for one durable aircraft.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - aircraftID: identifies the target aircraft.
+//
+// Returns:
+//   - result: is the readmodel.AircraftLiveState value produced by GetAircraftLiveState.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *FleetService) GetAircraftLiveState(ctx context.Context, aircraftID string) (readmodel.AircraftLiveState, error) {
 	aircraft, err := s.durable.GetAircraft(ctx, aircraftID)
 	if err != nil {
@@ -238,6 +367,17 @@ func (s *FleetService) GetAircraftLiveState(ctx context.Context, aircraftID stri
 	return s.composeLiveAircraft(ctx, []domain.Aircraft{aircraft})[0], nil
 }
 
+// GetAircraftMapView composes the live map marker, bounded telemetry history,
+// active intent geometry, and matching conformance evidence for one aircraft.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - aircraftID: identifies the target aircraft.
+//   - limit: caps historical telemetry samples included in the map view.
+//
+// Returns:
+//   - result: is the readmodel.AircraftMapView value produced by GetAircraftMapView.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *FleetService) GetAircraftMapView(ctx context.Context, aircraftID string, limit int) (readmodel.AircraftMapView, error) {
 	aircraft, err := s.durable.GetAircraft(ctx, aircraftID)
 	if err != nil {
@@ -299,6 +439,16 @@ func (s *FleetService) GetAircraftMapView(ctx context.Context, aircraftID string
 	return view, nil
 }
 
+// ListFlightRecords verifies the aircraft exists, then returns its durable
+// flight records.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - aircraftID: identifies the target aircraft.
+//
+// Returns:
+//   - result: is the []domain.FlightRecord value produced by ListFlightRecords.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *FleetService) ListFlightRecords(ctx context.Context, aircraftID string) ([]domain.FlightRecord, error) {
 	if _, err := s.durable.GetAircraft(ctx, aircraftID); err != nil {
 		return nil, fmt.Errorf("get aircraft: %w", err)
@@ -310,6 +460,15 @@ func (s *FleetService) ListFlightRecords(ctx context.Context, aircraftID string)
 	return flights, nil
 }
 
+// GetFlightRecord returns one durable flight record by identity.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - flightID: identifies the target flight.
+//
+// Returns:
+//   - result: is the domain.FlightRecord value produced by GetFlightRecord.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *FleetService) GetFlightRecord(ctx context.Context, flightID string) (domain.FlightRecord, error) {
 	flight, err := s.durable.GetFlightRecord(ctx, flightID)
 	if err != nil {
@@ -318,6 +477,17 @@ func (s *FleetService) GetFlightRecord(ctx context.Context, flightID string) (do
 	return flight, nil
 }
 
+// GetFlightReplay composes a flight, its replay manifest, bounded telemetry,
+// and durable conformance events into one replay response.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - flightID: identifies the target flight.
+//   - limit: caps telemetry samples returned for the replay.
+//
+// Returns:
+//   - result: is the ReplayResponse value produced by GetFlightReplay.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *FleetService) GetFlightReplay(ctx context.Context, flightID string, limit int) (ReplayResponse, error) {
 	flight, err := s.durable.GetFlightRecord(ctx, flightID)
 	if err != nil {
@@ -668,6 +838,16 @@ func liveAircraftForID(states []readmodel.AircraftLiveState, aircraftID string) 
 		Telemetry:  domain.AircraftTelemetryState{Status: domain.DataFreshnessUnavailable}}
 }
 
+// CalculateReadiness derives the aircraft readiness state from unresolved
+// critical maintenance, battery health, and live-state availability.
+//
+// Parameters:
+//   - battery: is the installed battery, or nil when no installation is known.
+//   - maintenanceEvents: contains the aircraft's recorded maintenance history.
+//   - liveStateAvailable: reports whether current aircraft state can be observed.
+//
+// Returns:
+//   - readiness: contains the derived status and human-readable blocking reasons.
 func CalculateReadiness(battery *domain.Battery, maintenanceEvents []domain.MaintenanceEvent, liveStateAvailable bool) domain.Readiness {
 	reasons := make([]string, 0)
 	for _, event := range maintenanceEvents {

--- a/internal/service/intent_service.go
+++ b/internal/service/intent_service.go
@@ -226,7 +226,8 @@ func (s *IntentService) CreateIntent(ctx context.Context, req CreateIntentReques
 	return intent, nil
 }
 
-// GetIntent returns the current operational intent together with its versioned volumes.
+// GetIntent returns the current durable operational-intent record. Volumes are
+// stored separately and are not included in this result.
 //
 // Parameters:
 //   - ctx: controls cancellation and deadlines for the operation.

--- a/internal/service/intent_service.go
+++ b/internal/service/intent_service.go
@@ -26,10 +26,18 @@ type ActiveIntentModificationError struct {
 	Version  int
 }
 
+// Error returns the active-intent modification failure message.
+//
+// Returns:
+//   - result: is the string value produced by Error.
 func (e ActiveIntentModificationError) Error() string {
 	return fmt.Sprintf("%s: active intent modification blocked", ErrInvalidTransition)
 }
 
+// Unwrap returns the underlying lifecycle error for errors.Is and errors.As.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (e ActiveIntentModificationError) Unwrap() error {
 	return ErrInvalidTransition
 }
@@ -119,10 +127,27 @@ type ModifyIntentResult struct {
 	SupersedesVersion  int                        `json:"supersedes_version,omitempty"`
 }
 
+// NewIntentService constructs service from the supplied configuration and dependencies.
+//
+// Parameters:
+//   - durableStore: is the durable.Store value supplied to NewIntentService.
+//   - deconfliction: is the DeconflictionCoordinator value supplied to NewIntentService.
+//
+// Returns:
+//   - result: is the *IntentService value produced by NewIntentService.
 func NewIntentService(durableStore durable.Store, deconfliction DeconflictionCoordinator) *IntentService {
 	return NewIntentServiceWithClock(durableStore, nil, deconfliction)
 }
 
+// NewIntentServiceWithClock constructs service from the supplied configuration and dependencies.
+//
+// Parameters:
+//   - durableStore: is the durable.Store value supplied to NewIntentServiceWithClock.
+//   - now: supplies the event or wall-clock timestamp used by the operation.
+//   - deconfliction: is the DeconflictionCoordinator value supplied to NewIntentServiceWithClock.
+//
+// Returns:
+//   - result: is the *IntentService value produced by NewIntentServiceWithClock.
 func NewIntentServiceWithClock(durableStore durable.Store, now func() time.Time, deconfliction DeconflictionCoordinator) *IntentService {
 	if now == nil {
 		now = func() time.Time { return time.Now().UTC() }
@@ -134,6 +159,15 @@ func NewIntentServiceWithClock(durableStore durable.Store, now func() time.Time,
 	}
 }
 
+// CreateIntent creates and stores the supplied IntentService record.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - req: contains the validated request payload.
+//
+// Returns:
+//   - result: is the domain.OperationalIntent value produced by CreateIntent.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *IntentService) CreateIntent(ctx context.Context, req CreateIntentRequest) (domain.OperationalIntent, error) {
 	now := s.now().UTC()
 	id := strings.TrimSpace(req.ID)
@@ -192,6 +226,15 @@ func (s *IntentService) CreateIntent(ctx context.Context, req CreateIntentReques
 	return intent, nil
 }
 
+// GetIntent returns the current operational intent together with its versioned volumes.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - intentID: identifies the target intent.
+//
+// Returns:
+//   - result: is the domain.OperationalIntent value produced by GetIntent.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *IntentService) GetIntent(ctx context.Context, intentID string) (domain.OperationalIntent, error) {
 	intent, err := s.durable.GetOperationalIntent(ctx, intentID)
 	if err != nil {
@@ -200,6 +243,16 @@ func (s *IntentService) GetIntent(ctx context.Context, intentID string) (domain.
 	return intent, nil
 }
 
+// AddOperationalVolume adds the supplied value to IntentService.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - intentID: identifies the target intent.
+//   - req: contains the validated request payload.
+//
+// Returns:
+//   - result: is the domain.OperationalVolume value produced by AddOperationalVolume.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *IntentService) AddOperationalVolume(ctx context.Context, intentID string, req AddOperationalVolumeRequest) (domain.OperationalVolume, error) {
 	intent, err := s.durable.GetOperationalIntent(ctx, intentID)
 	if err != nil {
@@ -244,6 +297,17 @@ func (s *IntentService) AddOperationalVolume(ctx context.Context, intentID strin
 	return volume, nil
 }
 
+// ModifyIntent creates a replacement version of a mutable operational intent
+// after validating its revision and supplied volumes.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - intentID: identifies the target intent.
+//   - req: contains the validated request payload.
+//
+// Returns:
+//   - result: is the ModifyIntentResult value produced by ModifyIntent.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *IntentService) ModifyIntent(ctx context.Context, intentID string, req ModifyIntentRequest) (ModifyIntentResult, error) {
 	intent, err := s.durable.GetOperationalIntent(ctx, intentID)
 	if err != nil {
@@ -311,6 +375,16 @@ func (s *IntentService) ModifyIntent(ctx context.Context, intentID string, req M
 	return result, nil
 }
 
+// SubmitIntent runs deconfliction for the current version and advances an
+// eligible draft intent into its submitted lifecycle state.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - intentID: identifies the target intent.
+//
+// Returns:
+//   - result: is the domain.OperationalIntent value produced by SubmitIntent.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *IntentService) SubmitIntent(ctx context.Context, intentID string) (domain.OperationalIntent, error) {
 	return s.transitionIntent(ctx, intentID, domain.IntentStatusSubmitted, map[domain.IntentStatus]bool{
 		domain.IntentStatusDraft: true,
@@ -319,6 +393,15 @@ func (s *IntentService) SubmitIntent(ctx context.Context, intentID string) (doma
 	})
 }
 
+// AcceptIntent accepts the selected IntentService state after validating its current revision.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - intentID: identifies the target intent.
+//
+// Returns:
+//   - result: is the domain.OperationalIntent value produced by AcceptIntent.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *IntentService) AcceptIntent(ctx context.Context, intentID string) (domain.OperationalIntent, error) {
 	intent, err := s.durable.GetOperationalIntent(ctx, intentID)
 	if err != nil {
@@ -353,6 +436,16 @@ func (s *IntentService) AcceptIntent(ctx context.Context, intentID string) (doma
 	return intent, nil
 }
 
+// ActivateIntent advances an accepted intent to active and establishes its
+// operation context with the assigned Relay when required.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - intentID: identifies the target intent.
+//
+// Returns:
+//   - result: is the domain.OperationalIntent value produced by ActivateIntent.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *IntentService) ActivateIntent(ctx context.Context, intentID string) (domain.OperationalIntent, error) {
 	intent, err := s.durable.GetOperationalIntent(ctx, intentID)
 	if err != nil {
@@ -487,6 +580,15 @@ func canonicalDSSIntentID(id string) (string, error) {
 	return parsed.String(), nil
 }
 
+// CompleteIntent transitions an active intent to complete and clears its Relay context.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - intentID: identifies the target intent.
+//
+// Returns:
+//   - result: is the domain.OperationalIntent value produced by CompleteIntent.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *IntentService) CompleteIntent(ctx context.Context, intentID string) (domain.OperationalIntent, error) {
 	return s.transitionIntentWithPublication(ctx, intentID, domain.IntentStatusComplete, map[domain.IntentStatus]bool{
 		domain.IntentStatusActive: true,
@@ -495,6 +597,15 @@ func (s *IntentService) CompleteIntent(ctx context.Context, intentID string) (do
 	}, domain.OperationalIntentExternalStateWithdrawn)
 }
 
+// CancelIntent transitions an eligible intent to cancelled and clears its Relay context.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - intentID: identifies the target intent.
+//
+// Returns:
+//   - result: is the domain.OperationalIntent value produced by CancelIntent.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *IntentService) CancelIntent(ctx context.Context, intentID string) (domain.OperationalIntent, error) {
 	return s.transitionIntentWithPublication(ctx, intentID, domain.IntentStatusCanceled, map[domain.IntentStatus]bool{
 		domain.IntentStatusDraft:     true,

--- a/internal/service/preflight_service.go
+++ b/internal/service/preflight_service.go
@@ -21,10 +21,25 @@ type PreflightEvaluation struct {
 	Blocked  bool                       `json:"blocked"`
 }
 
+// NewPreflightService constructs service from the supplied configuration and dependencies.
+//
+// Parameters:
+//   - durableStore: is the durable.Store value supplied to NewPreflightService.
+//
+// Returns:
+//   - result: is the *PreflightService value produced by NewPreflightService.
 func NewPreflightService(durableStore durable.Store) *PreflightService {
 	return NewPreflightServiceWithClock(durableStore, nil)
 }
 
+// NewPreflightServiceWithClock constructs service from the supplied configuration and dependencies.
+//
+// Parameters:
+//   - durableStore: is the durable.Store value supplied to NewPreflightServiceWithClock.
+//   - now: supplies the event or wall-clock timestamp used by the operation.
+//
+// Returns:
+//   - result: is the *PreflightService value produced by NewPreflightServiceWithClock.
 func NewPreflightServiceWithClock(durableStore durable.Store, now func() time.Time) *PreflightService {
 	if now == nil {
 		now = func() time.Time { return time.Now().UTC() }
@@ -32,6 +47,16 @@ func NewPreflightServiceWithClock(durableStore durable.Store, now func() time.Ti
 	return &PreflightService{durable: durableStore, now: now}
 }
 
+// EvaluateIntent runs the current preflight policy against an operational
+// intent and records the resulting checks.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - intentID: identifies the target intent.
+//
+// Returns:
+//   - result: is the PreflightEvaluation value produced by EvaluateIntent.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *PreflightService) EvaluateIntent(ctx context.Context, intentID string) (PreflightEvaluation, error) {
 	intent, err := s.durable.GetOperationalIntent(ctx, intentID)
 	if err != nil {

--- a/internal/store/durable/memory/durable.go
+++ b/internal/store/durable/memory/durable.go
@@ -324,7 +324,7 @@ func (s *Store) ListOperatingLimits(_ context.Context, aircraftID string) ([]dom
 //
 // Parameters:
 //   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
-//   - limit: caps the number of records claimed or returned in one call.
+//   - limit: is the operating-limit record stored or replaced by its ID.
 //
 // Returns:
 //   - error: reports validation, dependency, cancellation, or persistence failures.

--- a/internal/store/durable/memory/durable.go
+++ b/internal/store/durable/memory/durable.go
@@ -68,7 +68,7 @@ func NewStore() *Store {
 // UpsertOperator creates or replaces the supplied Store record by identity.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to UpsertOperator.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - operator: is the domain.Operator value supplied to UpsertOperator.
 //
 // Returns:
@@ -83,7 +83,7 @@ func (s *Store) UpsertOperator(_ context.Context, operator domain.Operator) erro
 // GetOperator returns one operator by identity.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to GetOperator.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - operatorID: identifies the target operator.
 //
 // Returns:
@@ -102,7 +102,7 @@ func (s *Store) GetOperator(_ context.Context, operatorID string) (domain.Operat
 // ListOperators returns Store records matching the supplied scope and filters.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to ListOperators.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //
 // Returns:
 //   - result: is the []domain.Operator value produced by ListOperators.
@@ -121,7 +121,7 @@ func (s *Store) ListOperators(_ context.Context) ([]domain.Operator, error) {
 // CreateAircraft creates and stores the supplied Store record.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to CreateAircraft.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - aircraft: is the domain.Aircraft value supplied to CreateAircraft.
 //
 // Returns:
@@ -136,7 +136,7 @@ func (s *Store) CreateAircraft(_ context.Context, aircraft domain.Aircraft) erro
 // GetAircraft returns one aircraft by identity.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to GetAircraft.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - aircraftID: identifies the target aircraft.
 //
 // Returns:
@@ -155,7 +155,7 @@ func (s *Store) GetAircraft(_ context.Context, aircraftID string) (domain.Aircra
 // ListAircraft returns Store records matching the supplied scope and filters.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to ListAircraft.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //
 // Returns:
 //   - result: is the []domain.Aircraft value produced by ListAircraft.
@@ -174,7 +174,7 @@ func (s *Store) ListAircraft(_ context.Context) ([]domain.Aircraft, error) {
 // CreateBattery creates and stores the supplied Store record.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to CreateBattery.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - battery: is the domain.Battery value supplied to CreateBattery.
 //
 // Returns:
@@ -189,7 +189,7 @@ func (s *Store) CreateBattery(_ context.Context, battery domain.Battery) error {
 // GetBattery returns one battery by identity.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to GetBattery.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - batteryID: identifies the target battery.
 //
 // Returns:
@@ -208,7 +208,7 @@ func (s *Store) GetBattery(_ context.Context, batteryID string) (domain.Battery,
 // ListBatteries returns Store records matching the supplied scope and filters.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to ListBatteries.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //
 // Returns:
 //   - result: is the []domain.Battery value produced by ListBatteries.
@@ -227,7 +227,7 @@ func (s *Store) ListBatteries(_ context.Context) ([]domain.Battery, error) {
 // RecordBatteryInstallation durably records the supplied Store data.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to RecordBatteryInstallation.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - installation: is the domain.BatteryInstallation value supplied to RecordBatteryInstallation.
 //
 // Returns:
@@ -242,7 +242,7 @@ func (s *Store) RecordBatteryInstallation(_ context.Context, installation domain
 // GetActiveBatteryInstallation returns the current battery installation for an aircraft.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to GetActiveBatteryInstallation.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - aircraftID: identifies the target aircraft.
 //
 // Returns:
@@ -267,7 +267,7 @@ func (s *Store) GetActiveBatteryInstallation(_ context.Context, aircraftID strin
 // UpsertAircraftOperatingProfile creates or replaces the supplied Store record by identity.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to UpsertAircraftOperatingProfile.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - profile: is the domain.AircraftOperatingProfile value supplied to UpsertAircraftOperatingProfile.
 //
 // Returns:
@@ -282,7 +282,7 @@ func (s *Store) UpsertAircraftOperatingProfile(_ context.Context, profile domain
 // GetAircraftOperatingProfile returns the operating profile assigned to an aircraft.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to GetAircraftOperatingProfile.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - aircraftID: identifies the target aircraft.
 //
 // Returns:
@@ -301,7 +301,7 @@ func (s *Store) GetAircraftOperatingProfile(_ context.Context, aircraftID string
 // ListOperatingLimits returns Store records matching the supplied scope and filters.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to ListOperatingLimits.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - aircraftID: identifies the target aircraft.
 //
 // Returns:
@@ -323,7 +323,7 @@ func (s *Store) ListOperatingLimits(_ context.Context, aircraftID string) ([]dom
 // UpsertOperatingLimit creates or replaces the supplied Store record by identity.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to UpsertOperatingLimit.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - limit: caps the number of records claimed or returned in one call.
 //
 // Returns:
@@ -338,7 +338,7 @@ func (s *Store) UpsertOperatingLimit(_ context.Context, limit domain.OperatingLi
 // RecordMaintenanceEvent durably records the supplied Store data.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to RecordMaintenanceEvent.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - event: is the domain.MaintenanceEvent value supplied to RecordMaintenanceEvent.
 //
 // Returns:
@@ -353,7 +353,7 @@ func (s *Store) RecordMaintenanceEvent(_ context.Context, event domain.Maintenan
 // ListMaintenanceEvents returns Store records matching the supplied scope and filters.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to ListMaintenanceEvents.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - aircraftID: identifies the target aircraft.
 //
 // Returns:
@@ -375,7 +375,7 @@ func (s *Store) ListMaintenanceEvents(_ context.Context, aircraftID string) ([]d
 // CreateOperationalIntent creates and stores the supplied Store record.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to CreateOperationalIntent.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - intent: is the domain.OperationalIntent value supplied to CreateOperationalIntent.
 //
 // Returns:
@@ -395,7 +395,7 @@ func (s *Store) CreateOperationalIntent(_ context.Context, intent domain.Operati
 // UpdateOperationalIntent updates the selected Store state while enforcing its consistency checks.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to UpdateOperationalIntent.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - intent: is the domain.OperationalIntent value supplied to UpdateOperationalIntent.
 //   - expectedRevision: is the int64 value supplied to UpdateOperationalIntent.
 //
@@ -436,7 +436,7 @@ func (s *Store) updateOperationalIntentLocked(intent domain.OperationalIntent, e
 // AcceptOperationalIntent accepts the selected Store state after validating its current revision.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to AcceptOperationalIntent.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - intent: is the domain.OperationalIntent value supplied to AcceptOperationalIntent.
 //   - expectedRevision: is the int64 value supplied to AcceptOperationalIntent.
 //
@@ -474,7 +474,7 @@ func (s *Store) acceptOperationalIntentLocked(intent domain.OperationalIntent, e
 // AcceptOperationalIntentAndRequestPublication accepts the selected Store state after validating its current revision.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to AcceptOperationalIntentAndRequestPublication.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - intent: is the domain.OperationalIntent value supplied to AcceptOperationalIntentAndRequestPublication.
 //   - expectedRevision: is the int64 value supplied to AcceptOperationalIntentAndRequestPublication.
 //   - publication: is the domain.OperationalIntentPublication value supplied to AcceptOperationalIntentAndRequestPublication.
@@ -494,7 +494,7 @@ func (s *Store) AcceptOperationalIntentAndRequestPublication(_ context.Context, 
 // UpdateOperationalIntentAndRequestPublication updates the selected Store state while enforcing its consistency checks.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to UpdateOperationalIntentAndRequestPublication.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - intent: is the domain.OperationalIntent value supplied to UpdateOperationalIntentAndRequestPublication.
 //   - expectedRevision: is the int64 value supplied to UpdateOperationalIntentAndRequestPublication.
 //   - publication: is the domain.OperationalIntentPublication value supplied to UpdateOperationalIntentAndRequestPublication.
@@ -514,7 +514,7 @@ func (s *Store) UpdateOperationalIntentAndRequestPublication(_ context.Context, 
 // RequestOperationalIntentPublication requests the selected Store operation and records it for processing.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to RequestOperationalIntentPublication.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - publication: is the domain.OperationalIntentPublication value supplied to RequestOperationalIntentPublication.
 //
 // Returns:
@@ -532,7 +532,7 @@ func (s *Store) RequestOperationalIntentPublication(_ context.Context, publicati
 // RequestOperationalIntentPublicationIfCurrent requests the selected Store operation and records it for processing.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to RequestOperationalIntentPublicationIfCurrent.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - publication: is the domain.OperationalIntentPublication value supplied to RequestOperationalIntentPublicationIfCurrent.
 //   - expectedIntentVersion: is the int value supplied to RequestOperationalIntentPublicationIfCurrent.
 //   - expectedIntentRevision: is the int64 value supplied to RequestOperationalIntentPublicationIfCurrent.
@@ -590,7 +590,7 @@ func (s *Store) requestPublicationLocked(request domain.OperationalIntentPublica
 // GetOperationalIntentPublication returns the current DSS publication state for an intent.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to GetOperationalIntentPublication.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - intentID: identifies the target intent.
 //
 // Returns:
@@ -609,7 +609,7 @@ func (s *Store) GetOperationalIntentPublication(_ context.Context, intentID stri
 // ClaimOperationalIntentPublication atomically leases eligible Store work to a worker.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to ClaimOperationalIntentPublication.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - intentID: identifies the target intent.
 //   - now: supplies the event or wall-clock timestamp used by the operation.
 //   - leaseUntil: is the time.Time value supplied to ClaimOperationalIntentPublication.
@@ -640,7 +640,7 @@ func (s *Store) ClaimOperationalIntentPublication(_ context.Context, intentID st
 // ClaimDueOperationalIntentPublications atomically leases eligible Store work to a worker.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to ClaimDueOperationalIntentPublications.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - now: supplies the event or wall-clock timestamp used by the operation.
 //   - leaseUntil: is the time.Time value supplied to ClaimDueOperationalIntentPublications.
 //   - limit: caps the number of records claimed or returned in one call.
@@ -688,7 +688,7 @@ func (s *Store) ClaimDueOperationalIntentPublications(_ context.Context, now, le
 // RenewOperationalIntentPublicationLease extends the selected Store lease when the caller still owns its fence.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to RenewOperationalIntentPublicationLease.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - intentID: identifies the target intent.
 //   - expectedRevision: is the int64 value supplied to RenewOperationalIntentPublicationLease.
 //   - leaseUntil: is the time.Time value supplied to RenewOperationalIntentPublicationLease.
@@ -713,7 +713,7 @@ func (s *Store) RenewOperationalIntentPublicationLease(_ context.Context, intent
 // UpdateOperationalIntentPublication updates the selected Store state while enforcing its consistency checks.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to UpdateOperationalIntentPublication.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - publication: is the domain.OperationalIntentPublication value supplied to UpdateOperationalIntentPublication.
 //   - expectedRevision: is the int64 value supplied to UpdateOperationalIntentPublication.
 //
@@ -738,7 +738,7 @@ func (s *Store) UpdateOperationalIntentPublication(_ context.Context, publicatio
 // ConfirmOperationalIntentPublication confirms the selected Store transition and records its durable outcome.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to ConfirmOperationalIntentPublication.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - publication: is the domain.OperationalIntentPublication value supplied to ConfirmOperationalIntentPublication.
 //   - expectedRevision: is the int64 value supplied to ConfirmOperationalIntentPublication.
 //   - notifications: is the []domain.PeerNotification value supplied to ConfirmOperationalIntentPublication.
@@ -777,7 +777,7 @@ func (s *Store) enqueuePeerNotificationsLocked(notifications []domain.PeerNotifi
 // ClaimDuePeerNotifications atomically leases eligible Store work to a worker.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to ClaimDuePeerNotifications.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - now: supplies the event or wall-clock timestamp used by the operation.
 //   - leaseUntil: is the time.Time value supplied to ClaimDuePeerNotifications.
 //   - limit: caps the number of records claimed or returned in one call.
@@ -814,7 +814,7 @@ func (s *Store) ClaimDuePeerNotifications(_ context.Context, now, leaseUntil tim
 // UpdatePeerNotification updates the selected Store state while enforcing its consistency checks.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to UpdatePeerNotification.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - notification: is the domain.PeerNotification value supplied to UpdatePeerNotification.
 //   - expectedRevision: is the int64 value supplied to UpdatePeerNotification.
 //
@@ -839,7 +839,7 @@ func (s *Store) UpdatePeerNotification(_ context.Context, notification domain.Pe
 // RecordReceivedPeerNotification durably records the supplied Store data.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to RecordReceivedPeerNotification.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - notification: is the domain.ReceivedPeerNotification value supplied to RecordReceivedPeerNotification.
 //
 // Returns:
@@ -856,7 +856,7 @@ func (s *Store) RecordReceivedPeerNotification(_ context.Context, notification d
 // ListReceivedPeerNotifications returns Store records matching the supplied scope and filters.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to ListReceivedPeerNotifications.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - intentID: identifies the target intent.
 //
 // Returns:
@@ -885,7 +885,7 @@ func clonePublication(publication domain.OperationalIntentPublication) domain.Op
 // GetOperationalIntent returns the current version of one operational intent.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to GetOperationalIntent.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - intentID: identifies the target intent.
 //
 // Returns:
@@ -904,7 +904,7 @@ func (s *Store) GetOperationalIntent(_ context.Context, intentID string) (domain
 // GetOperationalIntentVersion returns one immutable historical intent version.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to GetOperationalIntentVersion.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - intentID: identifies the target intent.
 //   - version: is the int value supplied to GetOperationalIntentVersion.
 //
@@ -924,7 +924,7 @@ func (s *Store) GetOperationalIntentVersion(_ context.Context, intentID string, 
 // ListOperationalIntents returns Store records matching the supplied scope and filters.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to ListOperationalIntents.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - aircraftID: identifies the target aircraft.
 //
 // Returns:
@@ -953,7 +953,7 @@ func (s *Store) ListOperationalIntents(_ context.Context, aircraftID string) ([]
 // ListOperationalIntentVersions returns Store records matching the supplied scope and filters.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to ListOperationalIntentVersions.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - intentID: identifies the target intent.
 //
 // Returns:
@@ -980,7 +980,7 @@ func (s *Store) ListOperationalIntentVersions(_ context.Context, intentID string
 // RecordOperationalVolume durably records the supplied Store data.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to RecordOperationalVolume.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - volume: is the domain.OperationalVolume value supplied to RecordOperationalVolume.
 //
 // Returns:
@@ -995,7 +995,7 @@ func (s *Store) RecordOperationalVolume(_ context.Context, volume domain.Operati
 // ReplaceOperationalVolumes atomically replaces the selected Store records.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to ReplaceOperationalVolumes.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - intentID: identifies the target intent.
 //   - intentVersion: is the int value supplied to ReplaceOperationalVolumes.
 //   - volumes: is the []domain.OperationalVolume value supplied to ReplaceOperationalVolumes.
@@ -1024,7 +1024,7 @@ func (s *Store) ReplaceOperationalVolumes(_ context.Context, intentID string, in
 // ReplaceOperationalIntent atomically replaces the selected Store records.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to ReplaceOperationalIntent.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - expectedVersion: is the int value supplied to ReplaceOperationalIntent.
 //   - expectedRevision: is the int64 value supplied to ReplaceOperationalIntent.
 //   - intent: is the domain.OperationalIntent value supplied to ReplaceOperationalIntent.
@@ -1079,7 +1079,7 @@ func (s *Store) ReplaceOperationalIntent(
 // ListOperationalVolumes returns Store records matching the supplied scope and filters.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to ListOperationalVolumes.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - intentID: identifies the target intent.
 //
 // Returns:
@@ -1133,7 +1133,7 @@ func (s *Store) latestOperationalIntent(intentID string) (domain.OperationalInte
 // UpsertRegulatoryAuthorization creates or replaces the supplied Store record by identity.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to UpsertRegulatoryAuthorization.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - authorization: is the domain.RegulatoryAuthorization value supplied to UpsertRegulatoryAuthorization.
 //
 // Returns:
@@ -1148,7 +1148,7 @@ func (s *Store) UpsertRegulatoryAuthorization(_ context.Context, authorization d
 // GetRegulatoryAuthorization returns one regulatory authorization by identity.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to GetRegulatoryAuthorization.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - authorizationID: identifies the target authorization.
 //
 // Returns:
@@ -1167,7 +1167,7 @@ func (s *Store) GetRegulatoryAuthorization(_ context.Context, authorizationID st
 // ListRegulatoryAuthorizations returns Store records matching the supplied scope and filters.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to ListRegulatoryAuthorizations.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - operatorID: identifies the target operator.
 //
 // Returns:
@@ -1191,7 +1191,7 @@ func (s *Store) ListRegulatoryAuthorizations(_ context.Context, operatorID strin
 // RecordPreflightCheck durably records the supplied Store data.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to RecordPreflightCheck.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - check: is the domain.PreflightCheck value supplied to RecordPreflightCheck.
 //
 // Returns:
@@ -1212,7 +1212,7 @@ func (s *Store) RecordPreflightCheck(_ context.Context, check domain.PreflightCh
 // ListPreflightChecks returns Store records matching the supplied scope and filters.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to ListPreflightChecks.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - intentID: identifies the target intent.
 //
 // Returns:
@@ -1234,7 +1234,7 @@ func (s *Store) ListPreflightChecks(_ context.Context, intentID string) ([]domai
 // CreateFlightRecord creates and stores the supplied Store record.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to CreateFlightRecord.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - flight: is the domain.FlightRecord value supplied to CreateFlightRecord.
 //
 // Returns:
@@ -1249,7 +1249,7 @@ func (s *Store) CreateFlightRecord(_ context.Context, flight domain.FlightRecord
 // GetFlightRecord returns one durable flight record by identity.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to GetFlightRecord.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - flightID: identifies the target flight.
 //
 // Returns:
@@ -1268,7 +1268,7 @@ func (s *Store) GetFlightRecord(_ context.Context, flightID string) (domain.Flig
 // ListFlightRecords returns Store records matching the supplied scope and filters.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to ListFlightRecords.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - aircraftID: identifies the target aircraft.
 //
 // Returns:
@@ -1290,7 +1290,7 @@ func (s *Store) ListFlightRecords(_ context.Context, aircraftID string) ([]domai
 // RecordConformanceEvent durably records the supplied Store data.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to RecordConformanceEvent.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - event: is the domain.ConformanceEvent value supplied to RecordConformanceEvent.
 //
 // Returns:
@@ -1311,7 +1311,7 @@ func (s *Store) RecordConformanceEvent(_ context.Context, event domain.Conforman
 // ListConformanceEvents returns Store records matching the supplied scope and filters.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to ListConformanceEvents.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - flightID: identifies the target flight.
 //
 // Returns:
@@ -1333,7 +1333,7 @@ func (s *Store) ListConformanceEvents(_ context.Context, flightID string) ([]dom
 // UpsertConformanceSummary creates or replaces the supplied Store record by identity.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to UpsertConformanceSummary.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - summary: is the domain.ConformanceSummary value supplied to UpsertConformanceSummary.
 //
 // Returns:
@@ -1348,7 +1348,7 @@ func (s *Store) UpsertConformanceSummary(_ context.Context, summary domain.Confo
 // GetConformanceSummary returns the current conformance projection for an intent.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to GetConformanceSummary.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - intentID: identifies the target intent.
 //
 // Returns:
@@ -1375,7 +1375,7 @@ func (s *Store) GetConformanceSummary(_ context.Context, intentID string) (*doma
 // ListConformanceSummaries returns Store records matching the supplied scope and filters.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to ListConformanceSummaries.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - intentID: identifies the target intent.
 //
 // Returns:
@@ -1397,7 +1397,7 @@ func (s *Store) ListConformanceSummaries(_ context.Context, intentID string) ([]
 // RecordEvidence durably records the supplied Store data.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to RecordEvidence.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - record: is the domain.EvidenceRecord value supplied to RecordEvidence.
 //
 // Returns:
@@ -1412,7 +1412,7 @@ func (s *Store) RecordEvidence(_ context.Context, record domain.EvidenceRecord) 
 // ListEvidence returns Store records matching the supplied scope and filters.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to ListEvidence.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - intentID: identifies the target intent.
 //
 // Returns:
@@ -1434,7 +1434,7 @@ func (s *Store) ListEvidence(_ context.Context, intentID string) ([]domain.Evide
 // RecordReportabilityReview durably records the supplied Store data.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to RecordReportabilityReview.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - review: is the domain.ReportabilityReview value supplied to RecordReportabilityReview.
 //
 // Returns:
@@ -1449,7 +1449,7 @@ func (s *Store) RecordReportabilityReview(_ context.Context, review domain.Repor
 // ListReportabilityReviews returns Store records matching the supplied scope and filters.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to ListReportabilityReviews.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - intentID: identifies the target intent.
 //
 // Returns:
@@ -1471,7 +1471,7 @@ func (s *Store) ListReportabilityReviews(_ context.Context, intentID string) ([]
 // RecordComplianceFinding durably records the supplied Store data.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to RecordComplianceFinding.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - finding: is the domain.ComplianceFinding value supplied to RecordComplianceFinding.
 //
 // Returns:
@@ -1492,7 +1492,7 @@ func (s *Store) RecordComplianceFinding(_ context.Context, finding domain.Compli
 // ListComplianceFindings returns Store records matching the supplied scope and filters.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to ListComplianceFindings.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - subjectType: is the string value supplied to ListComplianceFindings.
 //   - subjectID: identifies the target subject.
 //
@@ -1519,7 +1519,7 @@ func (s *Store) ListComplianceFindings(_ context.Context, subjectType string, su
 // ListComplianceFindingsForIntent returns Store records matching the supplied scope and filters.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to ListComplianceFindingsForIntent.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - intentID: identifies the target intent.
 //
 // Returns:
@@ -1541,7 +1541,7 @@ func (s *Store) ListComplianceFindingsForIntent(_ context.Context, intentID stri
 // RecordConflictFinding durably records the supplied Store data.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to RecordConflictFinding.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - finding: is the domain.ConflictFinding value supplied to RecordConflictFinding.
 //
 // Returns:
@@ -1562,7 +1562,7 @@ func (s *Store) RecordConflictFinding(_ context.Context, finding domain.Conflict
 // ListConflictFindings returns Store records matching the supplied scope and filters.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to ListConflictFindings.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - intentID: identifies the target intent.
 //   - intentVersion: is the int value supplied to ListConflictFindings.
 //
@@ -1594,7 +1594,7 @@ func (s *Store) ListConflictFindings(_ context.Context, intentID string, intentV
 // ReplaceConflictFindings atomically replaces the selected Store records.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to ReplaceConflictFindings.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - intentID: identifies the target intent.
 //   - intentVersion: is the int value supplied to ReplaceConflictFindings.
 //   - ruleVersion: is the string value supplied to ReplaceConflictFindings.
@@ -1624,7 +1624,7 @@ func (s *Store) ReplaceConflictFindings(_ context.Context, intentID string, inte
 // UpsertOperationsPersonnel creates or replaces the supplied Store record by identity.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to UpsertOperationsPersonnel.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - person: is the domain.OperationsPersonnel value supplied to UpsertOperationsPersonnel.
 //
 // Returns:
@@ -1639,7 +1639,7 @@ func (s *Store) UpsertOperationsPersonnel(_ context.Context, person domain.Opera
 // GetOperationsPersonnel returns one operations-personnel record by identity.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to GetOperationsPersonnel.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - personID: identifies the target person.
 //
 // Returns:
@@ -1658,7 +1658,7 @@ func (s *Store) GetOperationsPersonnel(_ context.Context, personID string) (doma
 // RecordPersonnelAssignment durably records the supplied Store data.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to RecordPersonnelAssignment.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - assignment: is the domain.PersonnelAssignment value supplied to RecordPersonnelAssignment.
 //
 // Returns:
@@ -1673,7 +1673,7 @@ func (s *Store) RecordPersonnelAssignment(_ context.Context, assignment domain.P
 // ListPersonnelAssignments returns Store records matching the supplied scope and filters.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to ListPersonnelAssignments.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - intentID: identifies the target intent.
 //
 // Returns:

--- a/internal/store/durable/memory/durable.go
+++ b/internal/store/durable/memory/durable.go
@@ -41,6 +41,10 @@ type Store struct {
 
 var _ durable.OperationalStore = (*Store)(nil)
 
+// NewStore constructs memory from the supplied configuration and dependencies.
+//
+// Returns:
+//   - result: is the *Store value produced by NewStore.
 func NewStore() *Store {
 	return &Store{
 		operators:                 make(map[string]domain.Operator),
@@ -61,6 +65,14 @@ func NewStore() *Store {
 	}
 }
 
+// UpsertOperator creates or replaces the supplied Store record by identity.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to UpsertOperator.
+//   - operator: is the domain.Operator value supplied to UpsertOperator.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) UpsertOperator(_ context.Context, operator domain.Operator) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -68,6 +80,15 @@ func (s *Store) UpsertOperator(_ context.Context, operator domain.Operator) erro
 	return nil
 }
 
+// GetOperator returns one operator by identity.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to GetOperator.
+//   - operatorID: identifies the target operator.
+//
+// Returns:
+//   - result: is the domain.Operator value produced by GetOperator.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) GetOperator(_ context.Context, operatorID string) (domain.Operator, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -78,6 +99,14 @@ func (s *Store) GetOperator(_ context.Context, operatorID string) (domain.Operat
 	return operator, nil
 }
 
+// ListOperators returns Store records matching the supplied scope and filters.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to ListOperators.
+//
+// Returns:
+//   - result: is the []domain.Operator value produced by ListOperators.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) ListOperators(_ context.Context) ([]domain.Operator, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -89,6 +118,14 @@ func (s *Store) ListOperators(_ context.Context) ([]domain.Operator, error) {
 	return operators, nil
 }
 
+// CreateAircraft creates and stores the supplied Store record.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to CreateAircraft.
+//   - aircraft: is the domain.Aircraft value supplied to CreateAircraft.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) CreateAircraft(_ context.Context, aircraft domain.Aircraft) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -96,6 +133,15 @@ func (s *Store) CreateAircraft(_ context.Context, aircraft domain.Aircraft) erro
 	return nil
 }
 
+// GetAircraft returns one aircraft by identity.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to GetAircraft.
+//   - aircraftID: identifies the target aircraft.
+//
+// Returns:
+//   - result: is the domain.Aircraft value produced by GetAircraft.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) GetAircraft(_ context.Context, aircraftID string) (domain.Aircraft, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -106,6 +152,14 @@ func (s *Store) GetAircraft(_ context.Context, aircraftID string) (domain.Aircra
 	return aircraft, nil
 }
 
+// ListAircraft returns Store records matching the supplied scope and filters.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to ListAircraft.
+//
+// Returns:
+//   - result: is the []domain.Aircraft value produced by ListAircraft.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) ListAircraft(_ context.Context) ([]domain.Aircraft, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -117,6 +171,14 @@ func (s *Store) ListAircraft(_ context.Context) ([]domain.Aircraft, error) {
 	return aircraft, nil
 }
 
+// CreateBattery creates and stores the supplied Store record.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to CreateBattery.
+//   - battery: is the domain.Battery value supplied to CreateBattery.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) CreateBattery(_ context.Context, battery domain.Battery) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -124,6 +186,15 @@ func (s *Store) CreateBattery(_ context.Context, battery domain.Battery) error {
 	return nil
 }
 
+// GetBattery returns one battery by identity.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to GetBattery.
+//   - batteryID: identifies the target battery.
+//
+// Returns:
+//   - result: is the domain.Battery value produced by GetBattery.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) GetBattery(_ context.Context, batteryID string) (domain.Battery, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -134,6 +205,14 @@ func (s *Store) GetBattery(_ context.Context, batteryID string) (domain.Battery,
 	return battery, nil
 }
 
+// ListBatteries returns Store records matching the supplied scope and filters.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to ListBatteries.
+//
+// Returns:
+//   - result: is the []domain.Battery value produced by ListBatteries.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) ListBatteries(_ context.Context) ([]domain.Battery, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -145,6 +224,14 @@ func (s *Store) ListBatteries(_ context.Context) ([]domain.Battery, error) {
 	return batteries, nil
 }
 
+// RecordBatteryInstallation durably records the supplied Store data.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to RecordBatteryInstallation.
+//   - installation: is the domain.BatteryInstallation value supplied to RecordBatteryInstallation.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) RecordBatteryInstallation(_ context.Context, installation domain.BatteryInstallation) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -152,6 +239,15 @@ func (s *Store) RecordBatteryInstallation(_ context.Context, installation domain
 	return nil
 }
 
+// GetActiveBatteryInstallation returns the current battery installation for an aircraft.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to GetActiveBatteryInstallation.
+//   - aircraftID: identifies the target aircraft.
+//
+// Returns:
+//   - result: is the *domain.BatteryInstallation value produced by GetActiveBatteryInstallation.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) GetActiveBatteryInstallation(_ context.Context, aircraftID string) (*domain.BatteryInstallation, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -168,6 +264,14 @@ func (s *Store) GetActiveBatteryInstallation(_ context.Context, aircraftID strin
 	return active, nil
 }
 
+// UpsertAircraftOperatingProfile creates or replaces the supplied Store record by identity.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to UpsertAircraftOperatingProfile.
+//   - profile: is the domain.AircraftOperatingProfile value supplied to UpsertAircraftOperatingProfile.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) UpsertAircraftOperatingProfile(_ context.Context, profile domain.AircraftOperatingProfile) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -175,6 +279,15 @@ func (s *Store) UpsertAircraftOperatingProfile(_ context.Context, profile domain
 	return nil
 }
 
+// GetAircraftOperatingProfile returns the operating profile assigned to an aircraft.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to GetAircraftOperatingProfile.
+//   - aircraftID: identifies the target aircraft.
+//
+// Returns:
+//   - result: is the *domain.AircraftOperatingProfile value produced by GetAircraftOperatingProfile.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) GetAircraftOperatingProfile(_ context.Context, aircraftID string) (*domain.AircraftOperatingProfile, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -185,6 +298,15 @@ func (s *Store) GetAircraftOperatingProfile(_ context.Context, aircraftID string
 	return &profile, nil
 }
 
+// ListOperatingLimits returns Store records matching the supplied scope and filters.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to ListOperatingLimits.
+//   - aircraftID: identifies the target aircraft.
+//
+// Returns:
+//   - result: is the []domain.OperatingLimit value produced by ListOperatingLimits.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) ListOperatingLimits(_ context.Context, aircraftID string) ([]domain.OperatingLimit, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -198,6 +320,14 @@ func (s *Store) ListOperatingLimits(_ context.Context, aircraftID string) ([]dom
 	return limits, nil
 }
 
+// UpsertOperatingLimit creates or replaces the supplied Store record by identity.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to UpsertOperatingLimit.
+//   - limit: caps the number of records claimed or returned in one call.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) UpsertOperatingLimit(_ context.Context, limit domain.OperatingLimit) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -205,6 +335,14 @@ func (s *Store) UpsertOperatingLimit(_ context.Context, limit domain.OperatingLi
 	return nil
 }
 
+// RecordMaintenanceEvent durably records the supplied Store data.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to RecordMaintenanceEvent.
+//   - event: is the domain.MaintenanceEvent value supplied to RecordMaintenanceEvent.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) RecordMaintenanceEvent(_ context.Context, event domain.MaintenanceEvent) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -212,6 +350,15 @@ func (s *Store) RecordMaintenanceEvent(_ context.Context, event domain.Maintenan
 	return nil
 }
 
+// ListMaintenanceEvents returns Store records matching the supplied scope and filters.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to ListMaintenanceEvents.
+//   - aircraftID: identifies the target aircraft.
+//
+// Returns:
+//   - result: is the []domain.MaintenanceEvent value produced by ListMaintenanceEvents.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) ListMaintenanceEvents(_ context.Context, aircraftID string) ([]domain.MaintenanceEvent, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -225,6 +372,14 @@ func (s *Store) ListMaintenanceEvents(_ context.Context, aircraftID string) ([]d
 	return events, nil
 }
 
+// CreateOperationalIntent creates and stores the supplied Store record.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to CreateOperationalIntent.
+//   - intent: is the domain.OperationalIntent value supplied to CreateOperationalIntent.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) CreateOperationalIntent(_ context.Context, intent domain.OperationalIntent) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -237,6 +392,15 @@ func (s *Store) CreateOperationalIntent(_ context.Context, intent domain.Operati
 	return nil
 }
 
+// UpdateOperationalIntent updates the selected Store state while enforcing its consistency checks.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to UpdateOperationalIntent.
+//   - intent: is the domain.OperationalIntent value supplied to UpdateOperationalIntent.
+//   - expectedRevision: is the int64 value supplied to UpdateOperationalIntent.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) UpdateOperationalIntent(_ context.Context, intent domain.OperationalIntent, expectedRevision int64) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -269,6 +433,15 @@ func (s *Store) updateOperationalIntentLocked(intent domain.OperationalIntent, e
 	return nil
 }
 
+// AcceptOperationalIntent accepts the selected Store state after validating its current revision.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to AcceptOperationalIntent.
+//   - intent: is the domain.OperationalIntent value supplied to AcceptOperationalIntent.
+//   - expectedRevision: is the int64 value supplied to AcceptOperationalIntent.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) AcceptOperationalIntent(_ context.Context, intent domain.OperationalIntent, expectedRevision int64) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -298,6 +471,16 @@ func (s *Store) acceptOperationalIntentLocked(intent domain.OperationalIntent, e
 	return nil
 }
 
+// AcceptOperationalIntentAndRequestPublication accepts the selected Store state after validating its current revision.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to AcceptOperationalIntentAndRequestPublication.
+//   - intent: is the domain.OperationalIntent value supplied to AcceptOperationalIntentAndRequestPublication.
+//   - expectedRevision: is the int64 value supplied to AcceptOperationalIntentAndRequestPublication.
+//   - publication: is the domain.OperationalIntentPublication value supplied to AcceptOperationalIntentAndRequestPublication.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) AcceptOperationalIntentAndRequestPublication(_ context.Context, intent domain.OperationalIntent, expectedRevision int64, publication domain.OperationalIntentPublication) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -308,6 +491,16 @@ func (s *Store) AcceptOperationalIntentAndRequestPublication(_ context.Context, 
 	return nil
 }
 
+// UpdateOperationalIntentAndRequestPublication updates the selected Store state while enforcing its consistency checks.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to UpdateOperationalIntentAndRequestPublication.
+//   - intent: is the domain.OperationalIntent value supplied to UpdateOperationalIntentAndRequestPublication.
+//   - expectedRevision: is the int64 value supplied to UpdateOperationalIntentAndRequestPublication.
+//   - publication: is the domain.OperationalIntentPublication value supplied to UpdateOperationalIntentAndRequestPublication.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) UpdateOperationalIntentAndRequestPublication(_ context.Context, intent domain.OperationalIntent, expectedRevision int64, publication domain.OperationalIntentPublication) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -318,6 +511,14 @@ func (s *Store) UpdateOperationalIntentAndRequestPublication(_ context.Context, 
 	return nil
 }
 
+// RequestOperationalIntentPublication requests the selected Store operation and records it for processing.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to RequestOperationalIntentPublication.
+//   - publication: is the domain.OperationalIntentPublication value supplied to RequestOperationalIntentPublication.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) RequestOperationalIntentPublication(_ context.Context, publication domain.OperationalIntentPublication) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -328,6 +529,17 @@ func (s *Store) RequestOperationalIntentPublication(_ context.Context, publicati
 	return nil
 }
 
+// RequestOperationalIntentPublicationIfCurrent requests the selected Store operation and records it for processing.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to RequestOperationalIntentPublicationIfCurrent.
+//   - publication: is the domain.OperationalIntentPublication value supplied to RequestOperationalIntentPublicationIfCurrent.
+//   - expectedIntentVersion: is the int value supplied to RequestOperationalIntentPublicationIfCurrent.
+//   - expectedIntentRevision: is the int64 value supplied to RequestOperationalIntentPublicationIfCurrent.
+//   - expectedStatus: is the domain.IntentStatus value supplied to RequestOperationalIntentPublicationIfCurrent.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) RequestOperationalIntentPublicationIfCurrent(_ context.Context, publication domain.OperationalIntentPublication, expectedIntentVersion int, expectedIntentRevision int64, expectedStatus domain.IntentStatus) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -375,6 +587,15 @@ func (s *Store) requestPublicationLocked(request domain.OperationalIntentPublica
 	s.publications[request.IntentID] = clonePublication(request)
 }
 
+// GetOperationalIntentPublication returns the current DSS publication state for an intent.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to GetOperationalIntentPublication.
+//   - intentID: identifies the target intent.
+//
+// Returns:
+//   - result: is the domain.OperationalIntentPublication value produced by GetOperationalIntentPublication.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) GetOperationalIntentPublication(_ context.Context, intentID string) (domain.OperationalIntentPublication, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -385,6 +606,17 @@ func (s *Store) GetOperationalIntentPublication(_ context.Context, intentID stri
 	return clonePublication(publication), nil
 }
 
+// ClaimOperationalIntentPublication atomically leases eligible Store work to a worker.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to ClaimOperationalIntentPublication.
+//   - intentID: identifies the target intent.
+//   - now: supplies the event or wall-clock timestamp used by the operation.
+//   - leaseUntil: is the time.Time value supplied to ClaimOperationalIntentPublication.
+//
+// Returns:
+//   - result: is the domain.OperationalIntentPublication value produced by ClaimOperationalIntentPublication.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) ClaimOperationalIntentPublication(_ context.Context, intentID string, now, leaseUntil time.Time) (domain.OperationalIntentPublication, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -405,6 +637,17 @@ func (s *Store) ClaimOperationalIntentPublication(_ context.Context, intentID st
 	return clonePublication(publication), nil
 }
 
+// ClaimDueOperationalIntentPublications atomically leases eligible Store work to a worker.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to ClaimDueOperationalIntentPublications.
+//   - now: supplies the event or wall-clock timestamp used by the operation.
+//   - leaseUntil: is the time.Time value supplied to ClaimDueOperationalIntentPublications.
+//   - limit: caps the number of records claimed or returned in one call.
+//
+// Returns:
+//   - result: is the []domain.OperationalIntentPublication value produced by ClaimDueOperationalIntentPublications.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) ClaimDueOperationalIntentPublications(_ context.Context, now, leaseUntil time.Time, limit int) ([]domain.OperationalIntentPublication, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -442,6 +685,16 @@ func (s *Store) ClaimDueOperationalIntentPublications(_ context.Context, now, le
 	return claimed, nil
 }
 
+// RenewOperationalIntentPublicationLease extends the selected Store lease when the caller still owns its fence.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to RenewOperationalIntentPublicationLease.
+//   - intentID: identifies the target intent.
+//   - expectedRevision: is the int64 value supplied to RenewOperationalIntentPublicationLease.
+//   - leaseUntil: is the time.Time value supplied to RenewOperationalIntentPublicationLease.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) RenewOperationalIntentPublicationLease(_ context.Context, intentID string, expectedRevision int64, leaseUntil time.Time) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -457,6 +710,15 @@ func (s *Store) RenewOperationalIntentPublicationLease(_ context.Context, intent
 	return nil
 }
 
+// UpdateOperationalIntentPublication updates the selected Store state while enforcing its consistency checks.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to UpdateOperationalIntentPublication.
+//   - publication: is the domain.OperationalIntentPublication value supplied to UpdateOperationalIntentPublication.
+//   - expectedRevision: is the int64 value supplied to UpdateOperationalIntentPublication.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) UpdateOperationalIntentPublication(_ context.Context, publication domain.OperationalIntentPublication, expectedRevision int64) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -473,6 +735,16 @@ func (s *Store) UpdateOperationalIntentPublication(_ context.Context, publicatio
 	return nil
 }
 
+// ConfirmOperationalIntentPublication confirms the selected Store transition and records its durable outcome.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to ConfirmOperationalIntentPublication.
+//   - publication: is the domain.OperationalIntentPublication value supplied to ConfirmOperationalIntentPublication.
+//   - expectedRevision: is the int64 value supplied to ConfirmOperationalIntentPublication.
+//   - notifications: is the []domain.PeerNotification value supplied to ConfirmOperationalIntentPublication.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) ConfirmOperationalIntentPublication(_ context.Context, publication domain.OperationalIntentPublication, expectedRevision int64, notifications []domain.PeerNotification) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -502,6 +774,17 @@ func (s *Store) enqueuePeerNotificationsLocked(notifications []domain.PeerNotifi
 	}
 }
 
+// ClaimDuePeerNotifications atomically leases eligible Store work to a worker.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to ClaimDuePeerNotifications.
+//   - now: supplies the event or wall-clock timestamp used by the operation.
+//   - leaseUntil: is the time.Time value supplied to ClaimDuePeerNotifications.
+//   - limit: caps the number of records claimed or returned in one call.
+//
+// Returns:
+//   - result: is the []domain.PeerNotification value produced by ClaimDuePeerNotifications.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) ClaimDuePeerNotifications(_ context.Context, now, leaseUntil time.Time, limit int) ([]domain.PeerNotification, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -528,6 +811,15 @@ func (s *Store) ClaimDuePeerNotifications(_ context.Context, now, leaseUntil tim
 	return claimed, nil
 }
 
+// UpdatePeerNotification updates the selected Store state while enforcing its consistency checks.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to UpdatePeerNotification.
+//   - notification: is the domain.PeerNotification value supplied to UpdatePeerNotification.
+//   - expectedRevision: is the int64 value supplied to UpdatePeerNotification.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) UpdatePeerNotification(_ context.Context, notification domain.PeerNotification, expectedRevision int64) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -544,6 +836,14 @@ func (s *Store) UpdatePeerNotification(_ context.Context, notification domain.Pe
 	return nil
 }
 
+// RecordReceivedPeerNotification durably records the supplied Store data.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to RecordReceivedPeerNotification.
+//   - notification: is the domain.ReceivedPeerNotification value supplied to RecordReceivedPeerNotification.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) RecordReceivedPeerNotification(_ context.Context, notification domain.ReceivedPeerNotification) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -553,6 +853,15 @@ func (s *Store) RecordReceivedPeerNotification(_ context.Context, notification d
 	return nil
 }
 
+// ListReceivedPeerNotifications returns Store records matching the supplied scope and filters.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to ListReceivedPeerNotifications.
+//   - intentID: identifies the target intent.
+//
+// Returns:
+//   - result: is the []domain.ReceivedPeerNotification value produced by ListReceivedPeerNotifications.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) ListReceivedPeerNotifications(_ context.Context, intentID string) ([]domain.ReceivedPeerNotification, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -573,6 +882,15 @@ func clonePublication(publication domain.OperationalIntentPublication) domain.Op
 	return publication
 }
 
+// GetOperationalIntent returns the current version of one operational intent.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to GetOperationalIntent.
+//   - intentID: identifies the target intent.
+//
+// Returns:
+//   - result: is the domain.OperationalIntent value produced by GetOperationalIntent.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) GetOperationalIntent(_ context.Context, intentID string) (domain.OperationalIntent, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -583,6 +901,16 @@ func (s *Store) GetOperationalIntent(_ context.Context, intentID string) (domain
 	return intent, nil
 }
 
+// GetOperationalIntentVersion returns one immutable historical intent version.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to GetOperationalIntentVersion.
+//   - intentID: identifies the target intent.
+//   - version: is the int value supplied to GetOperationalIntentVersion.
+//
+// Returns:
+//   - result: is the domain.OperationalIntent value produced by GetOperationalIntentVersion.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) GetOperationalIntentVersion(_ context.Context, intentID string, version int) (domain.OperationalIntent, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -593,6 +921,15 @@ func (s *Store) GetOperationalIntentVersion(_ context.Context, intentID string, 
 	return intent, nil
 }
 
+// ListOperationalIntents returns Store records matching the supplied scope and filters.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to ListOperationalIntents.
+//   - aircraftID: identifies the target aircraft.
+//
+// Returns:
+//   - result: is the []domain.OperationalIntent value produced by ListOperationalIntents.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) ListOperationalIntents(_ context.Context, aircraftID string) ([]domain.OperationalIntent, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -613,6 +950,15 @@ func (s *Store) ListOperationalIntents(_ context.Context, aircraftID string) ([]
 	return intents, nil
 }
 
+// ListOperationalIntentVersions returns Store records matching the supplied scope and filters.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to ListOperationalIntentVersions.
+//   - intentID: identifies the target intent.
+//
+// Returns:
+//   - result: is the []domain.OperationalIntent value produced by ListOperationalIntentVersions.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) ListOperationalIntentVersions(_ context.Context, intentID string) ([]domain.OperationalIntent, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -631,6 +977,14 @@ func (s *Store) ListOperationalIntentVersions(_ context.Context, intentID string
 	return intents, nil
 }
 
+// RecordOperationalVolume durably records the supplied Store data.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to RecordOperationalVolume.
+//   - volume: is the domain.OperationalVolume value supplied to RecordOperationalVolume.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) RecordOperationalVolume(_ context.Context, volume domain.OperationalVolume) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -638,6 +992,16 @@ func (s *Store) RecordOperationalVolume(_ context.Context, volume domain.Operati
 	return nil
 }
 
+// ReplaceOperationalVolumes atomically replaces the selected Store records.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to ReplaceOperationalVolumes.
+//   - intentID: identifies the target intent.
+//   - intentVersion: is the int value supplied to ReplaceOperationalVolumes.
+//   - volumes: is the []domain.OperationalVolume value supplied to ReplaceOperationalVolumes.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) ReplaceOperationalVolumes(_ context.Context, intentID string, intentVersion int, volumes []domain.OperationalVolume) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -657,6 +1021,17 @@ func (s *Store) ReplaceOperationalVolumes(_ context.Context, intentID string, in
 	return nil
 }
 
+// ReplaceOperationalIntent atomically replaces the selected Store records.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to ReplaceOperationalIntent.
+//   - expectedVersion: is the int value supplied to ReplaceOperationalIntent.
+//   - expectedRevision: is the int64 value supplied to ReplaceOperationalIntent.
+//   - intent: is the domain.OperationalIntent value supplied to ReplaceOperationalIntent.
+//   - volumes: is the []domain.OperationalVolume value supplied to ReplaceOperationalIntent.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) ReplaceOperationalIntent(
 	_ context.Context,
 	expectedVersion int,
@@ -701,6 +1076,15 @@ func (s *Store) ReplaceOperationalIntent(
 	return nil
 }
 
+// ListOperationalVolumes returns Store records matching the supplied scope and filters.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to ListOperationalVolumes.
+//   - intentID: identifies the target intent.
+//
+// Returns:
+//   - result: is the []domain.OperationalVolume value produced by ListOperationalVolumes.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) ListOperationalVolumes(_ context.Context, intentID string) ([]domain.OperationalVolume, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -746,6 +1130,14 @@ func (s *Store) latestOperationalIntent(intentID string) (domain.OperationalInte
 	return latest, ok
 }
 
+// UpsertRegulatoryAuthorization creates or replaces the supplied Store record by identity.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to UpsertRegulatoryAuthorization.
+//   - authorization: is the domain.RegulatoryAuthorization value supplied to UpsertRegulatoryAuthorization.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) UpsertRegulatoryAuthorization(_ context.Context, authorization domain.RegulatoryAuthorization) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -753,6 +1145,15 @@ func (s *Store) UpsertRegulatoryAuthorization(_ context.Context, authorization d
 	return nil
 }
 
+// GetRegulatoryAuthorization returns one regulatory authorization by identity.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to GetRegulatoryAuthorization.
+//   - authorizationID: identifies the target authorization.
+//
+// Returns:
+//   - result: is the domain.RegulatoryAuthorization value produced by GetRegulatoryAuthorization.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) GetRegulatoryAuthorization(_ context.Context, authorizationID string) (domain.RegulatoryAuthorization, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -763,6 +1164,15 @@ func (s *Store) GetRegulatoryAuthorization(_ context.Context, authorizationID st
 	return authorization, nil
 }
 
+// ListRegulatoryAuthorizations returns Store records matching the supplied scope and filters.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to ListRegulatoryAuthorizations.
+//   - operatorID: identifies the target operator.
+//
+// Returns:
+//   - result: is the []domain.RegulatoryAuthorization value produced by ListRegulatoryAuthorizations.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) ListRegulatoryAuthorizations(_ context.Context, operatorID string) ([]domain.RegulatoryAuthorization, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -778,6 +1188,14 @@ func (s *Store) ListRegulatoryAuthorizations(_ context.Context, operatorID strin
 	return authorizations, nil
 }
 
+// RecordPreflightCheck durably records the supplied Store data.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to RecordPreflightCheck.
+//   - check: is the domain.PreflightCheck value supplied to RecordPreflightCheck.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) RecordPreflightCheck(_ context.Context, check domain.PreflightCheck) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -791,6 +1209,15 @@ func (s *Store) RecordPreflightCheck(_ context.Context, check domain.PreflightCh
 	return nil
 }
 
+// ListPreflightChecks returns Store records matching the supplied scope and filters.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to ListPreflightChecks.
+//   - intentID: identifies the target intent.
+//
+// Returns:
+//   - result: is the []domain.PreflightCheck value produced by ListPreflightChecks.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) ListPreflightChecks(_ context.Context, intentID string) ([]domain.PreflightCheck, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -804,6 +1231,14 @@ func (s *Store) ListPreflightChecks(_ context.Context, intentID string) ([]domai
 	return checks, nil
 }
 
+// CreateFlightRecord creates and stores the supplied Store record.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to CreateFlightRecord.
+//   - flight: is the domain.FlightRecord value supplied to CreateFlightRecord.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) CreateFlightRecord(_ context.Context, flight domain.FlightRecord) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -811,6 +1246,15 @@ func (s *Store) CreateFlightRecord(_ context.Context, flight domain.FlightRecord
 	return nil
 }
 
+// GetFlightRecord returns one durable flight record by identity.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to GetFlightRecord.
+//   - flightID: identifies the target flight.
+//
+// Returns:
+//   - result: is the domain.FlightRecord value produced by GetFlightRecord.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) GetFlightRecord(_ context.Context, flightID string) (domain.FlightRecord, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -821,6 +1265,15 @@ func (s *Store) GetFlightRecord(_ context.Context, flightID string) (domain.Flig
 	return flight, nil
 }
 
+// ListFlightRecords returns Store records matching the supplied scope and filters.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to ListFlightRecords.
+//   - aircraftID: identifies the target aircraft.
+//
+// Returns:
+//   - result: is the []domain.FlightRecord value produced by ListFlightRecords.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) ListFlightRecords(_ context.Context, aircraftID string) ([]domain.FlightRecord, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -834,6 +1287,14 @@ func (s *Store) ListFlightRecords(_ context.Context, aircraftID string) ([]domai
 	return flights, nil
 }
 
+// RecordConformanceEvent durably records the supplied Store data.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to RecordConformanceEvent.
+//   - event: is the domain.ConformanceEvent value supplied to RecordConformanceEvent.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) RecordConformanceEvent(_ context.Context, event domain.ConformanceEvent) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -847,6 +1308,15 @@ func (s *Store) RecordConformanceEvent(_ context.Context, event domain.Conforman
 	return nil
 }
 
+// ListConformanceEvents returns Store records matching the supplied scope and filters.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to ListConformanceEvents.
+//   - flightID: identifies the target flight.
+//
+// Returns:
+//   - result: is the []domain.ConformanceEvent value produced by ListConformanceEvents.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) ListConformanceEvents(_ context.Context, flightID string) ([]domain.ConformanceEvent, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -860,6 +1330,14 @@ func (s *Store) ListConformanceEvents(_ context.Context, flightID string) ([]dom
 	return events, nil
 }
 
+// UpsertConformanceSummary creates or replaces the supplied Store record by identity.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to UpsertConformanceSummary.
+//   - summary: is the domain.ConformanceSummary value supplied to UpsertConformanceSummary.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) UpsertConformanceSummary(_ context.Context, summary domain.ConformanceSummary) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -867,6 +1345,15 @@ func (s *Store) UpsertConformanceSummary(_ context.Context, summary domain.Confo
 	return nil
 }
 
+// GetConformanceSummary returns the current conformance projection for an intent.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to GetConformanceSummary.
+//   - intentID: identifies the target intent.
+//
+// Returns:
+//   - result: is the *domain.ConformanceSummary value produced by GetConformanceSummary.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) GetConformanceSummary(_ context.Context, intentID string) (*domain.ConformanceSummary, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -885,6 +1372,15 @@ func (s *Store) GetConformanceSummary(_ context.Context, intentID string) (*doma
 	return selected, nil
 }
 
+// ListConformanceSummaries returns Store records matching the supplied scope and filters.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to ListConformanceSummaries.
+//   - intentID: identifies the target intent.
+//
+// Returns:
+//   - result: is the []domain.ConformanceSummary value produced by ListConformanceSummaries.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) ListConformanceSummaries(_ context.Context, intentID string) ([]domain.ConformanceSummary, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -898,6 +1394,14 @@ func (s *Store) ListConformanceSummaries(_ context.Context, intentID string) ([]
 	return summaries, nil
 }
 
+// RecordEvidence durably records the supplied Store data.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to RecordEvidence.
+//   - record: is the domain.EvidenceRecord value supplied to RecordEvidence.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) RecordEvidence(_ context.Context, record domain.EvidenceRecord) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -905,6 +1409,15 @@ func (s *Store) RecordEvidence(_ context.Context, record domain.EvidenceRecord) 
 	return nil
 }
 
+// ListEvidence returns Store records matching the supplied scope and filters.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to ListEvidence.
+//   - intentID: identifies the target intent.
+//
+// Returns:
+//   - result: is the []domain.EvidenceRecord value produced by ListEvidence.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) ListEvidence(_ context.Context, intentID string) ([]domain.EvidenceRecord, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -918,6 +1431,14 @@ func (s *Store) ListEvidence(_ context.Context, intentID string) ([]domain.Evide
 	return records, nil
 }
 
+// RecordReportabilityReview durably records the supplied Store data.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to RecordReportabilityReview.
+//   - review: is the domain.ReportabilityReview value supplied to RecordReportabilityReview.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) RecordReportabilityReview(_ context.Context, review domain.ReportabilityReview) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -925,6 +1446,15 @@ func (s *Store) RecordReportabilityReview(_ context.Context, review domain.Repor
 	return nil
 }
 
+// ListReportabilityReviews returns Store records matching the supplied scope and filters.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to ListReportabilityReviews.
+//   - intentID: identifies the target intent.
+//
+// Returns:
+//   - result: is the []domain.ReportabilityReview value produced by ListReportabilityReviews.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) ListReportabilityReviews(_ context.Context, intentID string) ([]domain.ReportabilityReview, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -938,6 +1468,14 @@ func (s *Store) ListReportabilityReviews(_ context.Context, intentID string) ([]
 	return reviews, nil
 }
 
+// RecordComplianceFinding durably records the supplied Store data.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to RecordComplianceFinding.
+//   - finding: is the domain.ComplianceFinding value supplied to RecordComplianceFinding.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) RecordComplianceFinding(_ context.Context, finding domain.ComplianceFinding) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -951,6 +1489,16 @@ func (s *Store) RecordComplianceFinding(_ context.Context, finding domain.Compli
 	return nil
 }
 
+// ListComplianceFindings returns Store records matching the supplied scope and filters.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to ListComplianceFindings.
+//   - subjectType: is the string value supplied to ListComplianceFindings.
+//   - subjectID: identifies the target subject.
+//
+// Returns:
+//   - result: is the []domain.ComplianceFinding value produced by ListComplianceFindings.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) ListComplianceFindings(_ context.Context, subjectType string, subjectID string) ([]domain.ComplianceFinding, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -968,6 +1516,15 @@ func (s *Store) ListComplianceFindings(_ context.Context, subjectType string, su
 	return findings, nil
 }
 
+// ListComplianceFindingsForIntent returns Store records matching the supplied scope and filters.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to ListComplianceFindingsForIntent.
+//   - intentID: identifies the target intent.
+//
+// Returns:
+//   - result: is the []domain.ComplianceFinding value produced by ListComplianceFindingsForIntent.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) ListComplianceFindingsForIntent(_ context.Context, intentID string) ([]domain.ComplianceFinding, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -981,6 +1538,14 @@ func (s *Store) ListComplianceFindingsForIntent(_ context.Context, intentID stri
 	return findings, nil
 }
 
+// RecordConflictFinding durably records the supplied Store data.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to RecordConflictFinding.
+//   - finding: is the domain.ConflictFinding value supplied to RecordConflictFinding.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) RecordConflictFinding(_ context.Context, finding domain.ConflictFinding) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -994,6 +1559,16 @@ func (s *Store) RecordConflictFinding(_ context.Context, finding domain.Conflict
 	return nil
 }
 
+// ListConflictFindings returns Store records matching the supplied scope and filters.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to ListConflictFindings.
+//   - intentID: identifies the target intent.
+//   - intentVersion: is the int value supplied to ListConflictFindings.
+//
+// Returns:
+//   - result: is the []domain.ConflictFinding value produced by ListConflictFindings.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) ListConflictFindings(_ context.Context, intentID string, intentVersion int) ([]domain.ConflictFinding, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -1016,6 +1591,17 @@ func (s *Store) ListConflictFindings(_ context.Context, intentID string, intentV
 	return findings, nil
 }
 
+// ReplaceConflictFindings atomically replaces the selected Store records.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to ReplaceConflictFindings.
+//   - intentID: identifies the target intent.
+//   - intentVersion: is the int value supplied to ReplaceConflictFindings.
+//   - ruleVersion: is the string value supplied to ReplaceConflictFindings.
+//   - findings: is the []domain.ConflictFinding value supplied to ReplaceConflictFindings.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) ReplaceConflictFindings(_ context.Context, intentID string, intentVersion int, ruleVersion string, findings []domain.ConflictFinding) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -1035,6 +1621,14 @@ func (s *Store) ReplaceConflictFindings(_ context.Context, intentID string, inte
 	return nil
 }
 
+// UpsertOperationsPersonnel creates or replaces the supplied Store record by identity.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to UpsertOperationsPersonnel.
+//   - person: is the domain.OperationsPersonnel value supplied to UpsertOperationsPersonnel.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) UpsertOperationsPersonnel(_ context.Context, person domain.OperationsPersonnel) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -1042,6 +1636,15 @@ func (s *Store) UpsertOperationsPersonnel(_ context.Context, person domain.Opera
 	return nil
 }
 
+// GetOperationsPersonnel returns one operations-personnel record by identity.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to GetOperationsPersonnel.
+//   - personID: identifies the target person.
+//
+// Returns:
+//   - result: is the domain.OperationsPersonnel value produced by GetOperationsPersonnel.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) GetOperationsPersonnel(_ context.Context, personID string) (domain.OperationsPersonnel, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -1052,6 +1655,14 @@ func (s *Store) GetOperationsPersonnel(_ context.Context, personID string) (doma
 	return person, nil
 }
 
+// RecordPersonnelAssignment durably records the supplied Store data.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to RecordPersonnelAssignment.
+//   - assignment: is the domain.PersonnelAssignment value supplied to RecordPersonnelAssignment.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) RecordPersonnelAssignment(_ context.Context, assignment domain.PersonnelAssignment) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -1059,6 +1670,15 @@ func (s *Store) RecordPersonnelAssignment(_ context.Context, assignment domain.P
 	return nil
 }
 
+// ListPersonnelAssignments returns Store records matching the supplied scope and filters.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to ListPersonnelAssignments.
+//   - intentID: identifies the target intent.
+//
+// Returns:
+//   - result: is the []domain.PersonnelAssignment value produced by ListPersonnelAssignments.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) ListPersonnelAssignments(_ context.Context, intentID string) ([]domain.PersonnelAssignment, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()

--- a/internal/store/durable/postgres/publication.go
+++ b/internal/store/durable/postgres/publication.go
@@ -12,6 +12,16 @@ import (
 	"github.com/jackc/pgx/v5"
 )
 
+// AcceptOperationalIntentAndRequestPublication accepts the selected Store state after validating its current revision.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - intent: is the domain.OperationalIntent value supplied to AcceptOperationalIntentAndRequestPublication.
+//   - expectedRevision: is the int64 value supplied to AcceptOperationalIntentAndRequestPublication.
+//   - publication: is the domain.OperationalIntentPublication value supplied to AcceptOperationalIntentAndRequestPublication.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) AcceptOperationalIntentAndRequestPublication(ctx context.Context, intent domain.OperationalIntent, expectedRevision int64, publication domain.OperationalIntentPublication) error {
 	tx, err := s.pool.Begin(ctx)
 	if err != nil {
@@ -33,6 +43,16 @@ func (s *Store) AcceptOperationalIntentAndRequestPublication(ctx context.Context
 	return nil
 }
 
+// UpdateOperationalIntentAndRequestPublication updates the selected Store state while enforcing its consistency checks.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - intent: is the domain.OperationalIntent value supplied to UpdateOperationalIntentAndRequestPublication.
+//   - expectedRevision: is the int64 value supplied to UpdateOperationalIntentAndRequestPublication.
+//   - publication: is the domain.OperationalIntentPublication value supplied to UpdateOperationalIntentAndRequestPublication.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) UpdateOperationalIntentAndRequestPublication(ctx context.Context, intent domain.OperationalIntent, expectedRevision int64, publication domain.OperationalIntentPublication) error {
 	tx, err := s.pool.Begin(ctx)
 	if err != nil {
@@ -54,6 +74,14 @@ func (s *Store) UpdateOperationalIntentAndRequestPublication(ctx context.Context
 	return nil
 }
 
+// RequestOperationalIntentPublication requests the selected Store operation and records it for processing.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - publication: is the domain.OperationalIntentPublication value supplied to RequestOperationalIntentPublication.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) RequestOperationalIntentPublication(ctx context.Context, publication domain.OperationalIntentPublication) error {
 	tx, err := s.pool.Begin(ctx)
 	if err != nil {
@@ -72,6 +100,17 @@ func (s *Store) RequestOperationalIntentPublication(ctx context.Context, publica
 	return nil
 }
 
+// RequestOperationalIntentPublicationIfCurrent requests the selected Store operation and records it for processing.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - publication: is the domain.OperationalIntentPublication value supplied to RequestOperationalIntentPublicationIfCurrent.
+//   - expectedIntentVersion: is the int value supplied to RequestOperationalIntentPublicationIfCurrent.
+//   - expectedIntentRevision: is the int64 value supplied to RequestOperationalIntentPublicationIfCurrent.
+//   - expectedStatus: is the domain.IntentStatus value supplied to RequestOperationalIntentPublicationIfCurrent.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) RequestOperationalIntentPublicationIfCurrent(ctx context.Context, publication domain.OperationalIntentPublication, expectedIntentVersion int, expectedIntentRevision int64, expectedStatus domain.IntentStatus) error {
 	tx, err := s.pool.Begin(ctx)
 	if err != nil {
@@ -143,10 +182,30 @@ func requestPublicationTx(ctx context.Context, tx pgx.Tx, request domain.Operati
 	return writePublication(ctx, tx, request)
 }
 
+// GetOperationalIntentPublication returns the durable DSS publication state for one intent.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - intentID: identifies the target intent.
+//
+// Returns:
+//   - result: is the domain.OperationalIntentPublication value produced by GetOperationalIntentPublication.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) GetOperationalIntentPublication(ctx context.Context, intentID string) (domain.OperationalIntentPublication, error) {
 	return scanPublication(s.pool.QueryRow(ctx, `SELECT data, revision FROM operational_intent_publications WHERE intent_id = $1`, intentID))
 }
 
+// ClaimOperationalIntentPublication atomically leases eligible Store work to a worker.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - intentID: identifies the target intent.
+//   - now: supplies the event or wall-clock timestamp used by the operation.
+//   - leaseUntil: is the time.Time value supplied to ClaimOperationalIntentPublication.
+//
+// Returns:
+//   - result: is the domain.OperationalIntentPublication value produced by ClaimOperationalIntentPublication.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) ClaimOperationalIntentPublication(ctx context.Context, intentID string, now, leaseUntil time.Time) (domain.OperationalIntentPublication, error) {
 	tx, err := s.pool.Begin(ctx)
 	if err != nil {
@@ -170,6 +229,17 @@ func (s *Store) ClaimOperationalIntentPublication(ctx context.Context, intentID 
 	return publication, nil
 }
 
+// ClaimDueOperationalIntentPublications atomically leases eligible Store work to a worker.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - now: supplies the event or wall-clock timestamp used by the operation.
+//   - leaseUntil: is the time.Time value supplied to ClaimDueOperationalIntentPublications.
+//   - limit: caps the number of records claimed or returned in one call.
+//
+// Returns:
+//   - result: is the []domain.OperationalIntentPublication value produced by ClaimDueOperationalIntentPublications.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) ClaimDueOperationalIntentPublications(ctx context.Context, now, leaseUntil time.Time, limit int) ([]domain.OperationalIntentPublication, error) {
 	if limit <= 0 {
 		return []domain.OperationalIntentPublication{}, nil
@@ -214,6 +284,16 @@ func claimPublication(publication *domain.OperationalIntentPublication, now, lea
 	publication.UpdatedAt = now
 }
 
+// RenewOperationalIntentPublicationLease extends the selected Store lease when the caller still owns its fence.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - intentID: identifies the target intent.
+//   - expectedRevision: is the int64 value supplied to RenewOperationalIntentPublicationLease.
+//   - leaseUntil: is the time.Time value supplied to RenewOperationalIntentPublicationLease.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) RenewOperationalIntentPublicationLease(ctx context.Context, intentID string, expectedRevision int64, leaseUntil time.Time) error {
 	rawLease, err := json.Marshal(leaseUntil)
 	if err != nil {
@@ -233,6 +313,15 @@ func (s *Store) RenewOperationalIntentPublicationLease(ctx context.Context, inte
 	return nil
 }
 
+// UpdateOperationalIntentPublication updates the selected Store state while enforcing its consistency checks.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - publication: is the domain.OperationalIntentPublication value supplied to UpdateOperationalIntentPublication.
+//   - expectedRevision: is the int64 value supplied to UpdateOperationalIntentPublication.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) UpdateOperationalIntentPublication(ctx context.Context, publication domain.OperationalIntentPublication, expectedRevision int64) error {
 	return updateOperationalIntentPublication(ctx, s.pool, publication, expectedRevision)
 }
@@ -263,6 +352,16 @@ func updateOperationalIntentPublication(ctx context.Context, db querier, publica
 	return nil
 }
 
+// ConfirmOperationalIntentPublication confirms the selected Store transition and records its durable outcome.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - publication: is the domain.OperationalIntentPublication value supplied to ConfirmOperationalIntentPublication.
+//   - expectedRevision: is the int64 value supplied to ConfirmOperationalIntentPublication.
+//   - notifications: is the []domain.PeerNotification value supplied to ConfirmOperationalIntentPublication.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) ConfirmOperationalIntentPublication(ctx context.Context, publication domain.OperationalIntentPublication, expectedRevision int64, notifications []domain.PeerNotification) error {
 	tx, err := s.pool.Begin(ctx)
 	if err != nil {
@@ -299,6 +398,17 @@ func enqueuePeerNotifications(ctx context.Context, db querier, notifications []d
 	return nil
 }
 
+// ClaimDuePeerNotifications atomically leases eligible Store work to a worker.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - now: supplies the event or wall-clock timestamp used by the operation.
+//   - leaseUntil: is the time.Time value supplied to ClaimDuePeerNotifications.
+//   - limit: caps the number of records claimed or returned in one call.
+//
+// Returns:
+//   - result: is the []domain.PeerNotification value produced by ClaimDuePeerNotifications.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) ClaimDuePeerNotifications(ctx context.Context, now, leaseUntil time.Time, limit int) ([]domain.PeerNotification, error) {
 	if limit <= 0 {
 		return []domain.PeerNotification{}, nil
@@ -335,6 +445,15 @@ func (s *Store) ClaimDuePeerNotifications(ctx context.Context, now, leaseUntil t
 	return notifications, nil
 }
 
+// UpdatePeerNotification updates the selected Store state while enforcing its consistency checks.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - notification: is the domain.PeerNotification value supplied to UpdatePeerNotification.
+//   - expectedRevision: is the int64 value supplied to UpdatePeerNotification.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) UpdatePeerNotification(ctx context.Context, notification domain.PeerNotification, expectedRevision int64) error {
 	notification.Revision = expectedRevision + 1
 	notification.LeaseUntil = nil
@@ -393,6 +512,14 @@ func readPeerNotifications(rows pgx.Rows) ([]domain.PeerNotification, error) {
 	return notifications, nil
 }
 
+// RecordReceivedPeerNotification durably records the supplied Store data.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - notification: is the domain.ReceivedPeerNotification value supplied to RecordReceivedPeerNotification.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) RecordReceivedPeerNotification(ctx context.Context, notification domain.ReceivedPeerNotification) error {
 	raw, err := json.Marshal(notification)
 	if err != nil {
@@ -408,6 +535,15 @@ func (s *Store) RecordReceivedPeerNotification(ctx context.Context, notification
 	return nil
 }
 
+// ListReceivedPeerNotifications returns Store records matching the supplied scope and filters.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - intentID: identifies the target intent.
+//
+// Returns:
+//   - result: is the []domain.ReceivedPeerNotification value produced by ListReceivedPeerNotifications.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) ListReceivedPeerNotifications(ctx context.Context, intentID string) ([]domain.ReceivedPeerNotification, error) {
 	rows, err := s.pool.Query(ctx, `
 		SELECT data FROM received_peer_notifications

--- a/internal/store/durable/postgres/store.go
+++ b/internal/store/durable/postgres/store.go
@@ -30,6 +30,15 @@ type Store struct {
 
 var _ durable.OperationalStore = (*Store)(nil)
 
+// Open opens postgres and initializes the resources required for use.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - databaseURL: is the string value supplied to Open.
+//
+// Returns:
+//   - result: is the *Store value produced by Open.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func Open(ctx context.Context, databaseURL string) (*Store, error) {
 	if strings.TrimSpace(databaseURL) == "" {
 		return nil, fmt.Errorf("PostgreSQL database URL is required")
@@ -49,8 +58,17 @@ func Open(ctx context.Context, databaseURL string) (*Store, error) {
 	return &Store{Store: durablememory.NewStore(), pool: pool}, nil
 }
 
+// Close releases resources owned by Store and completes any required shutdown work.
 func (s *Store) Close() { s.pool.Close() }
 
+// CreateOperationalIntent creates and stores the supplied Store record.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - intent: is the domain.OperationalIntent value supplied to CreateOperationalIntent.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) CreateOperationalIntent(ctx context.Context, intent domain.OperationalIntent) error {
 	intent.Revision = 0
 	raw, err := json.Marshal(intent)
@@ -72,6 +90,15 @@ func (s *Store) CreateOperationalIntent(ctx context.Context, intent domain.Opera
 	return fmt.Errorf("create operational intent: %w", err)
 }
 
+// UpdateOperationalIntent updates the selected Store state while enforcing its consistency checks.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - intent: is the domain.OperationalIntent value supplied to UpdateOperationalIntent.
+//   - expectedRevision: is the int64 value supplied to UpdateOperationalIntent.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) UpdateOperationalIntent(ctx context.Context, intent domain.OperationalIntent, expectedRevision int64) error {
 	tx, err := s.pool.Begin(ctx)
 	if err != nil {
@@ -156,6 +183,15 @@ func retirePriorAcceptedIntentsTx(ctx context.Context, tx pgx.Tx, terminal domai
 	return nil
 }
 
+// AcceptOperationalIntent accepts the selected Store state after validating its current revision.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - intent: is the domain.OperationalIntent value supplied to AcceptOperationalIntent.
+//   - expectedRevision: is the int64 value supplied to AcceptOperationalIntent.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) AcceptOperationalIntent(ctx context.Context, intent domain.OperationalIntent, expectedRevision int64) error {
 	tx, err := s.pool.Begin(ctx)
 	if err != nil {
@@ -213,14 +249,42 @@ func acceptOperationalIntentTx(ctx context.Context, tx pgx.Tx, intent domain.Ope
 	return nil
 }
 
+// GetOperationalIntent returns the current durable version of one operational intent.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - id: identifies the target record.
+//
+// Returns:
+//   - result: is the domain.OperationalIntent value produced by GetOperationalIntent.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) GetOperationalIntent(ctx context.Context, id string) (domain.OperationalIntent, error) {
 	return scanIntent(s.pool.QueryRow(ctx, `SELECT data, revision FROM operational_intents WHERE id = $1 ORDER BY version DESC, updated_at DESC LIMIT 1`, id))
 }
 
+// GetOperationalIntentVersion returns one immutable historical intent version.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - id: identifies the target record.
+//   - version: is the int value supplied to GetOperationalIntentVersion.
+//
+// Returns:
+//   - result: is the domain.OperationalIntent value produced by GetOperationalIntentVersion.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) GetOperationalIntentVersion(ctx context.Context, id string, version int) (domain.OperationalIntent, error) {
 	return scanIntent(s.pool.QueryRow(ctx, `SELECT data, revision FROM operational_intents WHERE id = $1 AND version = $2`, id, version))
 }
 
+// ListOperationalIntents returns Store records matching the supplied scope and filters.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - aircraftID: identifies the target aircraft.
+//
+// Returns:
+//   - result: is the []domain.OperationalIntent value produced by ListOperationalIntents.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) ListOperationalIntents(ctx context.Context, aircraftID string) ([]domain.OperationalIntent, error) {
 	rows, err := s.pool.Query(ctx, `
 			SELECT DISTINCT ON (id) data, revision
@@ -238,6 +302,15 @@ func (s *Store) ListOperationalIntents(ctx context.Context, aircraftID string) (
 	return intents, nil
 }
 
+// ListOperationalIntentVersions returns Store records matching the supplied scope and filters.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - id: identifies the target record.
+//
+// Returns:
+//   - result: is the []domain.OperationalIntent value produced by ListOperationalIntentVersions.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) ListOperationalIntentVersions(ctx context.Context, id string) ([]domain.OperationalIntent, error) {
 	rows, err := s.pool.Query(ctx, `SELECT data, revision FROM operational_intents WHERE id = $1 ORDER BY version, updated_at`, id)
 	if err != nil {
@@ -246,6 +319,14 @@ func (s *Store) ListOperationalIntentVersions(ctx context.Context, id string) ([
 	return readIntents(rows)
 }
 
+// RecordOperationalVolume durably records the supplied Store data.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - volume: is the domain.OperationalVolume value supplied to RecordOperationalVolume.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) RecordOperationalVolume(ctx context.Context, volume domain.OperationalVolume) error {
 	tx, err := s.pool.Begin(ctx)
 	if err != nil {
@@ -264,6 +345,16 @@ func (s *Store) RecordOperationalVolume(ctx context.Context, volume domain.Opera
 	return nil
 }
 
+// ReplaceOperationalVolumes atomically replaces the selected Store records.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - id: identifies the target record.
+//   - version: is the int value supplied to ReplaceOperationalVolumes.
+//   - volumes: is the []domain.OperationalVolume value supplied to ReplaceOperationalVolumes.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) ReplaceOperationalVolumes(ctx context.Context, id string, version int, volumes []domain.OperationalVolume) error {
 	if err := validateVolumeScope(id, version, volumes); err != nil {
 		return err
@@ -285,6 +376,17 @@ func (s *Store) ReplaceOperationalVolumes(ctx context.Context, id string, versio
 	return nil
 }
 
+// ReplaceOperationalIntent atomically replaces the selected Store records.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - expectedVersion: is the int value supplied to ReplaceOperationalIntent.
+//   - expectedRevision: is the int64 value supplied to ReplaceOperationalIntent.
+//   - intent: is the domain.OperationalIntent value supplied to ReplaceOperationalIntent.
+//   - volumes: is the []domain.OperationalVolume value supplied to ReplaceOperationalIntent.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) ReplaceOperationalIntent(ctx context.Context, expectedVersion int, expectedRevision int64, intent domain.OperationalIntent, volumes []domain.OperationalVolume) error {
 	if intent.Version != expectedVersion && intent.Version != expectedVersion+1 {
 		return durable.ErrVersionConflict
@@ -330,6 +432,15 @@ func (s *Store) ReplaceOperationalIntent(ctx context.Context, expectedVersion in
 	return nil
 }
 
+// ListOperationalVolumes returns Store records matching the supplied scope and filters.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - intentID: identifies the target intent.
+//
+// Returns:
+//   - result: is the []domain.OperationalVolume value produced by ListOperationalVolumes.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) ListOperationalVolumes(ctx context.Context, intentID string) ([]domain.OperationalVolume, error) {
 	rows, err := s.pool.Query(ctx, `SELECT data FROM operational_volumes WHERE $1 = '' OR intent_id = $1 ORDER BY sequence, starts_at`, intentID)
 	if err != nil {
@@ -354,6 +465,14 @@ func (s *Store) ListOperationalVolumes(ctx context.Context, intentID string) ([]
 	return volumes, nil
 }
 
+// RecordConflictFinding durably records the supplied Store data.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - finding: is the domain.ConflictFinding value supplied to RecordConflictFinding.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) RecordConflictFinding(ctx context.Context, finding domain.ConflictFinding) error {
 	tx, err := s.pool.Begin(ctx)
 	if err != nil {
@@ -372,6 +491,16 @@ func (s *Store) RecordConflictFinding(ctx context.Context, finding domain.Confli
 	return nil
 }
 
+// ListConflictFindings returns Store records matching the supplied scope and filters.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - intentID: identifies the target intent.
+//   - intentVersion: is the int value supplied to ListConflictFindings.
+//
+// Returns:
+//   - result: is the []domain.ConflictFinding value produced by ListConflictFindings.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) ListConflictFindings(ctx context.Context, intentID string, intentVersion int) ([]domain.ConflictFinding, error) {
 	rows, err := s.pool.Query(ctx, `
 		SELECT data FROM conflict_findings
@@ -399,6 +528,17 @@ func (s *Store) ListConflictFindings(ctx context.Context, intentID string, inten
 	return findings, nil
 }
 
+// ReplaceConflictFindings atomically replaces the selected Store records.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - intentID: identifies the target intent.
+//   - intentVersion: is the int value supplied to ReplaceConflictFindings.
+//   - ruleVersion: is the string value supplied to ReplaceConflictFindings.
+//   - findings: is the []domain.ConflictFinding value supplied to ReplaceConflictFindings.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) ReplaceConflictFindings(ctx context.Context, intentID string, intentVersion int, ruleVersion string, findings []domain.ConflictFinding) error {
 	if err := validateFindingScope(intentID, intentVersion, ruleVersion, findings); err != nil {
 		return err

--- a/internal/store/replay/memory/replay.go
+++ b/internal/store/replay/memory/replay.go
@@ -12,10 +12,22 @@ type Store struct {
 	manifests map[string]domain.ReplayManifest
 }
 
+// NewStore constructs memory from the supplied configuration and dependencies.
+//
+// Returns:
+//   - result: is the *Store value produced by NewStore.
 func NewStore() *Store {
 	return &Store{manifests: make(map[string]domain.ReplayManifest)}
 }
 
+// PutReplayManifest stores or replaces a replay manifest by flight identity.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to PutReplayManifest.
+//   - manifest: is the domain.ReplayManifest value supplied to PutReplayManifest.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) PutReplayManifest(_ context.Context, manifest domain.ReplayManifest) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -23,6 +35,15 @@ func (s *Store) PutReplayManifest(_ context.Context, manifest domain.ReplayManif
 	return nil
 }
 
+// GetReplayManifest returns the replay manifest associated with one flight.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to GetReplayManifest.
+//   - flightID: identifies the target flight.
+//
+// Returns:
+//   - result: is the *domain.ReplayManifest value produced by GetReplayManifest.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) GetReplayManifest(_ context.Context, flightID string) (*domain.ReplayManifest, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()

--- a/internal/store/replay/memory/replay.go
+++ b/internal/store/replay/memory/replay.go
@@ -23,7 +23,7 @@ func NewStore() *Store {
 // PutReplayManifest stores or replaces a replay manifest by flight identity.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to PutReplayManifest.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - manifest: is the domain.ReplayManifest value supplied to PutReplayManifest.
 //
 // Returns:
@@ -38,7 +38,7 @@ func (s *Store) PutReplayManifest(_ context.Context, manifest domain.ReplayManif
 // GetReplayManifest returns the replay manifest associated with one flight.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to GetReplayManifest.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - flightID: identifies the target flight.
 //
 // Returns:

--- a/internal/store/telemetry/influxdb/store.go
+++ b/internal/store/telemetry/influxdb/store.go
@@ -59,6 +59,17 @@ func (w sampleWindow) policy() (sampleWindowPolicy, error) {
 	}
 }
 
+// New constructs influxdb from the supplied configuration and dependencies.
+//
+// Parameters:
+//   - host: locates the external dependency used by the operation.
+//   - token: provides authentication material for the dependency.
+//   - database: locates the external dependency used by the operation.
+//   - latestLookback: is the time.Duration value supplied to New.
+//
+// Returns:
+//   - result: is the *Store value produced by New.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func New(host, token, database string, latestLookback time.Duration) (*Store, error) {
 	if latestLookback <= 0 {
 		return nil, fmt.Errorf("latest telemetry lookback must be > 0")
@@ -78,8 +89,22 @@ func newWithRunnerPolicy(runner queryRunner, latestLookback time.Duration, now f
 	return &Store{runner: runner, latestLookback: latestLookback, now: now}
 }
 
+// Close releases resources owned by Store and completes any required shutdown work.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) Close() error { return s.runner.Close() }
 
+// GetLatestAircraftStates queries and decodes the newest bounded observation for
+// each supported telemetry group and requested aircraft.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - aircraftIDs: identifies the target aircraft.
+//
+// Returns:
+//   - result: is the map[string]domain.AircraftTelemetryState value produced by GetLatestAircraftStates.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) GetLatestAircraftStates(ctx context.Context, aircraftIDs []string) (map[string]domain.AircraftTelemetryState, error) {
 	states := make(map[string]domain.AircraftTelemetryState, len(aircraftIDs))
 	unique := make([]string, 0, len(aircraftIDs))
@@ -175,6 +200,15 @@ WHERE time >= $latest_after AND message_name IN (%s) AND aircraft_id IN (%s)
 	return rows, nil
 }
 
+// GetLatestSample returns the newest legacy position sample for one aircraft.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - aircraftID: identifies the target aircraft.
+//
+// Returns:
+//   - result: is the *domain.TelemetrySample value produced by GetLatestSample.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) GetLatestSample(ctx context.Context, aircraftID string) (*domain.TelemetrySample, error) {
 	samples, err := s.latestSamplesChronological(ctx, `aircraft_id = $aircraft_id`, map[string]any{"aircraft_id": aircraftID}, 1)
 	if err != nil || len(samples) == 0 {
@@ -183,10 +217,30 @@ func (s *Store) GetLatestSample(ctx context.Context, aircraftID string) (*domain
 	return &samples[0], nil
 }
 
+// QueryAircraftSamples queries Store with the supplied statement and parameters.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - aircraftID: identifies the target aircraft.
+//   - limit: caps the number of records claimed or returned in one call.
+//
+// Returns:
+//   - result: is the []domain.TelemetrySample value produced by QueryAircraftSamples.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) QueryAircraftSamples(ctx context.Context, aircraftID string, limit int) ([]domain.TelemetrySample, error) {
 	return s.latestSamplesChronological(ctx, `aircraft_id = $aircraft_id`, map[string]any{"aircraft_id": aircraftID}, limit)
 }
 
+// QueryFlightSamples queries Store with the supplied statement and parameters.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - flightID: identifies the target flight.
+//   - limit: caps the number of records claimed or returned in one call.
+//
+// Returns:
+//   - result: is the []domain.TelemetrySample value produced by QueryFlightSamples.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) QueryFlightSamples(ctx context.Context, flightID string, limit int) ([]domain.TelemetrySample, error) {
 	samples, err := s.earliestSamplesChronological(ctx, `flight_id = $flight_id`, map[string]any{"flight_id": flightID}, limit)
 	if err != nil && isMissingColumn(err, "flight_id") {
@@ -521,6 +575,16 @@ func stringValue(v any) string {
 
 type clientRunner struct{ client *influxdb3.Client }
 
+// Query queries clientRunner with the supplied statement and parameters.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - query: is the string value supplied to Query.
+//   - params: is the map[string]any value supplied to Query.
+//
+// Returns:
+//   - result: is the []map[string]any value produced by Query.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (r *clientRunner) Query(ctx context.Context, query string, params map[string]any) ([]map[string]any, error) {
 	iterator, err := r.client.QueryWithParameters(ctx, query, params)
 	if err != nil {
@@ -536,4 +600,8 @@ func (r *clientRunner) Query(ctx context.Context, query string, params map[strin
 	return rows, nil
 }
 
+// Close releases resources owned by clientRunner and completes any required shutdown work.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (r *clientRunner) Close() error { return r.client.Close() }

--- a/internal/store/telemetry/memory/telemetry.go
+++ b/internal/store/telemetry/memory/telemetry.go
@@ -25,7 +25,7 @@ func NewStore() *Store {
 // AddSample adds the supplied value to Store.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to AddSample.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - sample: is the domain.TelemetrySample value supplied to AddSample.
 //
 // Returns:
@@ -40,7 +40,7 @@ func (s *Store) AddSample(_ context.Context, sample domain.TelemetrySample) erro
 // GetLatestAircraftStates returns the latest independently sampled telemetry groups for each requested aircraft.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to GetLatestAircraftStates.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - aircraftIDs: identifies the target aircraft.
 //
 // Returns:
@@ -86,7 +86,7 @@ func (s *Store) GetLatestAircraftStates(_ context.Context, aircraftIDs []string)
 // GetLatestSample returns the newest legacy telemetry sample for one aircraft.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to GetLatestSample.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - aircraftID: identifies the target aircraft.
 //
 // Returns:
@@ -111,7 +111,7 @@ func (s *Store) GetLatestSample(_ context.Context, aircraftID string) (*domain.T
 // QueryAircraftSamples queries Store with the supplied statement and parameters.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to QueryAircraftSamples.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - aircraftID: identifies the target aircraft.
 //   - limit: caps the number of records claimed or returned in one call.
 //
@@ -140,7 +140,7 @@ func (s *Store) QueryAircraftSamples(_ context.Context, aircraftID string, limit
 // QueryFlightSamples queries Store with the supplied statement and parameters.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to QueryFlightSamples.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //   - flightID: identifies the target flight.
 //   - limit: caps the number of records claimed or returned in one call.
 //

--- a/internal/store/telemetry/memory/telemetry.go
+++ b/internal/store/telemetry/memory/telemetry.go
@@ -14,10 +14,22 @@ type Store struct {
 	samples []domain.TelemetrySample
 }
 
+// NewStore constructs memory from the supplied configuration and dependencies.
+//
+// Returns:
+//   - result: is the *Store value produced by NewStore.
 func NewStore() *Store {
 	return &Store{}
 }
 
+// AddSample adds the supplied value to Store.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to AddSample.
+//   - sample: is the domain.TelemetrySample value supplied to AddSample.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) AddSample(_ context.Context, sample domain.TelemetrySample) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -25,6 +37,15 @@ func (s *Store) AddSample(_ context.Context, sample domain.TelemetrySample) erro
 	return nil
 }
 
+// GetLatestAircraftStates returns the latest independently sampled telemetry groups for each requested aircraft.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to GetLatestAircraftStates.
+//   - aircraftIDs: identifies the target aircraft.
+//
+// Returns:
+//   - result: is the map[string]domain.AircraftTelemetryState value produced by GetLatestAircraftStates.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) GetLatestAircraftStates(_ context.Context, aircraftIDs []string) (map[string]domain.AircraftTelemetryState, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -62,6 +83,15 @@ func (s *Store) GetLatestAircraftStates(_ context.Context, aircraftIDs []string)
 	return states, nil
 }
 
+// GetLatestSample returns the newest legacy telemetry sample for one aircraft.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to GetLatestSample.
+//   - aircraftID: identifies the target aircraft.
+//
+// Returns:
+//   - result: is the *domain.TelemetrySample value produced by GetLatestSample.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) GetLatestSample(_ context.Context, aircraftID string) (*domain.TelemetrySample, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -78,6 +108,16 @@ func (s *Store) GetLatestSample(_ context.Context, aircraftID string) (*domain.T
 	return latest, nil
 }
 
+// QueryAircraftSamples queries Store with the supplied statement and parameters.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to QueryAircraftSamples.
+//   - aircraftID: identifies the target aircraft.
+//   - limit: caps the number of records claimed or returned in one call.
+//
+// Returns:
+//   - result: is the []domain.TelemetrySample value produced by QueryAircraftSamples.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) QueryAircraftSamples(_ context.Context, aircraftID string, limit int) ([]domain.TelemetrySample, error) {
 	if limit <= 0 {
 		limit = telemetry.DefaultSampleLimit
@@ -97,6 +137,16 @@ func (s *Store) QueryAircraftSamples(_ context.Context, aircraftID string, limit
 	return samples, nil
 }
 
+// QueryFlightSamples queries Store with the supplied statement and parameters.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to QueryFlightSamples.
+//   - flightID: identifies the target flight.
+//   - limit: caps the number of records claimed or returned in one call.
+//
+// Returns:
+//   - result: is the []domain.TelemetrySample value produced by QueryFlightSamples.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *Store) QueryFlightSamples(_ context.Context, flightID string, limit int) ([]domain.TelemetrySample, error) {
 	if limit <= 0 {
 		limit = telemetry.DefaultSampleLimit


### PR DESCRIPTION
## Summary

- add hover-friendly documentation for every previously undocumented exported handwritten Go function and method
- describe parameters, return values, persistence behavior, and errors across services, stores, Registry clients, DSS publication, and HTTP adapters
- strengthen AGENTS.md with a durable Go documentation convention

## Validation

- exported declaration documentation audit: pass
- gofmt and git diff --check: pass
- go test ./...: pass
- go vet ./...: pass