### PR TITLE
Introduce preflight Snapshot, Checker, and Builder

### DIFF
--- a/internal/httpapi/handlers_test.go
+++ b/internal/httpapi/handlers_test.go
@@ -164,7 +164,7 @@ func TestHandleBootstrapBatteryAndFlightLifecycle(t *testing.T) {
 	server := NewWithWorkflows(
 		fleet,
 		service.NewIntentService(store, nil),
-		service.NewPreflightService(store),
+		preflight.NewPreflightService(store),
 		service.NewConformanceService(store, telemetry),
 		time.Second,
 	)

--- a/internal/service/preflight/builder.go
+++ b/internal/service/preflight/builder.go
@@ -1,0 +1,96 @@
+package preflight
+
+import (
+	"fmt"
+
+	"github.com/Aero-Arc/aero-arc-api/internal/domain"
+)
+
+const ruleVersion = "demo.v1"
+
+// Builder constructs PreflightCheck and ComplianceFinding records for one evaluation.
+type Builder struct {
+	snapshot Snapshot
+	checks   []domain.PreflightCheck
+	findings []domain.ComplianceFinding
+	blocked  bool
+}
+
+func newBuilder(snapshot Snapshot) *Builder {
+	return &Builder{snapshot: snapshot}
+}
+
+func (b *Builder) Checks() []domain.PreflightCheck {
+	return b.checks
+}
+
+func (b *Builder) Findings() []domain.ComplianceFinding {
+	return b.findings
+}
+
+func (b *Builder) Blocked() bool {
+	return b.blocked
+}
+
+func (b *Builder) Clear(category domain.PreflightCheckCategory, key, source, requirementCode, summary string) {
+	b.record(category, key, source, requirementCode, summary, "", domain.PreflightStatusClear, false)
+}
+
+func (b *Builder) Block(category domain.PreflightCheckCategory, key, source, requirementCode, summary, remediation string) {
+	b.record(category, key, source, requirementCode, summary, remediation, domain.PreflightStatusBlocked, true)
+	b.blocked = true
+}
+
+func (b *Builder) record(category domain.PreflightCheckCategory, key, source, requirementCode, summary, remediation string, status domain.PreflightStatus, blocking bool) {
+	intent := b.snapshot.Intent
+	check := domain.PreflightCheck{
+		ID:              fmt.Sprintf("preflight-%s-v%d-%s", intent.ID, intent.Version, key),
+		OperatorID:      intent.OperatorID,
+		IntentID:        intent.ID,
+		IntentVersion:   intent.Version,
+		AircraftID:      intent.AircraftID,
+		Category:        category,
+		Source:          source,
+		Status:          status,
+		Summary:         summary,
+		RequirementCode: requirementCode,
+		RuleVersion:     ruleVersion,
+		Blocking:        blocking,
+		CapturedAt:      b.snapshot.Now,
+	}
+	b.checks = append(b.checks, check)
+	if !blocking {
+		b.findings = append(b.findings, domain.ComplianceFinding{
+			ID:              fmt.Sprintf("finding-%s-v%d-%s", intent.ID, intent.Version, key),
+			OperatorID:      intent.OperatorID,
+			IntentID:        intent.ID,
+			IntentVersion:   intent.Version,
+			SubjectType:     "operational_intent",
+			SubjectID:       intent.ID,
+			RequirementCode: requirementCode,
+			Status:          domain.ComplianceFindingPass,
+			Severity:        domain.SeverityInfo,
+			Blocking:        false,
+			RuleVersion:     ruleVersion,
+			Message:         summary,
+			EvaluatedAt:     b.snapshot.Now,
+		})
+		return
+	}
+	b.findings = append(b.findings, domain.ComplianceFinding{
+		ID:              fmt.Sprintf("finding-%s-v%d-%s", intent.ID, intent.Version, key),
+		OperatorID:      intent.OperatorID,
+		IntentID:        intent.ID,
+		IntentVersion:   intent.Version,
+		SubjectType:     "operational_intent",
+		SubjectID:       intent.ID,
+		RequirementCode: requirementCode,
+		Status:          domain.ComplianceFindingFail,
+		Severity:        domain.SeverityCritical,
+		Blocking:        true,
+		RuleVersion:     ruleVersion,
+		Remediation:     remediation,
+		Message:         summary,
+		EvaluatedAt:     b.snapshot.Now,
+	})
+}

--- a/internal/service/preflight/builder_test.go
+++ b/internal/service/preflight/builder_test.go
@@ -1,0 +1,82 @@
+package preflight
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Aero-Arc/aero-arc-api/internal/domain"
+)
+
+func testSnapshot(now time.Time) Snapshot {
+	return Snapshot{
+		Intent: domain.OperationalIntent{
+			ID:         "intent-1",
+			Version:    2,
+			OperatorID: "operator-1",
+			AircraftID: "aircraft-1",
+		},
+		Now: now,
+	}
+}
+
+func TestBuilderClearWritesPassFinding(t *testing.T) {
+	now := time.Date(2026, time.January, 15, 12, 0, 0, 0, time.UTC)
+	builder := newBuilder(testSnapshot(now))
+	builder.Clear(domain.PreflightCheckAirspace, "aircraft_exists", "fleet_registry", "AIRCRAFT-EXISTS", "aircraft exists")
+
+	if builder.Blocked() {
+		t.Fatal("clear should not block")
+	}
+	if len(builder.Checks()) != 1 || len(builder.Findings()) != 1 {
+		t.Fatalf("checks=%d findings=%d, want 1 each", len(builder.Checks()), len(builder.Findings()))
+	}
+
+	check := builder.Checks()[0]
+	if check.ID != "preflight-intent-1-v2-aircraft_exists" {
+		t.Fatalf("check ID = %q", check.ID)
+	}
+	if check.Status != domain.PreflightStatusClear || check.Blocking || check.RuleVersion != "demo.v1" {
+		t.Fatalf("check = %#v", check)
+	}
+	if !check.CapturedAt.Equal(now) {
+		t.Fatalf("CapturedAt = %v, want %v", check.CapturedAt, now)
+	}
+
+	finding := builder.Findings()[0]
+	if finding.ID != "finding-intent-1-v2-aircraft_exists" {
+		t.Fatalf("finding ID = %q", finding.ID)
+	}
+	if finding.Status != domain.ComplianceFindingPass || finding.Severity != domain.SeverityInfo || finding.Blocking {
+		t.Fatalf("finding = %#v", finding)
+	}
+	if finding.RuleVersion != "demo.v1" || finding.Remediation != "" {
+		t.Fatalf("finding = %#v", finding)
+	}
+	if !finding.EvaluatedAt.Equal(now) {
+		t.Fatalf("EvaluatedAt = %v, want %v", finding.EvaluatedAt, now)
+	}
+}
+
+func TestBuilderBlockWritesFailFinding(t *testing.T) {
+	now := time.Date(2026, time.January, 15, 12, 0, 0, 0, time.UTC)
+	builder := newBuilder(testSnapshot(now))
+	builder.Block(domain.PreflightCheckBattery, "battery_soh_known", "maintenance_control", "BATTERY-SOH-KNOWN", "battery state of health is unknown", "record battery state of health")
+
+	if !builder.Blocked() {
+		t.Fatal("block should set blocked")
+	}
+	check := builder.Checks()[0]
+	if check.ID != "preflight-intent-1-v2-battery_soh_known" || check.Status != domain.PreflightStatusBlocked || !check.Blocking {
+		t.Fatalf("check = %#v", check)
+	}
+	finding := builder.Findings()[0]
+	if finding.ID != "finding-intent-1-v2-battery_soh_known" {
+		t.Fatalf("finding ID = %q", finding.ID)
+	}
+	if finding.Status != domain.ComplianceFindingFail || finding.Severity != domain.SeverityCritical || !finding.Blocking {
+		t.Fatalf("finding = %#v", finding)
+	}
+	if finding.Remediation != "record battery state of health" {
+		t.Fatalf("remediation = %q", finding.Remediation)
+	}
+}

