### PR TITLE
Expose ARM and DISARM aircraft endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,12 @@ AERO_API_REGISTRY_FRESHNESS=30s
 AERO_API_TELEMETRY_FRESHNESS=15s
 AERO_API_TELEMETRY_LATEST_LOOKBACK=5m
 
+# Immediate aircraft command path. Disable TLS verification only for local SITL.
+AERO_API_COMMAND_TIMEOUT=6s
+AERO_API_RELAY_CA_FILE=
+AERO_API_RELAY_SERVER_NAME=
+AERO_API_RELAY_INSECURE_SKIP_VERIFY=false
+
 # Compose uses PostgreSQL/PostGIS as the authoritative deconfliction store.
 # Add interuss to the comma-separated list to enable DSS discovery.
 AERO_API_AIRSPACE_PROVIDERS=local

--- a/cmd/aero-arc-api/main.go
+++ b/cmd/aero-arc-api/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"log/slog"
 	"net"
@@ -17,6 +19,7 @@ import (
 	"github.com/Aero-Arc/aero-arc-api/internal/config"
 	"github.com/Aero-Arc/aero-arc-api/internal/httpapi"
 	"github.com/Aero-Arc/aero-arc-api/internal/registry"
+	"github.com/Aero-Arc/aero-arc-api/internal/relaycontrol"
 	"github.com/Aero-Arc/aero-arc-api/internal/seed"
 	"github.com/Aero-Arc/aero-arc-api/internal/service"
 	"github.com/Aero-Arc/aero-arc-api/internal/service/deconfliction"
@@ -29,6 +32,7 @@ import (
 	telemetryinfluxdb "github.com/Aero-Arc/aero-arc-api/internal/store/telemetry/influxdb"
 	telemetrymemory "github.com/Aero-Arc/aero-arc-api/internal/store/telemetry/memory"
 	"github.com/urfave/cli/v3"
+	"google.golang.org/grpc/credentials"
 )
 
 func main() {
@@ -122,6 +126,10 @@ func newCommand() *cli.Command {
 						Usage:   "per-request timeout",
 						Sources: cli.EnvVars("AERO_API_REQUEST_TIMEOUT"),
 					},
+					&cli.DurationFlag{Name: "command-timeout", Value: defaults.CommandTimeout, Usage: "end-to-end aircraft command timeout", Sources: cli.EnvVars("AERO_API_COMMAND_TIMEOUT")},
+					&cli.StringFlag{Name: "relay-ca-file", Usage: "CA certificate used to verify Relay control endpoints", Sources: cli.EnvVars("AERO_API_RELAY_CA_FILE")},
+					&cli.StringFlag{Name: "relay-server-name", Usage: "TLS server name expected from Relay control endpoints", Sources: cli.EnvVars("AERO_API_RELAY_SERVER_NAME")},
+					&cli.BoolFlag{Name: "relay-insecure-skip-verify", Usage: "disable Relay TLS verification for local SITL only", Sources: cli.EnvVars("AERO_API_RELAY_INSECURE_SKIP_VERIFY")},
 					&cli.StringFlag{
 						Name:    "seed",
 						Value:   defaults.Seed,
@@ -164,6 +172,10 @@ func newCommand() *cli.Command {
 						TelemetryFreshness:       cmd.Duration("telemetry-freshness"),
 						TelemetryLatestLookback:  cmd.Duration("telemetry-latest-lookback"),
 						RequestTimeout:           cmd.Duration("request-timeout"),
+						CommandTimeout:           cmd.Duration("command-timeout"),
+						RelayCAFile:              cmd.String("relay-ca-file"),
+						RelayServerName:          cmd.String("relay-server-name"),
+						RelayInsecureSkipVerify:  cmd.Bool("relay-insecure-skip-verify"),
 						Seed:                     cmd.String("seed"),
 						Debug:                    cmd.Bool("debug"),
 					}
@@ -242,8 +254,24 @@ func run(ctx context.Context, cfg *config.Config) error {
 	intentService := service.NewIntentService(durableStore, deconflictionService)
 	preflightService := service.NewPreflightService(durableStore)
 	conformanceService := service.NewConformanceService(durableStore, telemetryStore)
+	relayCredentials, err := relayTransportCredentials(cfg)
+	if err != nil {
+		return err
+	}
+	relayControl, err := relaycontrol.New(registryClient, relayCredentials, cfg.CommandTimeout, cfg.RegistryFreshness)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := relayControl.Close(); err != nil {
+			slog.Warn("failed to close Relay control connections", slog.String("error", err.Error()))
+		}
+	}()
+	commandService := service.NewAircraftCommandService(durableStore, relayControl)
 
-	apiServer := httpapi.NewWithWorkflows(fleetService, intentService, preflightService, conformanceService, cfg.RequestTimeout, deconflictionService).WithDebug(cfg.Debug)
+	apiServer := httpapi.NewWithWorkflows(fleetService, intentService, preflightService, conformanceService, cfg.RequestTimeout, deconflictionService).
+		WithAircraftCommands(commandService, cfg.CommandTimeout).
+		WithDebug(cfg.Debug)
 	if deconflictionService.PublishingEnabled() {
 		authorizer, err := httpapi.NewUSSJWTAuthorizer(cfg.USSJWTPublicKeyFile, cfg.USSJWTIssuer, cfg.USSJWTAudience)
 		if err != nil {
@@ -302,6 +330,32 @@ func run(ctx context.Context, cfg *config.Config) error {
 
 	slog.Info("aero-arc-api shutdown complete")
 	return nil
+}
+
+func relayTransportCredentials(cfg *config.Config) (credentials.TransportCredentials, error) {
+	tlsConfig := &tls.Config{
+		MinVersion:         tls.VersionTLS12,
+		ServerName:         cfg.RelayServerName,
+		InsecureSkipVerify: cfg.RelayInsecureSkipVerify, // #nosec G402 -- explicit local-SITL escape hatch.
+	}
+	if cfg.RelayCAFile != "" {
+		pem, err := os.ReadFile(cfg.RelayCAFile)
+		if err != nil {
+			return nil, fmt.Errorf("read Relay CA file: %w", err)
+		}
+		roots, err := x509.SystemCertPool()
+		if err != nil {
+			return nil, fmt.Errorf("load system certificate pool: %w", err)
+		}
+		if roots == nil {
+			roots = x509.NewCertPool()
+		}
+		if !roots.AppendCertsFromPEM(pem) {
+			return nil, fmt.Errorf("Relay CA file contains no certificates")
+		}
+		tlsConfig.RootCAs = roots
+	}
+	return credentials.NewTLS(tlsConfig), nil
 }
 
 func newDurableStore(ctx context.Context, cfg *config.Config) (durable.Store, error) {

--- a/cmd/aero-arc-api/main.go
+++ b/cmd/aero-arc-api/main.go
@@ -351,7 +351,7 @@ func relayTransportCredentials(cfg *config.Config) (credentials.TransportCredent
 			roots = x509.NewCertPool()
 		}
 		if !roots.AppendCertsFromPEM(pem) {
-			return nil, fmt.Errorf("Relay CA file contains no certificates")
+			return nil, fmt.Errorf("relay CA file contains no certificates")
 		}
 		tlsConfig.RootCAs = roots
 	}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.2
 require (
 	github.com/Aero-Arc/dss-clients v0.0.0-20260727090752-3dbacffe9489
 	github.com/InfluxCommunity/influxdb3-go/v2 v2.13.0
-	github.com/aero-arc/aero-arc-protos v0.0.0-20260712235411-7691110ca7e7
+	github.com/aero-arc/aero-arc-protos v0.0.0-20260817050509-7f9124ee65fd
 	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.10.0

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.2
 require (
 	github.com/Aero-Arc/dss-clients v0.0.0-20260727090752-3dbacffe9489
 	github.com/InfluxCommunity/influxdb3-go/v2 v2.13.0
-	github.com/aero-arc/aero-arc-protos v0.0.0-20260712235411-7691110ca7e7
+	github.com/aero-arc/aero-arc-protos v0.0.0-20260817042625-1168c254a092
 	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.10.0

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,8 @@ github.com/InfluxCommunity/influxdb3-go/v2 v2.13.0/go.mod h1:fXhSEgDgX7iv++4t5cF
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=
-github.com/aero-arc/aero-arc-protos v0.0.0-20260712235411-7691110ca7e7 h1:Ex8lT3tkVP902PfjJiRU2E4Q4L4H7eyfzgwSUu+WiGw=
-github.com/aero-arc/aero-arc-protos v0.0.0-20260712235411-7691110ca7e7/go.mod h1:fILW3Dz6auXllS5ABRFTt0FTnNC4Mtw3ukvGrJa7zLo=
+github.com/aero-arc/aero-arc-protos v0.0.0-20260817050509-7f9124ee65fd h1:39SaVLyvowCAJFmSLPXpnJ04uPLlGko7z4tUY0423e4=
+github.com/aero-arc/aero-arc-protos v0.0.0-20260817050509-7f9124ee65fd/go.mod h1:fILW3Dz6auXllS5ABRFTt0FTnNC4Mtw3ukvGrJa7zLo=
 github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwToPjQ=
 github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/apache/arrow-go/v18 v18.5.1 h1:yaQ6zxMGgf9YCYw4/oaeOU3AULySDlAYDOcnr4LdHdI=

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,8 @@ github.com/InfluxCommunity/influxdb3-go/v2 v2.13.0/go.mod h1:fXhSEgDgX7iv++4t5cF
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=
-github.com/aero-arc/aero-arc-protos v0.0.0-20260712235411-7691110ca7e7 h1:Ex8lT3tkVP902PfjJiRU2E4Q4L4H7eyfzgwSUu+WiGw=
-github.com/aero-arc/aero-arc-protos v0.0.0-20260712235411-7691110ca7e7/go.mod h1:fILW3Dz6auXllS5ABRFTt0FTnNC4Mtw3ukvGrJa7zLo=
+github.com/aero-arc/aero-arc-protos v0.0.0-20260817042625-1168c254a092 h1:s39r5ktr4/mKXCBNdPfshs+V2UL6bDHOWkjlYMG90f4=
+github.com/aero-arc/aero-arc-protos v0.0.0-20260817042625-1168c254a092/go.mod h1:fILW3Dz6auXllS5ABRFTt0FTnNC4Mtw3ukvGrJa7zLo=
 github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwToPjQ=
 github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/apache/arrow-go/v18 v18.5.1 h1:yaQ6zxMGgf9YCYw4/oaeOU3AULySDlAYDOcnr4LdHdI=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,6 +31,7 @@ const (
 	defaultTelemetryFreshness  = 15 * time.Second
 	defaultTelemetryLookback   = 5 * time.Minute
 	defaultRequestTimeout      = 3 * time.Second
+	defaultCommandTimeout      = 6 * time.Second
 	defaultDSSOAuthAudience    = "localhost"
 	defaultDSSOAuthIssuer      = "localhost"
 	defaultDSSOAuthSubject     = "aero-arc-api"
@@ -66,6 +67,10 @@ type Config struct {
 	TelemetryFreshness       time.Duration
 	TelemetryLatestLookback  time.Duration
 	RequestTimeout           time.Duration
+	CommandTimeout           time.Duration
+	RelayCAFile              string
+	RelayServerName          string
+	RelayInsecureSkipVerify  bool
 	Seed                     string
 	Debug                    bool
 }
@@ -88,6 +93,7 @@ func Defaults() *Config {
 		TelemetryFreshness:      defaultTelemetryFreshness,
 		TelemetryLatestLookback: defaultTelemetryLookback,
 		RequestTimeout:          defaultRequestTimeout,
+		CommandTimeout:          defaultCommandTimeout,
 		DSSOAuthAudience:        defaultDSSOAuthAudience,
 		DSSOAuthIssuer:          defaultDSSOAuthIssuer,
 		DSSOAuthSubject:         defaultDSSOAuthSubject,
@@ -125,11 +131,16 @@ func Load() (*Config, error) {
 	applyStringEnv("AERO_API_REPLAY_STORE", &cfg.ReplayStore)
 	applyStringEnv("AERO_API_REGISTRY_MODE", &cfg.RegistryMode)
 	applyStringEnv("AERO_API_REGISTRY_ADDR", &cfg.RegistryAddress)
+	applyStringEnv("AERO_API_RELAY_CA_FILE", &cfg.RelayCAFile)
+	applyStringEnv("AERO_API_RELAY_SERVER_NAME", &cfg.RelayServerName)
 	applyStringEnv("AERO_API_SEED", &cfg.Seed)
 	if err := applyBoolEnv("AERO_API_DEBUG", &cfg.Debug); err != nil {
 		return nil, err
 	}
 	if err := applyBoolEnv("AERO_API_DSS_ALLOW_INSECURE_PEER_URLS", &cfg.DSSAllowInsecurePeerURLs); err != nil {
+		return nil, err
+	}
+	if err := applyBoolEnv("AERO_API_RELAY_INSECURE_SKIP_VERIFY", &cfg.RelayInsecureSkipVerify); err != nil {
 		return nil, err
 	}
 	if err := applyDurationEnv("AERO_API_REGISTRY_DIAL_TIMEOUT", &cfg.RegistryDialTimeout); err != nil {
@@ -145,6 +156,9 @@ func Load() (*Config, error) {
 		return nil, err
 	}
 	if err := applyDurationEnv("AERO_API_REQUEST_TIMEOUT", &cfg.RequestTimeout); err != nil {
+		return nil, err
+	}
+	if err := applyDurationEnv("AERO_API_COMMAND_TIMEOUT", &cfg.CommandTimeout); err != nil {
 		return nil, err
 	}
 
@@ -253,6 +267,9 @@ func (cfg *Config) Validate() error {
 	}
 	if cfg.RequestTimeout <= 0 {
 		return fmt.Errorf("AERO_API_REQUEST_TIMEOUT must be > 0")
+	}
+	if cfg.CommandTimeout <= 0 {
+		return fmt.Errorf("AERO_API_COMMAND_TIMEOUT must be > 0")
 	}
 	for name, value := range map[string]string{
 		"AERO_API_DATABASE_URL":        cfg.DatabaseURL,

--- a/internal/domain/aircraft_command.go
+++ b/internal/domain/aircraft_command.go
@@ -1,0 +1,31 @@
+package domain
+
+// AircraftCommandType identifies the immediate vehicle operation requested by
+// an API caller. The first control slice intentionally supports only ARM and
+// DISARM.
+type AircraftCommandType string
+
+const (
+	AircraftCommandTypeArm    AircraftCommandType = "arm"
+	AircraftCommandTypeDisarm AircraftCommandType = "disarm"
+)
+
+// AircraftCommandStatus is the terminal autopilot-level outcome of an
+// immediate aircraft command.
+type AircraftCommandStatus string
+
+const (
+	AircraftCommandStatusAccepted       AircraftCommandStatus = "accepted"
+	AircraftCommandStatusRejected       AircraftCommandStatus = "rejected"
+	AircraftCommandStatusTimeout        AircraftCommandStatus = "timeout"
+	AircraftCommandStatusDeliveryFailed AircraftCommandStatus = "delivery_failed"
+)
+
+// AircraftCommandResult reports the correlated terminal result returned by
+// the Agent after attempting an immediate vehicle command.
+type AircraftCommandResult struct {
+	CommandID  string                `json:"command_id"`
+	AircraftID string                `json:"aircraft_id"`
+	Status     AircraftCommandStatus `json:"status"`
+	Message    string                `json:"message,omitempty"`
+}

--- a/internal/httpapi/aircraft_command_integration_test.go
+++ b/internal/httpapi/aircraft_command_integration_test.go
@@ -1,0 +1,107 @@
+//go:build integration
+
+package httpapi
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/Aero-Arc/aero-arc-api/internal/domain"
+	"github.com/Aero-Arc/aero-arc-api/internal/registry"
+	"github.com/Aero-Arc/aero-arc-api/internal/relaycontrol"
+	"github.com/Aero-Arc/aero-arc-api/internal/service"
+	durablememory "github.com/Aero-Arc/aero-arc-api/internal/store/durable/memory"
+	agentv1 "github.com/aero-arc/aero-arc-protos/gen/go/aeroarc/agent/v1"
+	registryv1 "github.com/aero-arc/aero-arc-protos/gen/go/aeroarc/registry/v1"
+	relayv1 "github.com/aero-arc/aero-arc-protos/gen/go/aeroarc/relay/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+type commandRelayServer struct {
+	relayv1.UnimplementedRelayControlServer
+	requests chan *relayv1.SendAircraftCommandRequest
+}
+
+func (s *commandRelayServer) SendAircraftCommand(_ context.Context, request *relayv1.SendAircraftCommandRequest) (*relayv1.SendAircraftCommandResponse, error) {
+	s.requests <- request
+	command := request.GetCommand()
+	return &relayv1.SendAircraftCommandResponse{Result: &agentv1.AircraftCommandResult{
+		CommandId: command.GetCommandId(), AircraftId: command.GetAircraftId(),
+		Status:  agentv1.AircraftCommandResult_STATUS_ACCEPTED,
+		Message: "MAV_CMD_COMPONENT_ARM_DISARM accepted",
+	}}, nil
+}
+
+func TestAircraftCommandAcrossHTTPRegistryAndRelayGRPC(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := grpc.NewServer()
+	relay := &commandRelayServer{requests: make(chan *relayv1.SendAircraftCommandRequest, 1)}
+	relayv1.RegisterRelayControlServer(server, relay)
+	go func() { _ = server.Serve(listener) }()
+	defer server.Stop()
+
+	host, portText, err := net.SplitHostPort(listener.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	port, err := strconv.Atoi(portText)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	registryClient := registry.NewMemoryClient()
+	if _, err := registryClient.RegisterRelay(context.Background(), &registryv1.RegisterRelayRequest{Relay: &registryv1.Relay{
+		RelayId: "relay-command", Address: host, GrpcPort: int32(port), LastHeartbeatUnixMs: now.UnixMilli(),
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := registryClient.RegisterAgent(context.Background(), &registryv1.RegisterAgentRequest{
+		Agent: &registryv1.Agent{AgentId: "agent-command", LastHeartbeatUnixMs: now.UnixMilli()}, RelayId: "relay-command",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	transport, err := relaycontrol.New(registryClient, insecure.NewCredentials(), 2*time.Second, time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer transport.Close()
+	durable := durablememory.NewStore()
+	if err := durable.CreateAircraft(context.Background(), domain.Aircraft{ID: "aircraft-command", AgentID: "agent-command"}); err != nil {
+		t.Fatal(err)
+	}
+	commands := service.NewAircraftCommandService(durable, transport)
+	handler := New(nil, time.Second).WithAircraftCommands(commands, 3*time.Second).Handler()
+
+	request := httptest.NewRequest(http.MethodPost, "/api/v1/aircraft/aircraft-command/commands/arm", nil)
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", response.Code, response.Body.String())
+	}
+	var result domain.AircraftCommandResult
+	if err := json.NewDecoder(response.Body).Decode(&result); err != nil {
+		t.Fatal(err)
+	}
+	if result.Status != domain.AircraftCommandStatusAccepted || result.AircraftID != "aircraft-command" || result.CommandID == "" {
+		t.Fatalf("result = %+v", result)
+	}
+	select {
+	case routed := <-relay.requests:
+		if routed.GetAgentId() != "agent-command" || routed.GetCommand().GetType() != agentv1.AircraftCommandType_AIRCRAFT_COMMAND_TYPE_ARM {
+			t.Fatalf("routed request = %+v", routed)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("owning Relay did not receive the command")
+	}
+}

--- a/internal/httpapi/aircraft_command_test.go
+++ b/internal/httpapi/aircraft_command_test.go
@@ -1,0 +1,65 @@
+package httpapi
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Aero-Arc/aero-arc-api/internal/domain"
+	"github.com/Aero-Arc/aero-arc-api/internal/service"
+)
+
+type fakeAircraftCommander struct {
+	aircraftID  string
+	commandType domain.AircraftCommandType
+	result      domain.AircraftCommandResult
+	err         error
+}
+
+func (f *fakeAircraftCommander) SendAircraftCommand(_ context.Context, aircraftID string, commandType domain.AircraftCommandType) (domain.AircraftCommandResult, error) {
+	f.aircraftID = aircraftID
+	f.commandType = commandType
+	return f.result, f.err
+}
+
+func TestArmAircraftEndpointReturnsAutopilotResult(t *testing.T) {
+	commands := &fakeAircraftCommander{result: domain.AircraftCommandResult{
+		CommandID: "command-1", AircraftID: "aircraft-1", Status: domain.AircraftCommandStatusAccepted,
+	}}
+	handler := New(nil, time.Second).WithAircraftCommands(commands).Handler()
+	request := httptest.NewRequest(http.MethodPost, "/api/v1/aircraft/aircraft-1/commands/arm", nil)
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", response.Code, response.Body.String())
+	}
+	var result domain.AircraftCommandResult
+	if err := json.NewDecoder(response.Body).Decode(&result); err != nil {
+		t.Fatal(err)
+	}
+	if commands.aircraftID != "aircraft-1" || commands.commandType != domain.AircraftCommandTypeArm || result.Status != domain.AircraftCommandStatusAccepted {
+		t.Fatalf("request = %s %s, result = %+v", commands.aircraftID, commands.commandType, result)
+	}
+}
+
+func TestAircraftCommandEndpointReportsOfflineAircraft(t *testing.T) {
+	commands := &fakeAircraftCommander{err: fmt.Errorf("%w: no active session", service.ErrAircraftNotConnected)}
+	handler := New(nil, time.Second).WithAircraftCommands(commands).Handler()
+	request := httptest.NewRequest(http.MethodPost, "/api/v1/aircraft/aircraft-1/commands/disarm", nil)
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	if response.Code != http.StatusConflict {
+		t.Fatalf("status = %d, body = %s", response.Code, response.Body.String())
+	}
+	var body map[string]string
+	if err := json.NewDecoder(response.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	if body["error"] != "AIRCRAFT_NOT_CONNECTED" || commands.commandType != domain.AircraftCommandTypeDisarm {
+		t.Fatalf("body = %+v, command = %s", body, commands.commandType)
+	}
+}

--- a/internal/httpapi/handlers.go
+++ b/internal/httpapi/handlers.go
@@ -132,6 +132,29 @@ func (s *Server) handleGetAircraftLiveState(c *mach.Context) {
 	writeJSON(c, http.StatusOK, state)
 }
 
+func (s *Server) handleArmAircraft(c *mach.Context) {
+	s.handleAircraftCommand(c, domain.AircraftCommandTypeArm)
+}
+
+func (s *Server) handleDisarmAircraft(c *mach.Context) {
+	s.handleAircraftCommand(c, domain.AircraftCommandTypeDisarm)
+}
+
+func (s *Server) handleAircraftCommand(c *mach.Context, commandType domain.AircraftCommandType) {
+	timeout := s.commandTimeout
+	if timeout <= 0 {
+		timeout = s.requestTimeout
+	}
+	ctx, cancel := context.WithTimeout(c.Context(), timeout)
+	defer cancel()
+	result, err := s.commands.SendAircraftCommand(ctx, c.Param("aircraft_id"), commandType)
+	if err != nil {
+		writeCommandError(c, err)
+		return
+	}
+	writeJSON(c, http.StatusOK, result)
+}
+
 func (s *Server) handleGetAircraftMap(c *mach.Context) {
 	ctx, cancel := s.contextWithTimeout(c)
 	defer cancel()

--- a/internal/httpapi/response.go
+++ b/internal/httpapi/response.go
@@ -1,6 +1,7 @@
 package httpapi
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -42,4 +43,21 @@ func writeServiceError(c *mach.Context, err error) {
 		"error":   "request failed",
 		"details": strings.TrimSpace(err.Error()),
 	})
+}
+
+func writeCommandError(c *mach.Context, err error) {
+	switch {
+	case errors.Is(err, durable.ErrNotFound):
+		writeJSON(c, http.StatusNotFound, map[string]string{"error": "AIRCRAFT_NOT_FOUND", "details": strings.TrimSpace(err.Error())})
+	case errors.Is(err, service.ErrAircraftNotConnected):
+		writeJSON(c, http.StatusConflict, map[string]string{"error": "AIRCRAFT_NOT_CONNECTED", "details": strings.TrimSpace(err.Error())})
+	case errors.Is(err, context.DeadlineExceeded):
+		writeJSON(c, http.StatusGatewayTimeout, map[string]string{"error": "COMMAND_TIMEOUT", "details": strings.TrimSpace(err.Error())})
+	case errors.Is(err, service.ErrValidation):
+		writeJSON(c, http.StatusBadRequest, map[string]string{"error": "INVALID_COMMAND", "details": strings.TrimSpace(err.Error())})
+	case errors.Is(err, service.ErrAircraftCommandDelivery):
+		writeJSON(c, http.StatusBadGateway, map[string]string{"error": "COMMAND_DELIVERY_FAILED", "details": strings.TrimSpace(err.Error())})
+	default:
+		writeJSON(c, http.StatusInternalServerError, map[string]string{"error": "COMMAND_FAILED", "details": strings.TrimSpace(err.Error())})
+	}
 }

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -1,10 +1,12 @@
 package httpapi
 
 import (
+	"context"
 	"log/slog"
 	"net/http"
 	"time"
 
+	"github.com/Aero-Arc/aero-arc-api/internal/domain"
 	"github.com/Aero-Arc/aero-arc-api/internal/service"
 	"github.com/Aero-Arc/aero-arc-api/internal/service/deconfliction"
 	"github.com/mrshabel/mach"
@@ -19,6 +21,12 @@ type Server struct {
 	requestTimeout time.Duration
 	debug          bool
 	ussAuthorizer  USSAuthorizer
+	commands       aircraftCommander
+	commandTimeout time.Duration
+}
+
+type aircraftCommander interface {
+	SendAircraftCommand(context.Context, string, domain.AircraftCommandType) (domain.AircraftCommandResult, error)
 }
 
 // New constructs httpapi from the supplied configuration and dependencies.
@@ -71,6 +79,25 @@ func (s *Server) WithDebug(debug bool) *Server {
 	return s
 }
 
+// WithAircraftCommands enables the immediate ARM/DISARM HTTP routes using the
+// supplied aircraft-identity command workflow.
+//
+// Parameters:
+//   - commands: resolves aircraft identity and executes commands through Registry and Relay.
+//   - timeout: optionally overrides the HTTP lifetime for command completion; the
+//     first positive value is used and otherwise the ordinary request timeout applies.
+//
+// Returns:
+//   - server: is the same receiver with command routes enabled.
+func (s *Server) WithAircraftCommands(commands aircraftCommander, timeout ...time.Duration) *Server {
+	s.commands = commands
+	s.commandTimeout = s.requestTimeout
+	if len(timeout) > 0 && timeout[0] > 0 {
+		s.commandTimeout = timeout[0]
+	}
+	return s
+}
+
 // WithUSSAuthorizer installs the authorization policy used by USS routes.
 //
 // Parameters:
@@ -119,6 +146,10 @@ func (s *Server) Handler() http.Handler {
 	api.GET("/aircraft/{aircraft_id}/state", s.handleGetAircraftLiveState)
 	api.GET("/aircraft/{aircraft_id}/map", s.handleGetAircraftMap)
 	api.GET("/aircraft/{aircraft_id}/flights", s.handleListAircraftFlights)
+	if s.commands != nil {
+		api.POST("/aircraft/{aircraft_id}/commands/arm", s.handleArmAircraft)
+		api.POST("/aircraft/{aircraft_id}/commands/disarm", s.handleDisarmAircraft)
+	}
 	api.GET("/flights/{flight_id}", s.handleGetFlight)
 	api.GET("/flights/{flight_id}/replay", s.handleGetFlightReplay)
 

--- a/internal/registry/memory.go
+++ b/internal/registry/memory.go
@@ -250,6 +250,24 @@ func (c *MemoryClient) GetAgentPlacement(_ context.Context, req *registryv1.GetA
 	}, nil
 }
 
+// PublishConformanceSummary reports that the in-process Registry client does
+// not implement the separately owned conformance control-plane store.
+func (c *MemoryClient) PublishConformanceSummary(context.Context, *registryv1.PublishConformanceSummaryRequest, ...grpc.CallOption) (*registryv1.PublishConformanceSummaryResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "memory registry does not store conformance summaries")
+}
+
+// GetConformanceSummary reports that the in-process Registry client does not
+// implement the separately owned conformance control-plane store.
+func (c *MemoryClient) GetConformanceSummary(context.Context, *registryv1.GetConformanceSummaryRequest, ...grpc.CallOption) (*registryv1.GetConformanceSummaryResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "memory registry does not store conformance summaries")
+}
+
+// BatchGetConformanceSummaries reports that the in-process Registry client does
+// not implement the separately owned conformance control-plane store.
+func (c *MemoryClient) BatchGetConformanceSummaries(context.Context, *registryv1.BatchGetConformanceSummariesRequest, ...grpc.CallOption) (*registryv1.BatchGetConformanceSummariesResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "memory registry does not store conformance summaries")
+}
+
 func cloneRelay(relay *registryv1.Relay) *registryv1.Relay {
 	return &registryv1.Relay{
 		RelayId:             relay.GetRelayId(),

--- a/internal/relaycontrol/service.go
+++ b/internal/relaycontrol/service.go
@@ -4,13 +4,16 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
+	"log/slog"
 	"net"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/Aero-Arc/aero-arc-api/internal/domain"
 	agentv1 "github.com/aero-arc/aero-arc-protos/gen/go/aeroarc/agent/v1"
 	registryv1 "github.com/aero-arc/aero-arc-protos/gen/go/aeroarc/registry/v1"
 	relayv1 "github.com/aero-arc/aero-arc-protos/gen/go/aeroarc/relay/v1"
@@ -21,6 +24,10 @@ import (
 
 const defaultTimeout = 5 * time.Second
 
+// ErrAgentNotConnected reports that Registry or Relay has no active session
+// for the Agent selected by the API's durable aircraft mapping.
+var ErrAgentNotConnected = errors.New("agent is not connected")
+
 type SetRequest struct {
 	AgentID       string
 	FlightID      string
@@ -30,6 +37,16 @@ type SetRequest struct {
 }
 
 type ClearRequest struct{ AgentID, FlightID, CommandID string }
+
+// AircraftCommandRequest carries the resolved Agent route and the immediate
+// aircraft command that must be delivered without retries or persistence.
+type AircraftCommandRequest struct {
+	AgentID    string
+	AircraftID string
+	Type       domain.AircraftCommandType
+	CommandID  string
+	IssuedAt   time.Time
+}
 
 type Service struct {
 	registry              registryClient
@@ -135,6 +152,92 @@ func (s *Service) ClearOperationContext(ctx context.Context, req ClearRequest) (
 	return commandID, err
 }
 
+// SendAircraftCommand resolves the Agent's current Relay placement, delivers
+// one ARM or DISARM command exactly once, and returns the Agent's correlated
+// autopilot-level result. It deliberately bypasses the placement cache and
+// does not retry an ambiguous Relay failure because physical commands are not
+// idempotent at this boundary.
+//
+// Parameters:
+//   - ctx: bounds Registry lookup, Relay delivery, and result propagation.
+//   - req: identifies the Agent, aircraft, command type, and optional command ID.
+//
+// Returns:
+//   - result: contains accepted, rejected, timeout, or delivery-failed status.
+//   - error: reports validation, offline placement, Relay transport, correlation,
+//     or unsupported-result failures.
+func (s *Service) SendAircraftCommand(ctx context.Context, req AircraftCommandRequest) (domain.AircraftCommandResult, error) {
+	if strings.TrimSpace(req.AgentID) == "" || strings.TrimSpace(req.AircraftID) == "" {
+		return domain.AircraftCommandResult{}, fmt.Errorf("agent_id and aircraft_id are required")
+	}
+	var commandType agentv1.AircraftCommandType
+	switch req.Type {
+	case domain.AircraftCommandTypeArm:
+		commandType = agentv1.AircraftCommandType_AIRCRAFT_COMMAND_TYPE_ARM
+	case domain.AircraftCommandTypeDisarm:
+		commandType = agentv1.AircraftCommandType_AIRCRAFT_COMMAND_TYPE_DISARM
+	default:
+		return domain.AircraftCommandResult{}, fmt.Errorf("unsupported aircraft command type %q", req.Type)
+	}
+	commandID, err := ensureCommandID(req.CommandID)
+	if err != nil {
+		return domain.AircraftCommandResult{}, err
+	}
+	issuedAt := req.IssuedAt
+	if issuedAt.IsZero() {
+		issuedAt = s.now().UTC()
+	}
+	command := &agentv1.AircraftCommand{
+		CommandId: commandID, AircraftId: req.AircraftID,
+		Type: commandType, IssuedAtUnixMs: issuedAt.UnixMilli(),
+	}
+
+	placement, err := s.resolve(ctx, req.AgentID, true)
+	if err != nil {
+		return domain.AircraftCommandResult{}, err
+	}
+	client, err := s.pool.Client(ctx, placement.relayID, placement.address)
+	if err != nil {
+		return domain.AircraftCommandResult{}, fmt.Errorf("connect relay %s: %w", placement.relayID, err)
+	}
+	slog.LogAttrs(ctx, slog.LevelInfo, "command_routed",
+		slog.String("command_id", commandID),
+		slog.String("aircraft_id", req.AircraftID),
+		slog.String("agent_id", req.AgentID),
+		slog.String("relay_id", placement.relayID),
+		slog.String("command_type", string(req.Type)),
+	)
+	callCtx, cancel := context.WithTimeout(ctx, s.timeout)
+	response, err := client.SendAircraftCommand(callCtx, &relayv1.SendAircraftCommandRequest{
+		AgentId: req.AgentID, Command: command,
+	})
+	cancel()
+	if err != nil {
+		if status.Code(err) == codes.NotFound {
+			return domain.AircraftCommandResult{}, fmt.Errorf("%w: %v", ErrAgentNotConnected, err)
+		}
+		return domain.AircraftCommandResult{}, fmt.Errorf("deliver aircraft command: %w", err)
+	}
+	result := response.GetResult()
+	if result == nil || result.GetCommandId() != commandID || result.GetAircraftId() != req.AircraftID {
+		return domain.AircraftCommandResult{}, fmt.Errorf("relay returned a missing or mismatched aircraft command result")
+	}
+	mapped := domain.AircraftCommandResult{CommandID: commandID, AircraftID: req.AircraftID, Message: result.GetMessage()}
+	switch result.GetStatus() {
+	case agentv1.AircraftCommandResult_STATUS_ACCEPTED:
+		mapped.Status = domain.AircraftCommandStatusAccepted
+	case agentv1.AircraftCommandResult_STATUS_REJECTED:
+		mapped.Status = domain.AircraftCommandStatusRejected
+	case agentv1.AircraftCommandResult_STATUS_TIMEOUT:
+		mapped.Status = domain.AircraftCommandStatusTimeout
+	case agentv1.AircraftCommandResult_STATUS_DELIVERY_FAILED:
+		mapped.Status = domain.AircraftCommandStatusDeliveryFailed
+	default:
+		return domain.AircraftCommandResult{}, fmt.Errorf("agent returned unsupported command status %s", result.GetStatus())
+	}
+	return mapped, nil
+}
+
 func (s *Service) call(ctx context.Context, agentID string, invoke func(context.Context, relayv1.RelayControlClient) error) error {
 	for attempt := 0; attempt < 2; attempt++ {
 		placement, err := s.resolve(ctx, agentID, attempt > 0)
@@ -170,11 +273,14 @@ func (s *Service) resolve(ctx context.Context, agentID string, refresh bool) (ca
 	defer cancel()
 	response, err := s.registry.GetAgentPlacement(lookupCtx, &registryv1.GetAgentPlacementRequest{AgentId: agentID})
 	if err != nil {
+		if status.Code(err) == codes.NotFound {
+			return cachedPlacement{}, fmt.Errorf("%w: agent %s has no relay placement", ErrAgentNotConnected, agentID)
+		}
 		return cachedPlacement{}, fmt.Errorf("resolve agent placement: %w", err)
 	}
 	placement := response.GetPlacement()
 	if placement == nil || placement.GetRelayId() == "" {
-		return cachedPlacement{}, fmt.Errorf("agent %s has no relay placement", agentID)
+		return cachedPlacement{}, fmt.Errorf("%w: agent %s has no relay placement", ErrAgentNotConnected, agentID)
 	}
 	relays, err := s.registry.ListRelays(lookupCtx, &registryv1.ListRelaysRequest{})
 	if err != nil {

--- a/internal/relaycontrol/service_test.go
+++ b/internal/relaycontrol/service_test.go
@@ -3,9 +3,11 @@ package relaycontrol
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/Aero-Arc/aero-arc-api/internal/domain"
 	agentv1 "github.com/aero-arc/aero-arc-protos/gen/go/aeroarc/agent/v1"
 	registryv1 "github.com/aero-arc/aero-arc-protos/gen/go/aeroarc/registry/v1"
 	relayv1 "github.com/aero-arc/aero-arc-protos/gen/go/aeroarc/relay/v1"
@@ -44,10 +46,12 @@ func (f *fakePool) Invalidate(id string) { f.invalidated = append(f.invalidated,
 func (f *fakePool) Close() error         { return nil }
 
 type fakeRelayClient struct {
-	setRequests   []*relayv1.SetOperationContextRequest
-	clearRequests []*relayv1.ClearOperationContextRequest
-	setErrors     []error
-	block         bool
+	setRequests     []*relayv1.SetOperationContextRequest
+	clearRequests   []*relayv1.ClearOperationContextRequest
+	commandRequests []*relayv1.SendAircraftCommandRequest
+	setErrors       []error
+	commandErrors   []error
+	block           bool
 }
 
 func TestNewRequiresRelayTransportCredentials(t *testing.T) {
@@ -87,6 +91,21 @@ func (f *fakeRelayClient) SetOperationContext(ctx context.Context, r *relayv1.Se
 func (f *fakeRelayClient) ClearOperationContext(_ context.Context, r *relayv1.ClearOperationContextRequest, _ ...grpc.CallOption) (*relayv1.ClearOperationContextResponse, error) {
 	f.clearRequests = append(f.clearRequests, r)
 	return &relayv1.ClearOperationContextResponse{Result: &agentv1.OperationContextCommandAck{CommandId: r.Command.GetCommandId(), Status: agentv1.OperationContextCommandAck_STATUS_ALREADY_APPLIED}}, nil
+}
+
+func (f *fakeRelayClient) SendAircraftCommand(_ context.Context, r *relayv1.SendAircraftCommandRequest, _ ...grpc.CallOption) (*relayv1.SendAircraftCommandResponse, error) {
+	f.commandRequests = append(f.commandRequests, r)
+	if len(f.commandErrors) > 0 {
+		err := f.commandErrors[0]
+		f.commandErrors = f.commandErrors[1:]
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &relayv1.SendAircraftCommandResponse{Result: &agentv1.AircraftCommandResult{
+		CommandId: r.GetCommand().GetCommandId(), AircraftId: r.GetCommand().GetAircraftId(),
+		Status: agentv1.AircraftCommandResult_STATUS_ACCEPTED,
+	}}, nil
 }
 
 func TestSetOperationContextCachesPlacementAndPreservesCommandID(t *testing.T) {
@@ -153,5 +172,43 @@ func TestTimeout(t *testing.T) {
 	_, err := service.SetOperationContext(context.Background(), SetRequest{AgentID: "agent-1", FlightID: "flight-1", CommandID: "command"})
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("err=%v", err)
+	}
+}
+
+func TestSendAircraftCommandRoutesFreshAndMapsAcceptedResult(t *testing.T) {
+	registry := &fakeRegistry{relayIDs: []string{"relay-1"}}
+	client := &fakeRelayClient{}
+	service := newWithPool(registry, &fakePool{clients: map[string]*fakeRelayClient{"relay-1": client}}, time.Second, time.Minute)
+	result, err := service.SendAircraftCommand(context.Background(), AircraftCommandRequest{
+		AgentID: "agent-1", AircraftID: "aircraft-1", Type: domain.AircraftCommandTypeArm,
+		CommandID: "command-1", IssuedAt: time.Unix(100, 0),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Status != domain.AircraftCommandStatusAccepted || result.CommandID != "command-1" {
+		t.Fatalf("result = %+v", result)
+	}
+	request := client.commandRequests[0]
+	if request.GetAgentId() != "agent-1" || request.GetCommand().GetAircraftId() != "aircraft-1" || request.GetCommand().GetIssuedAtUnixMs() != time.Unix(100, 0).UnixMilli() {
+		t.Fatalf("request = %+v", request)
+	}
+}
+
+func TestSendAircraftCommandDoesNotRetryAmbiguousRelayFailure(t *testing.T) {
+	registry := &fakeRegistry{relayIDs: []string{"relay-1", "relay-2"}}
+	first := &fakeRelayClient{commandErrors: []error{status.Error(codes.Unavailable, "response lost")}}
+	second := &fakeRelayClient{}
+	service := newWithPool(registry, &fakePool{clients: map[string]*fakeRelayClient{
+		"relay-1": first, "relay-2": second,
+	}}, time.Second, time.Minute)
+	_, err := service.SendAircraftCommand(context.Background(), AircraftCommandRequest{
+		AgentID: "agent-1", AircraftID: "aircraft-1", Type: domain.AircraftCommandTypeArm, CommandID: "command-1",
+	})
+	if status.Code(errors.Unwrap(err)) != codes.Unavailable && !strings.Contains(err.Error(), "response lost") {
+		t.Fatalf("error = %v", err)
+	}
+	if registry.calls != 1 || len(first.commandRequests) != 1 || len(second.commandRequests) != 0 {
+		t.Fatalf("registry calls = %d, first requests = %d, second requests = %d", registry.calls, len(first.commandRequests), len(second.commandRequests))
 	}
 }

--- a/internal/service/aircraft_command_service.go
+++ b/internal/service/aircraft_command_service.go
@@ -1,0 +1,93 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/Aero-Arc/aero-arc-api/internal/domain"
+	"github.com/Aero-Arc/aero-arc-api/internal/relaycontrol"
+)
+
+var (
+	// ErrAircraftNotConnected reports that an aircraft has no mapped Agent or
+	// that its mapped Agent has no current Relay session.
+	ErrAircraftNotConnected = errors.New("aircraft is not connected")
+	// ErrAircraftCommandDelivery reports a Registry or Relay failure before a
+	// correlated Agent result could be returned.
+	ErrAircraftCommandDelivery = errors.New("aircraft command delivery failed")
+)
+
+type aircraftCommandStore interface {
+	GetAircraft(context.Context, string) (domain.Aircraft, error)
+}
+
+type aircraftCommandTransport interface {
+	SendAircraftCommand(context.Context, relaycontrol.AircraftCommandRequest) (domain.AircraftCommandResult, error)
+}
+
+// AircraftCommandService resolves API aircraft identities to their durable
+// Agent mappings before invoking the ephemeral Relay control path.
+type AircraftCommandService struct {
+	store     aircraftCommandStore
+	transport aircraftCommandTransport
+}
+
+// NewAircraftCommandService constructs the immediate command workflow.
+//
+// Parameters:
+//   - store: supplies the authoritative aircraft-to-Agent mapping.
+//   - transport: resolves Registry placement and invokes the owning Relay.
+//
+// Returns:
+//   - service: is ready to issue non-durable ARM and DISARM commands.
+func NewAircraftCommandService(store aircraftCommandStore, transport aircraftCommandTransport) *AircraftCommandService {
+	return &AircraftCommandService{store: store, transport: transport}
+}
+
+// SendAircraftCommand resolves aircraftID through the durable record and sends
+// one immediate ARM or DISARM command to its currently connected Agent.
+//
+// Parameters:
+//   - ctx: bounds durable lookup, Registry routing, Relay delivery, and result propagation.
+//   - aircraftID: identifies the Aero Arc aircraft requested by the caller.
+//   - commandType: must be arm or disarm.
+//
+// Returns:
+//   - result: is the Agent's correlated autopilot-level terminal outcome.
+//   - error: reports validation, missing aircraft records, disconnected aircraft,
+//     or control-path delivery failures.
+func (s *AircraftCommandService) SendAircraftCommand(ctx context.Context, aircraftID string, commandType domain.AircraftCommandType) (domain.AircraftCommandResult, error) {
+	aircraftID = strings.TrimSpace(aircraftID)
+	if aircraftID == "" {
+		return domain.AircraftCommandResult{}, fmt.Errorf("%w: aircraft_id is required", ErrValidation)
+	}
+	if commandType != domain.AircraftCommandTypeArm && commandType != domain.AircraftCommandTypeDisarm {
+		return domain.AircraftCommandResult{}, fmt.Errorf("%w: unsupported aircraft command %q", ErrValidation, commandType)
+	}
+	aircraft, err := s.store.GetAircraft(ctx, aircraftID)
+	if err != nil {
+		return domain.AircraftCommandResult{}, err
+	}
+	agentID := strings.TrimSpace(aircraft.AgentID)
+	if agentID == "" {
+		return domain.AircraftCommandResult{}, fmt.Errorf("%w: aircraft %s has no agent mapping", ErrAircraftNotConnected, aircraftID)
+	}
+	slog.LogAttrs(ctx, slog.LevelInfo, "command_requested",
+		slog.String("aircraft_id", aircraftID),
+		slog.String("agent_id", agentID),
+		slog.String("command_type", string(commandType)),
+	)
+	result, err := s.transport.SendAircraftCommand(ctx, relaycontrol.AircraftCommandRequest{
+		AgentID: agentID, AircraftID: aircraftID, Type: commandType,
+	})
+	if err != nil {
+		if errors.Is(err, relaycontrol.ErrAgentNotConnected) {
+			return domain.AircraftCommandResult{}, fmt.Errorf("%w: %w", ErrAircraftNotConnected, err)
+		}
+		return domain.AircraftCommandResult{}, fmt.Errorf("%w: %w", ErrAircraftCommandDelivery, err)
+	}
+	return result, nil
+}

--- a/internal/service/aircraft_command_service_test.go
+++ b/internal/service/aircraft_command_service_test.go
@@ -1,0 +1,68 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Aero-Arc/aero-arc-api/internal/domain"
+	"github.com/Aero-Arc/aero-arc-api/internal/relaycontrol"
+	durablememory "github.com/Aero-Arc/aero-arc-api/internal/store/durable/memory"
+)
+
+type recordingAircraftCommandTransport struct {
+	request relaycontrol.AircraftCommandRequest
+	result  domain.AircraftCommandResult
+	err     error
+}
+
+func (t *recordingAircraftCommandTransport) SendAircraftCommand(_ context.Context, request relaycontrol.AircraftCommandRequest) (domain.AircraftCommandResult, error) {
+	t.request = request
+	return t.result, t.err
+}
+
+func TestAircraftCommandServiceRoutesUsingDurableAgentMapping(t *testing.T) {
+	store := durablememory.NewStore()
+	if err := store.CreateAircraft(context.Background(), domain.Aircraft{ID: "aircraft-1", AgentID: "agent-7"}); err != nil {
+		t.Fatal(err)
+	}
+	transport := &recordingAircraftCommandTransport{result: domain.AircraftCommandResult{
+		CommandID: "command-1", AircraftID: "aircraft-1", Status: domain.AircraftCommandStatusAccepted,
+	}}
+	service := NewAircraftCommandService(store, transport)
+	result, err := service.SendAircraftCommand(context.Background(), "aircraft-1", domain.AircraftCommandTypeArm)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Status != domain.AircraftCommandStatusAccepted {
+		t.Fatalf("result = %+v", result)
+	}
+	if transport.request.AgentID != "agent-7" || transport.request.AircraftID != "aircraft-1" || transport.request.Type != domain.AircraftCommandTypeArm {
+		t.Fatalf("transport request = %+v", transport.request)
+	}
+}
+
+func TestAircraftCommandServiceRejectsUnmappedAircraft(t *testing.T) {
+	store := durablememory.NewStore()
+	if err := store.CreateAircraft(context.Background(), domain.Aircraft{ID: "aircraft-1"}); err != nil {
+		t.Fatal(err)
+	}
+	_, err := NewAircraftCommandService(store, &recordingAircraftCommandTransport{}).
+		SendAircraftCommand(context.Background(), "aircraft-1", domain.AircraftCommandTypeArm)
+	if !errors.Is(err, ErrAircraftNotConnected) {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestAircraftCommandServiceMapsOfflineAgent(t *testing.T) {
+	store := durablememory.NewStore()
+	if err := store.CreateAircraft(context.Background(), domain.Aircraft{ID: "aircraft-1", AgentID: "agent-1"}); err != nil {
+		t.Fatal(err)
+	}
+	transport := &recordingAircraftCommandTransport{err: relaycontrol.ErrAgentNotConnected}
+	_, err := NewAircraftCommandService(store, transport).
+		SendAircraftCommand(context.Background(), "aircraft-1", domain.AircraftCommandTypeDisarm)
+	if !errors.Is(err, ErrAircraftNotConnected) {
+		t.Fatalf("error = %v", err)
+	}
+}

--- a/internal/service/fleet_service_test.go
+++ b/internal/service/fleet_service_test.go
@@ -18,7 +18,7 @@ import (
 	"google.golang.org/grpc"
 )
 
-type failingRegistry struct{}
+type failingRegistry struct{ registryv1.AeroRegistryClient }
 
 func (failingRegistry) RegisterRelay(context.Context, *registryv1.RegisterRelayRequest, ...grpc.CallOption) (*registryv1.RegisterRelayResponse, error) {
 	return nil, errors.New("registry unavailable")


### PR DESCRIPTION
## Summary

Adds the API and Registry-routing portion of the ARM/DISARM command vertical slice defined by [aero-arc-protos#10](https://github.com/Aero-Arc/aero-arc-protos/pull/10).

New endpoints:

```text
POST /api/v1/aircraft/{aircraft_id}/commands/arm
POST /api/v1/aircraft/{aircraft_id}/commands/disarm
```

The workflow:

- loads the durable aircraft record
- uses `Aircraft.agent_id` as the only aircraft-to-Agent mapping
- performs a fresh Registry placement lookup for the Agent
- invokes only the Relay that owns the current session
- waits for the Agent/autopilot terminal result before returning HTTP 200
- does not retry ambiguous Relay failures

## Result and failure behavior

- ArduPilot `COMMAND_ACK` accepted → `status: accepted`
- ArduPilot denial/failure → `status: rejected`
- no MAVLink ACK → `status: timeout`
- no current Agent session → HTTP 409 `AIRCRAFT_NOT_CONNECTED`
- Relay/control transport failure → HTTP 502 `COMMAND_DELIVERY_FAILED`
- missing aircraft → HTTP 404 `AIRCRAFT_NOT_FOUND`

Relay TLS verification is enabled by default. A CA file and server name are configurable; certificate verification can only be explicitly disabled for local SITL testing.

## Tests

- `go test ./...`
- `go vet ./...`
- unit coverage for durable identity mapping, offline aircraft behavior, fresh Registry routing, result mapping, HTTP responses, and the no-retry rule
- integration-tagged coverage for HTTP → durable aircraft mapping → Registry placement → selected Relay gRPC

## Manual end-to-end SITL test

This was exercised with the real locally built ArduCopter SITL executable, not a mocked MAVLink server. Feature binaries for Registry, Relay, Agent, and API were run together with this topology:

```text
ArduCopter SERIAL0 ──UDP :14550──> Agent ──gRPC──> Relay :15052
                                             │
                                      Registry :15051
                                             │
                                          API :18080

Independent verifier ──TCP :5762──> ArduCopter SERIAL1
```

From the ArduPilot repository, SITL was started with:

```bash
build/sitl/bin/arducopter \
  --model quad \
  --wipe \
  --home 41.8781,-87.6298,180,0 \
  --serial0 udpclient:127.0.0.1:14550 \
  --defaults Tools/autotest/default_params/copter.parm
```

The API was started against the external in-memory Registry and the feature Relay:

```bash
/tmp/aero-arc-command-bin/aero-arc-api start \
  --addr 127.0.0.1:18080 \
  --durable-store memory \
  --telemetry-store memory \
  --replay-store memory \
  --registry-mode grpc \
  --registry-addr 127.0.0.1:15051 \
  --command-timeout 7s \
  --relay-insecure-skip-verify \
  --debug
```

An `aircraft-sitl` record was created with its durable `agent_id` set to the registered Agent identity. Registry confirmed that Agent's current placement on `relay-sitl`.

ARM was issued with:

```bash
curl --fail-with-body --silent --show-error -X POST \
  http://127.0.0.1:18080/api/v1/aircraft/aircraft-sitl/commands/arm
```

The API returned:

```json
{
  "aircraft_id": "aircraft-sitl",
  "status": "accepted",
  "message": "autopilot acknowledged command"
}
```

Actual vehicle state was verified independently through SITL's `SERIAL1` port using `pymavlink`, checking `MAV_MODE_FLAG_SAFETY_ARMED` in autopilot heartbeats:

```python
from pymavlink import mavutil

m = mavutil.mavlink_connection("tcp:127.0.0.1:5762")
heartbeat = m.wait_heartbeat(timeout=10)
armed = bool(heartbeat.base_mode & mavutil.mavlink.MAV_MODE_FLAG_SAFETY_ARMED)
print(f"armed={armed}")
```

The observer transitioned from `armed=False` to `armed=True`. DISARM was then issued through `/commands/disarm`; the API again returned `accepted`, and the independent observer transitioned from `armed=True` to `armed=False`.

ArduCopter's default idle auto-disarm behavior means state verification must happen immediately after ARM; a delayed heartbeat check may correctly observe the later automatic disarm.

Failure paths were also exercised:

- SITL stopped while Agent remained connected: ARM returned terminal `status: timeout` after the Agent's configured five-second ACK bound.
- Agent stopped: ARM returned HTTP 409 `AIRCRAFT_NOT_CONNECTED`; the command was not queued or retained for reconnect.

## Dependencies and rollout

- [aero-arc-protos#10](https://github.com/Aero-Arc/aero-arc-protos/pull/10) — merged; this branch pins its merged commit
- deploy the Relay and Agent support before enabling callers of these API endpoints
