### PR TITLE
Extract preflight into internal/service/preflight

### DIFF
--- a/cmd/aero-arc-api/main.go
+++ b/cmd/aero-arc-api/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/Aero-Arc/aero-arc-api/internal/seed"
 	"github.com/Aero-Arc/aero-arc-api/internal/service"
 	"github.com/Aero-Arc/aero-arc-api/internal/service/deconfliction"
+	"github.com/Aero-Arc/aero-arc-api/internal/service/preflight"
 	"github.com/Aero-Arc/aero-arc-api/internal/store/durable"
 	durablememory "github.com/Aero-Arc/aero-arc-api/internal/store/durable/memory"
 	durablepostgres "github.com/Aero-Arc/aero-arc-api/internal/store/durable/postgres"
@@ -240,7 +241,7 @@ func run(ctx context.Context, cfg *config.Config) error {
 	workerCtx, stopWorker := context.WithCancel(ctx)
 	defer stopWorker()
 	intentService := service.NewIntentService(durableStore, deconflictionService)
-	preflightService := service.NewPreflightService(durableStore)
+	preflightService := preflight.NewPreflightService(durableStore)
 	conformanceService := service.NewConformanceService(durableStore, telemetryStore)
 
 	apiServer := httpapi.NewWithWorkflows(fleetService, intentService, preflightService, conformanceService, cfg.RequestTimeout, deconflictionService).WithDebug(cfg.Debug)

--- a/internal/httpapi/handlers_test.go
+++ b/internal/httpapi/handlers_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Aero-Arc/aero-arc-api/internal/readmodel"
 	"github.com/Aero-Arc/aero-arc-api/internal/registry"
 	"github.com/Aero-Arc/aero-arc-api/internal/service"
+	"github.com/Aero-Arc/aero-arc-api/internal/service/preflight"
 	durablememory "github.com/Aero-Arc/aero-arc-api/internal/store/durable/memory"
 	replaymemory "github.com/Aero-Arc/aero-arc-api/internal/store/replay/memory"
 	telemetrymemory "github.com/Aero-Arc/aero-arc-api/internal/store/telemetry/memory"
@@ -298,7 +299,7 @@ func TestHandleActivateOperationalIntentRunsPreflight(t *testing.T) {
 	server := NewWithWorkflows(
 		fleet,
 		intents,
-		service.NewPreflightService(durable),
+		preflight.NewPreflightService(durable),
 		service.NewConformanceService(durable, telemetry),
 		time.Second,
 	)
@@ -334,7 +335,7 @@ func TestOperationalIntentTerminalTransitionRoutes(t *testing.T) {
 	server := NewWithWorkflows(
 		nil,
 		service.NewIntentServiceWithClock(store, func() time.Time { return now }, nil),
-		service.NewPreflightServiceWithClock(store, func() time.Time { return now }),
+		preflight.NewPreflightServiceWithClock(store, func() time.Time { return now }),
 		service.NewConformanceServiceWithClock(store, telemetrymemory.NewStore(), func() time.Time { return now }),
 		time.Second,
 	)
@@ -403,7 +404,7 @@ func TestHandleAddOperationalVolumeRejectsSubmittedIntent(t *testing.T) {
 	server := NewWithWorkflows(
 		fleet,
 		intents,
-		service.NewPreflightService(durable),
+		preflight.NewPreflightService(durable),
 		service.NewConformanceService(durable, telemetry),
 		time.Second,
 	)
@@ -460,7 +461,7 @@ func TestHandleModifyOperationalIntentBlocksActiveIntent(t *testing.T) {
 	server := NewWithWorkflows(
 		fleet,
 		service.NewIntentService(durable, nil),
-		service.NewPreflightService(durable),
+		preflight.NewPreflightService(durable),
 		service.NewConformanceService(durable, telemetry),
 		time.Second,
 	)
@@ -524,7 +525,7 @@ func TestHandleAddOperationalVolumeRejectsMissingAltitudeFields(t *testing.T) {
 	server := NewWithWorkflows(
 		fleet,
 		intents,
-		service.NewPreflightService(durable),
+		preflight.NewPreflightService(durable),
 		service.NewConformanceService(durable, telemetry),
 		time.Second,
 		newTestDeconflictionService(t, durable),
@@ -554,7 +555,7 @@ func TestHandleCheckOperationalIntentDeconfliction(t *testing.T) {
 	server := NewWithWorkflows(
 		fleet,
 		service.NewIntentService(durable, deconflictionService),
-		service.NewPreflightService(durable),
+		preflight.NewPreflightService(durable),
 		service.NewConformanceService(durable, telemetry),
 		time.Second,
 		deconflictionService,
@@ -611,7 +612,7 @@ func TestHandleActivateOperationalIntentBlocksOnDeconflictionPotentialConflict(t
 	server := NewWithWorkflows(
 		fleet,
 		service.NewIntentService(durable, deconflictionService),
-		service.NewPreflightService(durable),
+		preflight.NewPreflightService(durable),
 		service.NewConformanceService(durable, telemetry),
 		time.Second,
 		deconflictionService,
@@ -646,7 +647,7 @@ func TestHandleActivateOperationalIntentInvalidTransitionDoesNotRunDeconfliction
 	server := NewWithWorkflows(
 		fleet,
 		service.NewIntentService(durable, nil),
-		service.NewPreflightService(durable),
+		preflight.NewPreflightService(durable),
 		service.NewConformanceService(durable, telemetry),
 		time.Second,
 		newTestDeconflictionService(t, durable),
@@ -780,7 +781,7 @@ func TestHandleActivateOperationalIntentDoesNotTrustOldVersionClearFinding(t *te
 	server := NewWithWorkflows(
 		fleet,
 		service.NewIntentService(durable, deconflictionService),
-		service.NewPreflightService(durable),
+		preflight.NewPreflightService(durable),
 		service.NewConformanceService(durable, telemetry),
 		time.Second,
 		deconflictionService,

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -7,13 +7,14 @@ import (
 
 	"github.com/Aero-Arc/aero-arc-api/internal/service"
 	"github.com/Aero-Arc/aero-arc-api/internal/service/deconfliction"
+	"github.com/Aero-Arc/aero-arc-api/internal/service/preflight"
 	"github.com/mrshabel/mach"
 )
 
 type Server struct {
 	fleet          *service.FleetService
 	intents        *service.IntentService
-	preflight      *service.PreflightService
+	preflight      *preflight.PreflightService
 	conformance    *service.ConformanceService
 	deconfliction  *deconfliction.DeconflictionService
 	requestTimeout time.Duration
@@ -38,18 +39,18 @@ func New(fleet *service.FleetService, requestTimeout time.Duration) *Server {
 // Parameters:
 //   - fleet: is the *service.FleetService value supplied to NewWithWorkflows.
 //   - intents: is the *service.IntentService value supplied to NewWithWorkflows.
-//   - preflight: is the *service.PreflightService value supplied to NewWithWorkflows.
+//   - preflightSvc: is the *preflight.PreflightService value supplied to NewWithWorkflows.
 //   - conformance: is the *service.ConformanceService value supplied to NewWithWorkflows.
 //   - requestTimeout: defines the time bound applied by the operation.
 //   - deconflictionServices: is the ...*deconfliction.DeconflictionService value supplied to NewWithWorkflows.
 //
 // Returns:
 //   - result: is the *Server value produced by NewWithWorkflows.
-func NewWithWorkflows(fleet *service.FleetService, intents *service.IntentService, preflight *service.PreflightService, conformance *service.ConformanceService, requestTimeout time.Duration, deconflictionServices ...*deconfliction.DeconflictionService) *Server {
+func NewWithWorkflows(fleet *service.FleetService, intents *service.IntentService, preflightSvc *preflight.PreflightService, conformance *service.ConformanceService, requestTimeout time.Duration, deconflictionServices ...*deconfliction.DeconflictionService) *Server {
 	server := &Server{
 		fleet:          fleet,
 		intents:        intents,
-		preflight:      preflight,
+		preflight:      preflightSvc,
 		conformance:    conformance,
 		requestTimeout: requestTimeout,
 	}

--- a/internal/service/deconfliction/deconfliction_test.go
+++ b/internal/service/deconfliction/deconfliction_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Aero-Arc/aero-arc-api/internal/domain"
 	. "github.com/Aero-Arc/aero-arc-api/internal/service"
 	. "github.com/Aero-Arc/aero-arc-api/internal/service/deconfliction"
+	. "github.com/Aero-Arc/aero-arc-api/internal/service/preflight"
 	"github.com/Aero-Arc/aero-arc-api/internal/store/durable"
 	durablememory "github.com/Aero-Arc/aero-arc-api/internal/store/durable/memory"
 )

--- a/internal/service/preflight/service.go
+++ b/internal/service/preflight/service.go
@@ -1,4 +1,4 @@
-package service
+package preflight
 
 import (
 	"context"
@@ -255,4 +255,14 @@ func (b *preflightBuilder) check(category domain.PreflightCheckCategory, key, so
 		Message:         summary,
 		EvaluatedAt:     b.now,
 	})
+}
+
+func volumesForVersion(volumes []domain.OperationalVolume, version int) []domain.OperationalVolume {
+	filtered := make([]domain.OperationalVolume, 0, len(volumes))
+	for _, volume := range volumes {
+		if volume.IntentVersion == version {
+			filtered = append(filtered, volume)
+		}
+	}
+	return filtered
 }

--- a/internal/service/workflow_service_test.go
+++ b/internal/service/workflow_service_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/Aero-Arc/aero-arc-api/internal/domain"
+	preflightsvc "github.com/Aero-Arc/aero-arc-api/internal/service/preflight"
 	"github.com/Aero-Arc/aero-arc-api/internal/store/durable"
 	durablememory "github.com/Aero-Arc/aero-arc-api/internal/store/durable/memory"
 	telemetrymemory "github.com/Aero-Arc/aero-arc-api/internal/store/telemetry/memory"
@@ -460,7 +461,7 @@ func TestIntentLifecycleHappyPath(t *testing.T) {
 	seedWorkflowAircraft(t, ctx, store, now, float64Ptr(95))
 
 	intents := NewIntentServiceWithClock(store, fixedClock(now), nil)
-	preflight := NewPreflightServiceWithClock(store, fixedClock(now))
+	preflight := preflightsvc.NewPreflightServiceWithClock(store, fixedClock(now))
 
 	intent, err := intents.CreateIntent(ctx, workflowIntentRequest(now))
 	if err != nil {
@@ -679,7 +680,7 @@ func TestModifySubmittedIntentRequiresFreshPreflightForReplacementVolumes(t *tes
 	now := fixedWorkflowTime()
 	seedWorkflowAircraft(t, ctx, store, now, float64Ptr(95))
 	intent := seedSubmittedIntentWithVolume(t, ctx, store, now)
-	if evaluation, err := NewPreflightServiceWithClock(store, fixedClock(now)).EvaluateIntent(ctx, intent.ID); err != nil {
+	if evaluation, err := preflightsvc.NewPreflightServiceWithClock(store, fixedClock(now)).EvaluateIntent(ctx, intent.ID); err != nil {
 		t.Fatalf("EvaluateIntent returned error: %v", err)
 	} else if evaluation.Blocked {
 		t.Fatalf("preflight blocked unexpectedly: %#v", evaluation.Findings)
@@ -714,7 +715,7 @@ func TestModifySubmittedIntentRequiresFreshPreflightForReplacementVolumes(t *tes
 		t.Fatalf("ActivateIntent stale preflight error = %v, want ErrActivationBlocked", err)
 	}
 
-	if evaluation, err := NewPreflightServiceWithClock(store, fixedClock(modifyAt.Add(time.Minute))).EvaluateIntent(ctx, intent.ID); err != nil {
+	if evaluation, err := preflightsvc.NewPreflightServiceWithClock(store, fixedClock(modifyAt.Add(time.Minute))).EvaluateIntent(ctx, intent.ID); err != nil {
 		t.Fatalf("EvaluateIntent after modify returned error: %v", err)
 	} else if evaluation.Blocked {
 		t.Fatalf("preflight after modify blocked unexpectedly: %#v", evaluation.Findings)
@@ -891,7 +892,7 @@ func TestPreflightBlockedWhenBatterySOHMissing(t *testing.T) {
 	seedWorkflowAircraft(t, ctx, store, now, nil)
 	intent := seedSubmittedIntentWithVolume(t, ctx, store, now)
 
-	evaluation, err := NewPreflightServiceWithClock(store, fixedClock(now)).EvaluateIntent(ctx, intent.ID)
+	evaluation, err := preflightsvc.NewPreflightServiceWithClock(store, fixedClock(now)).EvaluateIntent(ctx, intent.ID)
 	if err != nil {
 		t.Fatalf("EvaluateIntent returned error: %v", err)
 	}
@@ -909,7 +910,7 @@ func TestPreflightClearOverwritesStaleBlockingFinding(t *testing.T) {
 	now := fixedWorkflowTime()
 	seedWorkflowAircraft(t, ctx, store, now, nil)
 	intent := seedSubmittedIntentWithVolume(t, ctx, store, now)
-	preflight := NewPreflightServiceWithClock(store, fixedClock(now))
+	preflight := preflightsvc.NewPreflightServiceWithClock(store, fixedClock(now))
 
 	evaluation, err := preflight.EvaluateIntent(ctx, intent.ID)
 	if err != nil {
@@ -967,7 +968,7 @@ func TestPreflightBlockedWhenCriticalMaintenanceOpen(t *testing.T) {
 	}))
 	intent := seedSubmittedIntentWithVolume(t, ctx, store, now)
 
-	evaluation, err := NewPreflightServiceWithClock(store, fixedClock(now)).EvaluateIntent(ctx, intent.ID)
+	evaluation, err := preflightsvc.NewPreflightServiceWithClock(store, fixedClock(now)).EvaluateIntent(ctx, intent.ID)
 	if err != nil {
 		t.Fatalf("EvaluateIntent returned error: %v", err)
 	}
@@ -996,7 +997,7 @@ func TestPreflightBlockedWhenOperationalVolumeMissingInlineGeoJSON(t *testing.T)
 		VolumeType:   domain.OperationalVolumeLoiter,
 	})
 
-	evaluation, err := NewPreflightServiceWithClock(store, fixedClock(now)).EvaluateIntent(ctx, intent.ID)
+	evaluation, err := preflightsvc.NewPreflightServiceWithClock(store, fixedClock(now)).EvaluateIntent(ctx, intent.ID)
 	if err != nil {
 		t.Fatalf("EvaluateIntent returned error: %v", err)
 	}
@@ -1060,7 +1061,7 @@ func TestPreflightIgnoresOperationalVolumesFromOldIntentVersion(t *testing.T) {
 		UpdatedAt:     now,
 	}))
 
-	evaluation, err := NewPreflightServiceWithClock(store, fixedClock(now)).EvaluateIntent(ctx, "intent-versioned-preflight")
+	evaluation, err := preflightsvc.NewPreflightServiceWithClock(store, fixedClock(now)).EvaluateIntent(ctx, "intent-versioned-preflight")
 	if err != nil {
 		t.Fatalf("EvaluateIntent returned error: %v", err)
 	}
@@ -1617,7 +1618,7 @@ func TestActivationReadinessIgnoresPreflightAndFindingsFromOldIntentVersion(t *t
 		Message:         "old version block",
 		EvaluatedAt:     now,
 	}))
-	evaluation, err := NewPreflightServiceWithClock(store, fixedClock(now)).EvaluateIntent(ctx, "intent-versioned-activation")
+	evaluation, err := preflightsvc.NewPreflightServiceWithClock(store, fixedClock(now)).EvaluateIntent(ctx, "intent-versioned-activation")
 	if err != nil {
 		t.Fatalf("EvaluateIntent returned error: %v", err)
 	}
@@ -1702,7 +1703,7 @@ func seedActiveIntentWithVolume(t *testing.T, ctx context.Context, store durable
 func seedActiveIntentWithVolumeRequest(t *testing.T, ctx context.Context, store durable.Store, now time.Time, volumeReq AddOperationalVolumeRequest) domain.OperationalIntent {
 	t.Helper()
 	intent := seedSubmittedIntentWithVolumeRequest(t, ctx, store, now, volumeReq)
-	if evaluation, err := NewPreflightServiceWithClock(store, fixedClock(now)).EvaluateIntent(ctx, intent.ID); err != nil {
+	if evaluation, err := preflightsvc.NewPreflightServiceWithClock(store, fixedClock(now)).EvaluateIntent(ctx, intent.ID); err != nil {
 		t.Fatalf("EvaluateIntent returned error: %v", err)
 	} else if evaluation.Blocked {
 		t.Fatalf("preflight blocked unexpectedly: %#v", evaluation.Findings)
@@ -1753,7 +1754,7 @@ func createActiveIntentWithVolume(t *testing.T, ctx context.Context, store durab
 	if intent, err = intents.SubmitIntent(ctx, intent.ID); err != nil {
 		t.Fatalf("SubmitIntent returned error: %v", err)
 	}
-	if evaluation, err := NewPreflightServiceWithClock(store, fixedClock(now)).EvaluateIntent(ctx, intent.ID); err != nil {
+	if evaluation, err := preflightsvc.NewPreflightServiceWithClock(store, fixedClock(now)).EvaluateIntent(ctx, intent.ID); err != nil {
 		t.Fatalf("EvaluateIntent returned error: %v", err)
 	} else if evaluation.Blocked {
 		t.Fatalf("preflight blocked unexpectedly: %#v", evaluation.Findings)


### PR DESCRIPTION
## Summary
- Move preflight orchestration from `internal/service/preflight_service.go` into `internal/service/preflight` as a behavior-preserving package extraction (PR 1 for #33).
- Keep existing HTTP routes, JSON shapes, check/finding IDs, `demo.v1`, demo weather/NOTAM clears, and activation order: accepted → evaluate → blocked → `IntentService.ActivateIntent`.
- No Checker/Snapshot/provider seams and no checker file splits; those belong in later PRs.

## Test plan
- [ ] `go test ./internal/service/preflight/ ./internal/service/ ./internal/httpapi/ ./internal/service/deconfliction/`
- [ ] Confirm `POST /api/v1/operational-intents/{intent_id}/preflight/evaluate` still returns `intent`, `checks`, `findings`, `blocked`
- [ ] Confirm activate still evaluates preflight before `ActivateIntent` and still blocks on a failed check