--- a/internal/service/preflight/checker.go
+++ b/internal/service/preflight/checker.go
@@ -1,0 +1,10 @@
+package preflight
+
+import "context"
+
+// Checker evaluates one readiness concern against a Snapshot and records
+// results through Builder. Existing policy stays in service.go until PR 3.
+type Checker interface {
+	Name() string
+	Evaluate(ctx context.Context, snapshot Snapshot, builder *Builder)
+}

--- a/internal/service/preflight/service.go
+++ b/internal/service/preflight/service.go
@@ -10,8 +10,9 @@ import (
 )
 
 type PreflightService struct {
-	durable durable.Store
-	now     func() time.Time
+	durable  durable.Store
+	now      func() time.Time
+	checkers []Checker
 }
 
 type PreflightEvaluation struct {
@@ -44,7 +45,11 @@ func NewPreflightServiceWithClock(durableStore durable.Store, now func() time.Ti
 	if now == nil {
 		now = func() time.Time { return time.Now().UTC() }
 	}
-	return &PreflightService{durable: durableStore, now: now}
+	return &PreflightService{
+		durable:  durableStore,
+		now:      now,
+		checkers: []Checker{currentPolicy{durable: durableStore}},
+	}
 }
 
 // EvaluateIntent runs the current preflight policy against an operational
@@ -58,211 +63,135 @@ func NewPreflightServiceWithClock(durableStore durable.Store, now func() time.Ti
 //   - result: is the PreflightEvaluation value produced by EvaluateIntent.
 //   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *PreflightService) EvaluateIntent(ctx context.Context, intentID string) (PreflightEvaluation, error) {
-	intent, err := s.durable.GetOperationalIntent(ctx, intentID)
+	snapshot, err := s.loadSnapshot(ctx, intentID)
 	if err != nil {
-		return PreflightEvaluation{}, fmt.Errorf("get operational intent: %w", err)
+		return PreflightEvaluation{}, err
 	}
 
-	aircraft, aircraftErr := s.durable.GetAircraft(ctx, intent.AircraftID)
-	volumes, err := s.durable.ListOperationalVolumes(ctx, intent.ID)
-	if err != nil {
-		return PreflightEvaluation{}, fmt.Errorf("list operational volumes: %w", err)
-	}
-	volumes = volumesForVersion(volumes, intent.Version)
-
-	now := s.now().UTC()
-	builder := preflightBuilder{intent: intent, now: now}
-	if aircraftErr != nil {
-		builder.block(domain.PreflightCheckAirspace, "aircraft_exists", "fleet_registry", "AIRCRAFT-EXISTS", "aircraft does not exist", "create or select a valid aircraft")
-	} else {
-		builder.clear(domain.PreflightCheckAirspace, "aircraft_exists", "fleet_registry", "AIRCRAFT-EXISTS", "aircraft exists")
-		if aircraft.Status != domain.AircraftStatusActive || aircraft.AcceptanceStatus != domain.AcceptanceStatusAccepted {
-			builder.block(domain.PreflightCheckAirspace, "aircraft_operational_status", "fleet_registry", "AIRCRAFT-STATUS", "aircraft is not active or accepted", "set aircraft active or complete acceptance")
-		} else {
-			builder.clear(domain.PreflightCheckAirspace, "aircraft_operational_status", "fleet_registry", "AIRCRAFT-STATUS", "aircraft status allows operation")
-		}
-		if aircraft.RemoteIDStatus == domain.RemoteIDStatusOffline {
-			builder.block(domain.PreflightCheckRemoteID, "remote_id_online", "remote_id_monitor", "RID-ONLINE", "remote ID is offline", "restore Remote ID broadcast before activation")
-		} else {
-			builder.clear(domain.PreflightCheckRemoteID, "remote_id_online", "remote_id_monitor", "RID-ONLINE", "remote ID is not offline")
-		}
+	builder := newBuilder(snapshot)
+	for _, checker := range s.checkers {
+		checker.Evaluate(ctx, snapshot, builder)
 	}
 
-	if intent.PlannedStartAt.Before(intent.PlannedEndAt) {
-		builder.clear(domain.PreflightCheckAirspace, "intent_time_window", "intent_service", "INTENT-WINDOW", "intent planned time window is valid")
-	} else {
-		builder.block(domain.PreflightCheckAirspace, "intent_time_window", "intent_service", "INTENT-WINDOW", "intent planned start must be before planned end", "set planned_start_at before planned_end_at")
-	}
-
-	if len(volumes) == 0 {
-		builder.block(domain.PreflightCheckAirspace, "operational_volume_exists", "intent_service", "VOLUME-EXISTS", "at least one operational volume is required", "add an operational volume")
-	} else {
-		builder.clear(domain.PreflightCheckAirspace, "operational_volume_exists", "intent_service", "VOLUME-EXISTS", "operational volume exists")
-	}
-	for _, volume := range volumes {
-		prefix := fmt.Sprintf("volume_%s", volume.ID)
-		if volume.StartsAt.Before(volume.EndsAt) {
-			builder.clear(domain.PreflightCheckAirspace, prefix+"_time_window", "intent_service", "VOLUME-WINDOW", "operational volume time window is valid")
-		} else {
-			builder.block(domain.PreflightCheckAirspace, prefix+"_time_window", "intent_service", "VOLUME-WINDOW", "operational volume start must be before end", "set volume starts_at before ends_at")
-		}
-		if volume.MinAltitudeM <= volume.MaxAltitudeM {
-			builder.clear(domain.PreflightCheckAirspace, prefix+"_altitude_range", "intent_service", "VOLUME-ALTITUDE", "operational volume altitude range is valid")
-		} else {
-			builder.block(domain.PreflightCheckAirspace, prefix+"_altitude_range", "intent_service", "VOLUME-ALTITUDE", "operational volume minimum altitude exceeds maximum altitude", "set min_altitude_m <= max_altitude_m")
-		}
-		if !volume.StartsAt.Before(intent.PlannedStartAt) && !volume.EndsAt.After(intent.PlannedEndAt) {
-			builder.clear(domain.PreflightCheckAirspace, prefix+"_inside_intent_window", "intent_service", "VOLUME-IN-INTENT", "operational volume is inside planned intent window")
-		} else {
-			builder.block(domain.PreflightCheckAirspace, prefix+"_inside_intent_window", "intent_service", "VOLUME-IN-INTENT", "operational volume must be inside planned intent window", "adjust volume or planned intent time window")
-		}
-		if volume.GeoJSON != "" {
-			builder.clear(domain.PreflightCheckAirspace, prefix+"_inline_geojson", "intent_service", "VOLUME-GEOJSON", "operational volume has inline GeoJSON evaluable by this server")
-		} else {
-			builder.block(domain.PreflightCheckAirspace, prefix+"_inline_geojson", "intent_service", "VOLUME-GEOJSON", "operational volume requires inline GeoJSON for local conformance evaluation", "provide inline GeoJSON; geometry_uri resolution is not implemented")
-		}
-	}
-
-	s.evaluateBattery(ctx, &builder, intent)
-	s.evaluateMaintenance(ctx, &builder, intent)
-	builder.clear(domain.PreflightCheckWeather, "demo_weather", "demo_weather_provider", "WX-DEMO", "demo weather check clear")
-	builder.clear(domain.PreflightCheckNOTAM, "demo_notam", "demo_notam_provider", "NOTAM-DEMO", "demo NOTAM check clear")
-
-	for _, check := range builder.checks {
+	for _, check := range builder.Checks() {
 		if err := s.durable.RecordPreflightCheck(ctx, check); err != nil {
 			return PreflightEvaluation{}, fmt.Errorf("record preflight check: %w", err)
 		}
 	}
-	for _, finding := range builder.findings {
+	for _, finding := range builder.Findings() {
 		if err := s.durable.RecordComplianceFinding(ctx, finding); err != nil {
 			return PreflightEvaluation{}, fmt.Errorf("record compliance finding: %w", err)
 		}
 	}
 
 	return PreflightEvaluation{
-		Intent:   intent,
-		Checks:   builder.checks,
-		Findings: builder.findings,
-		Blocked:  builder.blocked,
+		Intent:   snapshot.Intent,
+		Checks:   builder.Checks(),
+		Findings: builder.Findings(),
+		Blocked:  builder.Blocked(),
 	}, nil
 }
 
-func (s *PreflightService) evaluateBattery(ctx context.Context, builder *preflightBuilder, intent domain.OperationalIntent) {
-	installation, err := s.durable.GetActiveBatteryInstallation(ctx, intent.AircraftID)
+type currentPolicy struct {
+	durable durable.Store
+}
+
+func (currentPolicy) Name() string { return "current_policy" }
+
+func (c currentPolicy) Evaluate(ctx context.Context, snapshot Snapshot, builder *Builder) {
+	if snapshot.AircraftErr != nil {
+		builder.Block(domain.PreflightCheckAirspace, "aircraft_exists", "fleet_registry", "AIRCRAFT-EXISTS", "aircraft does not exist", "create or select a valid aircraft")
+	} else {
+		builder.Clear(domain.PreflightCheckAirspace, "aircraft_exists", "fleet_registry", "AIRCRAFT-EXISTS", "aircraft exists")
+		if snapshot.Aircraft.Status != domain.AircraftStatusActive || snapshot.Aircraft.AcceptanceStatus != domain.AcceptanceStatusAccepted {
+			builder.Block(domain.PreflightCheckAirspace, "aircraft_operational_status", "fleet_registry", "AIRCRAFT-STATUS", "aircraft is not active or accepted", "set aircraft active or complete acceptance")
+		} else {
+			builder.Clear(domain.PreflightCheckAirspace, "aircraft_operational_status", "fleet_registry", "AIRCRAFT-STATUS", "aircraft status allows operation")
+		}
+		if snapshot.Aircraft.RemoteIDStatus == domain.RemoteIDStatusOffline {
+			builder.Block(domain.PreflightCheckRemoteID, "remote_id_online", "remote_id_monitor", "RID-ONLINE", "remote ID is offline", "restore Remote ID broadcast before activation")
+		} else {
+			builder.Clear(domain.PreflightCheckRemoteID, "remote_id_online", "remote_id_monitor", "RID-ONLINE", "remote ID is not offline")
+		}
+	}
+
+	if snapshot.Intent.PlannedStartAt.Before(snapshot.Intent.PlannedEndAt) {
+		builder.Clear(domain.PreflightCheckAirspace, "intent_time_window", "intent_service", "INTENT-WINDOW", "intent planned time window is valid")
+	} else {
+		builder.Block(domain.PreflightCheckAirspace, "intent_time_window", "intent_service", "INTENT-WINDOW", "intent planned start must be before planned end", "set planned_start_at before planned_end_at")
+	}
+
+	if len(snapshot.Volumes) == 0 {
+		builder.Block(domain.PreflightCheckAirspace, "operational_volume_exists", "intent_service", "VOLUME-EXISTS", "at least one operational volume is required", "add an operational volume")
+	} else {
+		builder.Clear(domain.PreflightCheckAirspace, "operational_volume_exists", "intent_service", "VOLUME-EXISTS", "operational volume exists")
+	}
+	for _, volume := range snapshot.Volumes {
+		prefix := fmt.Sprintf("volume_%s", volume.ID)
+		if volume.StartsAt.Before(volume.EndsAt) {
+			builder.Clear(domain.PreflightCheckAirspace, prefix+"_time_window", "intent_service", "VOLUME-WINDOW", "operational volume time window is valid")
+		} else {
+			builder.Block(domain.PreflightCheckAirspace, prefix+"_time_window", "intent_service", "VOLUME-WINDOW", "operational volume start must be before end", "set volume starts_at before ends_at")
+		}
+		if volume.MinAltitudeM <= volume.MaxAltitudeM {
+			builder.Clear(domain.PreflightCheckAirspace, prefix+"_altitude_range", "intent_service", "VOLUME-ALTITUDE", "operational volume altitude range is valid")
+		} else {
+			builder.Block(domain.PreflightCheckAirspace, prefix+"_altitude_range", "intent_service", "VOLUME-ALTITUDE", "operational volume minimum altitude exceeds maximum altitude", "set min_altitude_m <= max_altitude_m")
+		}
+		if !volume.StartsAt.Before(snapshot.Intent.PlannedStartAt) && !volume.EndsAt.After(snapshot.Intent.PlannedEndAt) {
+			builder.Clear(domain.PreflightCheckAirspace, prefix+"_inside_intent_window", "intent_service", "VOLUME-IN-INTENT", "operational volume is inside planned intent window")
+		} else {
+			builder.Block(domain.PreflightCheckAirspace, prefix+"_inside_intent_window", "intent_service", "VOLUME-IN-INTENT", "operational volume must be inside planned intent window", "adjust volume or planned intent time window")
+		}
+		if volume.GeoJSON != "" {
+			builder.Clear(domain.PreflightCheckAirspace, prefix+"_inline_geojson", "intent_service", "VOLUME-GEOJSON", "operational volume has inline GeoJSON evaluable by this server")
+		} else {
+			builder.Block(domain.PreflightCheckAirspace, prefix+"_inline_geojson", "intent_service", "VOLUME-GEOJSON", "operational volume requires inline GeoJSON for local conformance evaluation", "provide inline GeoJSON; geometry_uri resolution is not implemented")
+		}
+	}
+
+	c.evaluateBattery(ctx, snapshot, builder)
+	c.evaluateMaintenance(ctx, snapshot, builder)
+	builder.Clear(domain.PreflightCheckWeather, "demo_weather", "demo_weather_provider", "WX-DEMO", "demo weather check clear")
+	builder.Clear(domain.PreflightCheckNOTAM, "demo_notam", "demo_notam_provider", "NOTAM-DEMO", "demo NOTAM check clear")
+}
+
+func (c currentPolicy) evaluateBattery(ctx context.Context, snapshot Snapshot, builder *Builder) {
+	installation, err := c.durable.GetActiveBatteryInstallation(ctx, snapshot.Intent.AircraftID)
 	if err != nil || installation == nil {
-		builder.block(domain.PreflightCheckBattery, "battery_installed", "maintenance_control", "BATTERY-INSTALLED", "battery is not installed", "install a battery")
+		builder.Block(domain.PreflightCheckBattery, "battery_installed", "maintenance_control", "BATTERY-INSTALLED", "battery is not installed", "install a battery")
 		return
 	}
-	builder.clear(domain.PreflightCheckBattery, "battery_installed", "maintenance_control", "BATTERY-INSTALLED", "battery is installed")
+	builder.Clear(domain.PreflightCheckBattery, "battery_installed", "maintenance_control", "BATTERY-INSTALLED", "battery is installed")
 
-	battery, err := s.durable.GetBattery(ctx, installation.BatteryID)
+	battery, err := c.durable.GetBattery(ctx, installation.BatteryID)
 	if err != nil {
-		builder.block(domain.PreflightCheckBattery, "battery_soh_known", "maintenance_control", "BATTERY-SOH-KNOWN", "battery state of health is unknown", "record battery state of health")
+		builder.Block(domain.PreflightCheckBattery, "battery_soh_known", "maintenance_control", "BATTERY-SOH-KNOWN", "battery state of health is unknown", "record battery state of health")
 		return
 	}
 	if battery.StateOfHealth == nil {
-		builder.block(domain.PreflightCheckBattery, "battery_soh_known", "maintenance_control", "BATTERY-SOH-KNOWN", "battery state of health is unknown", "record battery state of health")
+		builder.Block(domain.PreflightCheckBattery, "battery_soh_known", "maintenance_control", "BATTERY-SOH-KNOWN", "battery state of health is unknown", "record battery state of health")
 		return
 	}
-	builder.clear(domain.PreflightCheckBattery, "battery_soh_known", "maintenance_control", "BATTERY-SOH-KNOWN", "battery state of health is known")
+	builder.Clear(domain.PreflightCheckBattery, "battery_soh_known", "maintenance_control", "BATTERY-SOH-KNOWN", "battery state of health is known")
 	if *battery.StateOfHealth < 80 {
-		builder.block(domain.PreflightCheckBattery, "battery_soh_minimum", "maintenance_control", "BATTERY-SOH-80", "battery state of health is below 80", "replace or service battery")
+		builder.Block(domain.PreflightCheckBattery, "battery_soh_minimum", "maintenance_control", "BATTERY-SOH-80", "battery state of health is below 80", "replace or service battery")
 		return
 	}
-	builder.clear(domain.PreflightCheckBattery, "battery_soh_minimum", "maintenance_control", "BATTERY-SOH-80", "battery state of health is at least 80")
+	builder.Clear(domain.PreflightCheckBattery, "battery_soh_minimum", "maintenance_control", "BATTERY-SOH-80", "battery state of health is at least 80")
 }
 
-func (s *PreflightService) evaluateMaintenance(ctx context.Context, builder *preflightBuilder, intent domain.OperationalIntent) {
-	events, err := s.durable.ListMaintenanceEvents(ctx, intent.AircraftID)
+func (c currentPolicy) evaluateMaintenance(ctx context.Context, snapshot Snapshot, builder *Builder) {
+	events, err := c.durable.ListMaintenanceEvents(ctx, snapshot.Intent.AircraftID)
 	if err != nil {
-		builder.block(domain.PreflightCheckMaintenance, "maintenance_events_available", "maintenance_control", "MX-AVAILABLE", "maintenance status could not be loaded", "retry maintenance status lookup")
+		builder.Block(domain.PreflightCheckMaintenance, "maintenance_events_available", "maintenance_control", "MX-AVAILABLE", "maintenance status could not be loaded", "retry maintenance status lookup")
 		return
 	}
 	for _, event := range events {
 		if event.Severity == domain.SeverityCritical && event.ResolvedAt == nil && event.Status != domain.MaintenanceStatusClosed {
-			builder.block(domain.PreflightCheckMaintenance, "critical_open_maintenance", "maintenance_control", "MX-CRITICAL-OPEN", "critical open maintenance event exists", "resolve critical maintenance before activation")
+			builder.Block(domain.PreflightCheckMaintenance, "critical_open_maintenance", "maintenance_control", "MX-CRITICAL-OPEN", "critical open maintenance event exists", "resolve critical maintenance before activation")
 			return
 		}
 	}
-	builder.clear(domain.PreflightCheckMaintenance, "critical_open_maintenance", "maintenance_control", "MX-CRITICAL-OPEN", "no critical open maintenance events")
-}
-
-type preflightBuilder struct {
-	intent   domain.OperationalIntent
-	now      time.Time
-	checks   []domain.PreflightCheck
-	findings []domain.ComplianceFinding
-	blocked  bool
-}
-
-func (b *preflightBuilder) clear(category domain.PreflightCheckCategory, key, source, requirementCode, summary string) {
-	b.check(category, key, source, requirementCode, summary, "", domain.PreflightStatusClear, false)
-}
-
-func (b *preflightBuilder) block(category domain.PreflightCheckCategory, key, source, requirementCode, summary, remediation string) {
-	b.check(category, key, source, requirementCode, summary, remediation, domain.PreflightStatusBlocked, true)
-	b.blocked = true
-}
-
-func (b *preflightBuilder) check(category domain.PreflightCheckCategory, key, source, requirementCode, summary, remediation string, status domain.PreflightStatus, blocking bool) {
-	check := domain.PreflightCheck{
-		ID:              fmt.Sprintf("preflight-%s-v%d-%s", b.intent.ID, b.intent.Version, key),
-		OperatorID:      b.intent.OperatorID,
-		IntentID:        b.intent.ID,
-		IntentVersion:   b.intent.Version,
-		AircraftID:      b.intent.AircraftID,
-		Category:        category,
-		Source:          source,
-		Status:          status,
-		Summary:         summary,
-		RequirementCode: requirementCode,
-		RuleVersion:     "demo.v1",
-		Blocking:        blocking,
-		CapturedAt:      b.now,
-	}
-	b.checks = append(b.checks, check)
-	if !blocking {
-		b.findings = append(b.findings, domain.ComplianceFinding{
-			ID:              fmt.Sprintf("finding-%s-v%d-%s", b.intent.ID, b.intent.Version, key),
-			OperatorID:      b.intent.OperatorID,
-			IntentID:        b.intent.ID,
-			IntentVersion:   b.intent.Version,
-			SubjectType:     "operational_intent",
-			SubjectID:       b.intent.ID,
-			RequirementCode: requirementCode,
-			Status:          domain.ComplianceFindingPass,
-			Severity:        domain.SeverityInfo,
-			Blocking:        false,
-			RuleVersion:     "demo.v1",
-			Message:         summary,
-			EvaluatedAt:     b.now,
-		})
-		return
-	}
-	b.findings = append(b.findings, domain.ComplianceFinding{
-		ID:              fmt.Sprintf("finding-%s-v%d-%s", b.intent.ID, b.intent.Version, key),
-		OperatorID:      b.intent.OperatorID,
-		IntentID:        b.intent.ID,
-		IntentVersion:   b.intent.Version,
-		SubjectType:     "operational_intent",
-		SubjectID:       b.intent.ID,
-		RequirementCode: requirementCode,
-		Status:          domain.ComplianceFindingFail,
-		Severity:        domain.SeverityCritical,
-		Blocking:        true,
-		RuleVersion:     "demo.v1",
-		Remediation:     remediation,
-		Message:         summary,
-		EvaluatedAt:     b.now,
-	})
-}
-
-func volumesForVersion(volumes []domain.OperationalVolume, version int) []domain.OperationalVolume {
-	filtered := make([]domain.OperationalVolume, 0, len(volumes))
-	for _, volume := range volumes {
-		if volume.IntentVersion == version {
-			filtered = append(filtered, volume)
-		}
-	}
-	return filtered
+	builder.Clear(domain.PreflightCheckMaintenance, "critical_open_maintenance", "maintenance_control", "MX-CRITICAL-OPEN", "no critical open maintenance events")
 }

--- a/internal/service/preflight/snapshot.go
+++ b/internal/service/preflight/snapshot.go
@@ -1,0 +1,49 @@
+package preflight
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/Aero-Arc/aero-arc-api/internal/domain"
+)
+
+// Snapshot is the immutable input state for one preflight evaluation.
+type Snapshot struct {
+	Intent      domain.OperationalIntent
+	Aircraft    domain.Aircraft
+	AircraftErr error
+	Volumes     []domain.OperationalVolume
+	Now         time.Time
+}
+
+func (s *PreflightService) loadSnapshot(ctx context.Context, intentID string) (Snapshot, error) {
+	intent, err := s.durable.GetOperationalIntent(ctx, intentID)
+	if err != nil {
+		return Snapshot{}, fmt.Errorf("get operational intent: %w", err)
+	}
+
+	aircraft, aircraftErr := s.durable.GetAircraft(ctx, intent.AircraftID)
+	volumes, err := s.durable.ListOperationalVolumes(ctx, intent.ID)
+	if err != nil {
+		return Snapshot{}, fmt.Errorf("list operational volumes: %w", err)
+	}
+
+	return Snapshot{
+		Intent:      intent,
+		Aircraft:    aircraft,
+		AircraftErr: aircraftErr,
+		Volumes:     volumesForVersion(volumes, intent.Version),
+		Now:         s.now().UTC(),
+	}, nil
+}
+
+func volumesForVersion(volumes []domain.OperationalVolume, version int) []domain.OperationalVolume {
+	filtered := make([]domain.OperationalVolume, 0, len(volumes))
+	for _, volume := range volumes {
+		if volume.IntentVersion == version {
+			filtered = append(filtered, volume)
+		}
+	}
+	return filtered
+}

--- a/internal/service/preflight/snapshot_test.go
+++ b/internal/service/preflight/snapshot_test.go
@@ -1,0 +1,80 @@
+package preflight
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/Aero-Arc/aero-arc-api/internal/domain"
+	"github.com/Aero-Arc/aero-arc-api/internal/store/durable"
+	durablememory "github.com/Aero-Arc/aero-arc-api/internal/store/durable/memory"
+)
+
+func TestVolumesForVersionKeepsCurrentIntentVersion(t *testing.T) {
+	volumes := []domain.OperationalVolume{
+		{ID: "old", IntentVersion: 1},
+		{ID: "current", IntentVersion: 2},
+		{ID: "other", IntentVersion: 3},
+	}
+	got := volumesForVersion(volumes, 2)
+	if len(got) != 1 || got[0].ID != "current" {
+		t.Fatalf("volumesForVersion = %#v, want only current", got)
+	}
+}
+
+func TestLoadSnapshotPreservesMissingAircraftAsCheckInput(t *testing.T) {
+	ctx := context.Background()
+	store := durablememory.NewStore()
+	now := time.Date(2026, time.January, 15, 12, 0, 0, 0, time.UTC)
+	if err := store.CreateOperationalIntent(ctx, domain.OperationalIntent{
+		ID:             "intent-1",
+		AircraftID:     "missing-aircraft",
+		Version:        2,
+		PlannedStartAt: now,
+		PlannedEndAt:   now.Add(time.Hour),
+		UpdatedAt:      now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.RecordOperationalVolume(ctx, domain.OperationalVolume{
+		ID:            "volume-old",
+		IntentID:      "intent-1",
+		IntentVersion: 1,
+		UpdatedAt:     now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.RecordOperationalVolume(ctx, domain.OperationalVolume{
+		ID:            "volume-current",
+		IntentID:      "intent-1",
+		IntentVersion: 2,
+		UpdatedAt:     now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	service := NewPreflightServiceWithClock(store, func() time.Time { return now })
+	snapshot, err := service.loadSnapshot(ctx, "intent-1")
+	if err != nil {
+		t.Fatalf("loadSnapshot returned error: %v", err)
+	}
+	if snapshot.AircraftErr == nil || !errors.Is(snapshot.AircraftErr, durable.ErrNotFound) {
+		t.Fatalf("AircraftErr = %v, want durable.ErrNotFound", snapshot.AircraftErr)
+	}
+	if len(snapshot.Volumes) != 1 || snapshot.Volumes[0].ID != "volume-current" {
+		t.Fatalf("volumes = %#v, want current version only", snapshot.Volumes)
+	}
+	if !snapshot.Now.Equal(now) {
+		t.Fatalf("Now = %v, want %v", snapshot.Now, now)
+	}
+}
+
+func TestLoadSnapshotMissingIntentIsAnError(t *testing.T) {
+	ctx := context.Background()
+	service := NewPreflightService(durablememory.NewStore())
+	_, err := service.loadSnapshot(ctx, "missing")
+	if err == nil || !errors.Is(err, durable.ErrNotFound) {
+		t.Fatalf("error = %v, want wrapped durable.ErrNotFound", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Stacked on #34. This is a **separate PR** for outline PR 2 only; do not squash it into the extract.
- Add `Snapshot`, `Checker`, and `Builder` in `internal/service/preflight` and route `EvaluateIntent` through them.
- Keep existing readiness rules in one `currentPolicy` checker in `service.go`. No dedicated aircraft/volume/battery/maintenance files, no weather/NOTAM providers, and no HTTP/JSON/ID/`demo.v1`/activation changes.

## Test plan
- [ ] `go test ./internal/service/preflight/ ./internal/service/ ./internal/httpapi/`
- [ ] Confirm evaluate/activate JSON and check/finding IDs are unchanged
- [ ] Confirm checks still persist before findings
- [ ] Confirm current-version volumes only are evaluated