### PR TITLE
Read live conformance and enforce one active flight

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,9 @@ Fleet and replay:
 - `GET /api/v1/aircraft/{aircraft_id}`
 - `GET /api/v1/aircraft/{aircraft_id}/map?limit=500`
 - `GET /api/v1/aircraft/{aircraft_id}/flights`
+- `POST /api/v1/aircraft/{aircraft_id}/battery-installations`
 - `GET /api/v1/flights/{flight_id}`
+- `POST /api/v1/flights/{flight_id}/start`
 - `GET /api/v1/flights/{flight_id}/replay?limit=500`
 - `POST /api/v1/batteries`
 - `POST /api/v1/maintenance-events`
@@ -294,8 +296,53 @@ Operational workflows:
 - `GET /api/v1/operational-intents/{intent_id}/coordination`
 - `POST /api/v1/operational-intents/{intent_id}/accept`
 - `POST /api/v1/operational-intents/{intent_id}/activate`
+- `POST /api/v1/operational-intents/{intent_id}/flights`
 - `GET /api/v1/operational-intents/{intent_id}/conformance`
 - `POST /api/v1/telemetry`
+
+### No-seed battery and flight bootstrap
+
+An aircraft must have a healthy active battery installation before preflight
+can clear and an intent can activate. Create the battery with `POST
+/api/v1/batteries`, then install it with:
+
+```json
+POST /api/v1/aircraft/{aircraft_id}/battery-installations
+{
+  "id": "installation-1",
+  "battery_id": "battery-1",
+  "operator_id": "operator-1"
+}
+```
+
+`operator_id` is optional when it can be derived from the aircraft and battery;
+all nonempty operator IDs must agree. `installed_at` is optional and defaults to
+server time. A second active installation for the same aircraft returns `409`
+rather than silently replacing physical state.
+
+Reserve the flight identity while the linked intent is accepted or active:
+
+```json
+POST /api/v1/operational-intents/{intent_id}/flights
+{
+  "id": "flight-1",
+  "operator_id": "operator-1",
+  "mission_type": "sitl"
+}
+```
+
+The API derives `aircraft_id`, `intent_id`, `intent_version`, and the effective
+operator from authoritative records and creates a `planned` flight. After the
+exact linked intent version becomes active, start the flight with an empty
+`POST /api/v1/flights/{flight_id}/start`. Starting assigns server time to
+`started_at`; retrying an already-active flight is idempotent. Starting against
+an accepted, superseded, completed, or otherwise non-active intent returns
+`409`.
+
+These operator-console routes follow the API's current local, unauthenticated
+single-operator deployment posture. They enforce operator consistency between
+linked records, but they are not a substitute for the authentication, tenancy,
+and authorization layer required before external exposure.
 
 Authenticated USS-to-USS SCD endpoints, enabled with
 `AERO_API_USS_BASE_URL`:

--- a/docs/ui-data-contract.md
+++ b/docs/ui-data-contract.md
@@ -123,6 +123,40 @@ observation malformed. Optional numeric fields are nullable in API JSON so an
 omitted column is never coerced to zero. A malformed row is isolated to its
 aircraft/message group; independently sampled valid groups remain available.
 
+## Live Conformance Contract
+
+`GET /api/v1/operations` and `GET /api/v1/conformance` batch-read current live
+Conformance projections from Registry using the deterministic
+`assignment_id == intent_id` contract. The API never performs one Registry call
+per intent. Missing, expired, unavailable, or not-yet-implemented Registry
+projections do not fail either dashboard.
+
+Each summary preserves the legacy durable fields (`id`, `operator_id`,
+`intent_id`, `intent_version`, `flight_id`, `aircraft_id`, `status`, `score`,
+`alert_count`, `reportability_status`, and `updated_at`) and may add these live
+fields:
+
+- `assignment_id`, `assignment_generation`
+- `evaluation_revision`, `evaluation_id`
+- `condition`: `unknown`, `conforming`, `suspected`, `non_conforming`, or
+  `recovering`
+- `monitoring_status`: `received`, `armed`, `current`, `stale`, or `unavailable`
+- `recording_status`: `pending`, `confirmed`, or `degraded`
+- `observed_at`, `frame_id`
+- `violations`: current violation summaries containing `violation_type`,
+  `phase`, optional opening/observation timestamps and frame identity, and
+  `worst_deviation_m`
+
+Registry is the replaceable source for current state, not incident history.
+The `events` array in the Conformance dashboard and durable legacy fields such
+as score, alert count, and reportability remain sourced from the API store. A
+live projection for the same intent version overlays its current condition and
+cursor fields without erasing those durable values. A live-only projection is
+also returned so a no-seed flight appears immediately. The API maps the live
+condition onto legacy `status` for older clients: conforming and non-conforming
+map directly, suspected/recovering map to contingent, and unknown maps to
+unknown.
+
 ## Known Gaps
 
 - `AircraftDashboard.operating_profile` exists but is not currently populated

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.2
 require (
 	github.com/Aero-Arc/dss-clients v0.0.0-20260727090752-3dbacffe9489
 	github.com/InfluxCommunity/influxdb3-go/v2 v2.13.0
-	github.com/aero-arc/aero-arc-protos v0.0.0-20260712235411-7691110ca7e7
+	github.com/aero-arc/aero-arc-protos v0.0.0-20260824041357-48c5373260e0
 	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.10.0

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA
 github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=
 github.com/aero-arc/aero-arc-protos v0.0.0-20260712235411-7691110ca7e7 h1:Ex8lT3tkVP902PfjJiRU2E4Q4L4H7eyfzgwSUu+WiGw=
 github.com/aero-arc/aero-arc-protos v0.0.0-20260712235411-7691110ca7e7/go.mod h1:fILW3Dz6auXllS5ABRFTt0FTnNC4Mtw3ukvGrJa7zLo=
+github.com/aero-arc/aero-arc-protos v0.0.0-20260824041357-48c5373260e0 h1:B0S2USrnGt5CkzMVmBfMrKmUPh6BUDi+tzoNDkj+Weg=
+github.com/aero-arc/aero-arc-protos v0.0.0-20260824041357-48c5373260e0/go.mod h1:fILW3Dz6auXllS5ABRFTt0FTnNC4Mtw3ukvGrJa7zLo=
 github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwToPjQ=
 github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/apache/arrow-go/v18 v18.5.1 h1:yaQ6zxMGgf9YCYw4/oaeOU3AULySDlAYDOcnr4LdHdI=

--- a/internal/domain/conformance.go
+++ b/internal/domain/conformance.go
@@ -25,15 +25,36 @@ type ConformanceEvent struct {
 }
 
 type ConformanceSummary struct {
-	ID                  string              `json:"id"`
-	OperatorID          string              `json:"operator_id,omitempty"`
-	IntentID            string              `json:"intent_id"`
-	IntentVersion       int                 `json:"intent_version,omitempty"`
-	FlightID            string              `json:"flight_id,omitempty"`
-	AircraftID          string              `json:"aircraft_id"`
-	Status              ConformanceStatus   `json:"status"`
-	Score               *float64            `json:"score,omitempty"`
-	AlertCount          int                 `json:"alert_count"`
-	ReportabilityStatus ReportabilityStatus `json:"reportability_status"`
-	UpdatedAt           time.Time           `json:"updated_at"`
+	ID                   string                        `json:"id"`
+	OperatorID           string                        `json:"operator_id,omitempty"`
+	IntentID             string                        `json:"intent_id"`
+	IntentVersion        int                           `json:"intent_version,omitempty"`
+	FlightID             string                        `json:"flight_id,omitempty"`
+	AircraftID           string                        `json:"aircraft_id"`
+	Status               ConformanceStatus             `json:"status"`
+	Score                *float64                      `json:"score,omitempty"`
+	AlertCount           int                           `json:"alert_count"`
+	ReportabilityStatus  ReportabilityStatus           `json:"reportability_status"`
+	UpdatedAt            time.Time                     `json:"updated_at"`
+	AssignmentID         string                        `json:"assignment_id,omitempty"`
+	AssignmentGeneration uint64                        `json:"assignment_generation,omitempty"`
+	EvaluationRevision   uint64                        `json:"evaluation_revision,omitempty"`
+	EvaluationID         string                        `json:"evaluation_id,omitempty"`
+	Condition            string                        `json:"condition,omitempty"`
+	MonitoringStatus     string                        `json:"monitoring_status,omitempty"`
+	RecordingStatus      string                        `json:"recording_status,omitempty"`
+	ObservedAt           *time.Time                    `json:"observed_at,omitempty"`
+	FrameID              string                        `json:"frame_id,omitempty"`
+	Violations           []ConformanceViolationSummary `json:"violations,omitempty"`
+}
+
+// ConformanceViolationSummary describes one live Registry violation without
+// replacing the durable incident history represented by ConformanceEvent.
+type ConformanceViolationSummary struct {
+	ViolationType   string     `json:"violation_type"`
+	Phase           string     `json:"phase"`
+	OpeningFrameID  string     `json:"opening_frame_id,omitempty"`
+	OpenedAt        *time.Time `json:"opened_at,omitempty"`
+	LastObservedAt  *time.Time `json:"last_observed_at,omitempty"`
+	WorstDeviationM float64    `json:"worst_deviation_m"`
 }

--- a/internal/httpapi/handlers.go
+++ b/internal/httpapi/handlers.go
@@ -242,6 +242,49 @@ func (s *Server) handleCreateBattery(c *mach.Context) {
 	writeJSON(c, http.StatusCreated, battery)
 }
 
+func (s *Server) handleInstallBattery(c *mach.Context) {
+	var req service.InstallBatteryRequest
+	if err := decodeJSON(c, &req); err != nil {
+		writeError(c, http.StatusBadRequest, err.Error())
+		return
+	}
+	ctx, cancel := s.contextWithTimeout(c)
+	defer cancel()
+	installation, err := s.fleet.InstallBattery(ctx, c.Param("aircraft_id"), req)
+	if err != nil {
+		writeServiceError(c, err)
+		return
+	}
+	writeJSON(c, http.StatusCreated, installation)
+}
+
+func (s *Server) handleCreatePlannedFlight(c *mach.Context) {
+	var req service.CreateFlightRequest
+	if err := decodeJSON(c, &req); err != nil {
+		writeError(c, http.StatusBadRequest, err.Error())
+		return
+	}
+	ctx, cancel := s.contextWithTimeout(c)
+	defer cancel()
+	flight, err := s.fleet.CreatePlannedFlight(ctx, c.Param("intent_id"), req)
+	if err != nil {
+		writeServiceError(c, err)
+		return
+	}
+	writeJSON(c, http.StatusCreated, flight)
+}
+
+func (s *Server) handleStartFlight(c *mach.Context) {
+	ctx, cancel := s.contextWithTimeout(c)
+	defer cancel()
+	flight, err := s.fleet.StartFlight(ctx, c.Param("flight_id"))
+	if err != nil {
+		writeServiceError(c, err)
+		return
+	}
+	writeJSON(c, http.StatusOK, flight)
+}
+
 func (s *Server) handleCreateMaintenanceEvent(c *mach.Context) {
 	var event domain.MaintenanceEvent
 	if err := decodeJSON(c, &event); err != nil {

--- a/internal/httpapi/handlers_test.go
+++ b/internal/httpapi/handlers_test.go
@@ -16,6 +16,9 @@ import (
 	durablememory "github.com/Aero-Arc/aero-arc-api/internal/store/durable/memory"
 	replaymemory "github.com/Aero-Arc/aero-arc-api/internal/store/replay/memory"
 	telemetrymemory "github.com/Aero-Arc/aero-arc-api/internal/store/telemetry/memory"
+	conformancev1 "github.com/aero-arc/aero-arc-protos/gen/go/aeroarc/conformance/v1"
+	registryv1 "github.com/aero-arc/aero-arc-protos/gen/go/aeroarc/registry/v1"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func TestHandleListAircraft(t *testing.T) {
@@ -134,6 +137,134 @@ func TestHandleGetAircraftUsesMachPathParam(t *testing.T) {
 	}
 	if body.Aircraft.ID != "aircraft-1" {
 		t.Fatalf("aircraft ID = %q, want aircraft-1", body.Aircraft.ID)
+	}
+}
+
+func TestHandleBootstrapBatteryAndFlightLifecycle(t *testing.T) {
+	ctx := context.Background()
+	store := durablememory.NewStore()
+	telemetry := telemetrymemory.NewStore()
+	reg := registry.NewMemoryClient()
+	now := time.Now().UTC()
+	if err := store.CreateAircraft(ctx, domain.Aircraft{ID: "aircraft-1", OperatorID: "operator-1"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.CreateBattery(ctx, domain.Battery{ID: "battery-1", OperatorID: "operator-1"}); err != nil {
+		t.Fatal(err)
+	}
+	intent := domain.OperationalIntent{
+		ID: "intent-1", Version: 2, OperatorID: "operator-1", AircraftID: "aircraft-1",
+		Status: domain.IntentStatusAccepted, UpdatedAt: now,
+	}
+	if err := store.CreateOperationalIntent(ctx, intent); err != nil {
+		t.Fatal(err)
+	}
+	fleet := service.NewFleetService(store, telemetry, replaymemory.NewStore(), reg)
+	server := NewWithWorkflows(
+		fleet,
+		service.NewIntentService(store, nil),
+		service.NewPreflightService(store),
+		service.NewConformanceService(store, telemetry),
+		time.Second,
+	)
+
+	installationResponse := performJSONRequest(t, server.Handler(), http.MethodPost, "/api/v1/aircraft/aircraft-1/battery-installations", `{"id":"install-1","battery_id":"battery-1"}`)
+	if installationResponse.Code != http.StatusCreated {
+		t.Fatalf("installation status=%d body=%s", installationResponse.Code, installationResponse.Body.String())
+	}
+	var installation domain.BatteryInstallation
+	if err := json.Unmarshal(installationResponse.Body.Bytes(), &installation); err != nil {
+		t.Fatal(err)
+	}
+	if installation.AircraftID != "aircraft-1" || installation.OperatorID != "operator-1" || installation.InstalledAt.IsZero() {
+		t.Fatalf("installation = %#v", installation)
+	}
+
+	flightResponse := performJSONRequest(t, server.Handler(), http.MethodPost, "/api/v1/operational-intents/intent-1/flights", `{"id":"flight-1","mission_type":"sitl"}`)
+	if flightResponse.Code != http.StatusCreated {
+		t.Fatalf("flight create status=%d body=%s", flightResponse.Code, flightResponse.Body.String())
+	}
+	var flight domain.FlightRecord
+	if err := json.Unmarshal(flightResponse.Body.Bytes(), &flight); err != nil {
+		t.Fatal(err)
+	}
+	if flight.Status != domain.FlightStatusPlanned || flight.IntentVersion != 2 || flight.AircraftID != "aircraft-1" {
+		t.Fatalf("planned flight = %#v", flight)
+	}
+	blocked := performJSONRequest(t, server.Handler(), http.MethodPost, "/api/v1/flights/flight-1/start", `{}`)
+	if blocked.Code != http.StatusConflict {
+		t.Fatalf("start before activation status=%d body=%s", blocked.Code, blocked.Body.String())
+	}
+
+	intent.Status = domain.IntentStatusActive
+	if err := store.UpdateOperationalIntent(ctx, intent, 0); err != nil {
+		t.Fatal(err)
+	}
+	startedResponse := performJSONRequest(t, server.Handler(), http.MethodPost, "/api/v1/flights/flight-1/start", `{}`)
+	if startedResponse.Code != http.StatusOK {
+		t.Fatalf("start status=%d body=%s", startedResponse.Code, startedResponse.Body.String())
+	}
+	if err := json.Unmarshal(startedResponse.Body.Bytes(), &flight); err != nil {
+		t.Fatal(err)
+	}
+	if flight.Status != domain.FlightStatusActive || flight.StartedAt.IsZero() {
+		t.Fatalf("started flight = %#v", flight)
+	}
+	retryResponse := performJSONRequest(t, server.Handler(), http.MethodPost, "/api/v1/flights/flight-1/start", `{}`)
+	if retryResponse.Code != http.StatusOK {
+		t.Fatalf("start retry status=%d body=%s", retryResponse.Code, retryResponse.Body.String())
+	}
+}
+
+func TestHandleOperationsExposesRegistryConformanceJSON(t *testing.T) {
+	ctx := context.Background()
+	store := durablememory.NewStore()
+	reg := registry.NewMemoryClient()
+	observedAt := time.Date(2026, 8, 24, 8, 0, 0, 0, time.UTC)
+	if err := store.CreateOperationalIntent(ctx, domain.OperationalIntent{ID: "intent-1", Version: 1, ConformanceRequired: true}); err != nil {
+		t.Fatal(err)
+	}
+	_, err := reg.PublishConformanceSummary(ctx, &registryv1.PublishConformanceSummaryRequest{Summary: &conformancev1.ConformanceSummary{
+		AssignmentId: "intent-1", AssignmentGeneration: 5, EvaluationRevision: 6,
+		EvaluationId: "evaluation-6", AircraftId: "aircraft-1", FlightId: "flight-1",
+		IntentId: "intent-1", IntentVersion: 1,
+		Condition:        conformancev1.ConformanceCondition_CONFORMANCE_CONDITION_NON_CONFORMING,
+		MonitoringStatus: conformancev1.MonitoringStatus_MONITORING_STATUS_CURRENT,
+		RecordingStatus:  conformancev1.RecordingStatus_RECORDING_STATUS_CONFIRMED,
+		ObservedAt:       timestamppb.New(observedAt), FrameId: "frame-6",
+		Violations: []*conformancev1.ViolationSummary{{
+			ViolationType: conformancev1.ViolationType_VIOLATION_TYPE_ALTITUDE_DEVIATION,
+			Phase:         conformancev1.IncidentPhase_INCIDENT_PHASE_OPEN, WorstDeviationM: 8.25,
+		}},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := New(service.NewFleetService(store, telemetrymemory.NewStore(), replaymemory.NewStore(), reg), time.Second)
+	response := httptest.NewRecorder()
+	server.Handler().ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/api/v1/operations", nil))
+	if response.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(response.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	summaries := body["conformance"].([]any)
+	summary := summaries[0].(map[string]any)
+	for key, want := range map[string]any{
+		"assignment_id": "intent-1", "assignment_generation": float64(5),
+		"evaluation_revision": float64(6), "evaluation_id": "evaluation-6",
+		"condition": "non_conforming", "monitoring_status": "current",
+		"recording_status": "confirmed", "frame_id": "frame-6", "status": "non_conforming",
+	} {
+		if summary[key] != want {
+			t.Fatalf("summary[%q] = %#v, want %#v; summary=%#v", key, summary[key], want, summary)
+		}
+	}
+	violations := summary["violations"].([]any)
+	if len(violations) != 1 || violations[0].(map[string]any)["violation_type"] != "altitude_deviation" {
+		t.Fatalf("violations = %#v", violations)
 	}
 }
 
@@ -928,4 +1059,13 @@ func float64Ptr(value float64) *float64 {
 
 func timePtr(value time.Time) *time.Time {
 	return &value
+}
+
+func performJSONRequest(t *testing.T, handler http.Handler, method, path, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	request := httptest.NewRequest(method, path, bytes.NewBufferString(body))
+	request.Header.Set("Content-Type", "application/json")
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	return response
 }

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -119,7 +119,9 @@ func (s *Server) Handler() http.Handler {
 	api.GET("/aircraft/{aircraft_id}/state", s.handleGetAircraftLiveState)
 	api.GET("/aircraft/{aircraft_id}/map", s.handleGetAircraftMap)
 	api.GET("/aircraft/{aircraft_id}/flights", s.handleListAircraftFlights)
+	api.POST("/aircraft/{aircraft_id}/battery-installations", s.handleInstallBattery)
 	api.GET("/flights/{flight_id}", s.handleGetFlight)
+	api.POST("/flights/{flight_id}/start", s.handleStartFlight)
 	api.GET("/flights/{flight_id}/replay", s.handleGetFlightReplay)
 
 	if s.workflowsAvailable() {
@@ -135,6 +137,7 @@ func (s *Server) Handler() http.Handler {
 		}
 		api.POST("/operational-intents/{intent_id}/accept", s.handleAcceptOperationalIntent)
 		api.POST("/operational-intents/{intent_id}/activate", s.handleActivateOperationalIntent)
+		api.POST("/operational-intents/{intent_id}/flights", s.handleCreatePlannedFlight)
 		api.POST("/operational-intents/{intent_id}/complete", s.handleCompleteOperationalIntent)
 		api.POST("/operational-intents/{intent_id}/cancel", s.handleCancelOperationalIntent)
 		api.GET("/operational-intents/{intent_id}/conformance", s.handleGetOperationalIntentConformance)

--- a/internal/registry/memory.go
+++ b/internal/registry/memory.go
@@ -3,21 +3,26 @@ package registry
 import (
 	"context"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/Aero-Arc/aero-arc-api/internal/domain"
+	conformancev1 "github.com/aero-arc/aero-arc-protos/gen/go/aeroarc/conformance/v1"
 	registryv1 "github.com/aero-arc/aero-arc-protos/gen/go/aeroarc/registry/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 type MemoryClient struct {
-	mu         sync.RWMutex
-	relays     map[string]*registryv1.Relay
-	agents     map[string]*registryv1.Agent
-	placements map[string]*registryv1.AgentPlacement
+	mu          sync.RWMutex
+	relays      map[string]*registryv1.Relay
+	agents      map[string]*registryv1.Agent
+	placements  map[string]*registryv1.AgentPlacement
+	conformance map[string]*registryv1.ConformanceProjection
 }
 
 // NewMemoryClient constructs an empty, concurrency-safe Registry client for
@@ -27,10 +32,159 @@ type MemoryClient struct {
 //   - client: stores cloned Relay, Agent, and placement records in process memory.
 func NewMemoryClient() *MemoryClient {
 	return &MemoryClient{
-		relays:     make(map[string]*registryv1.Relay),
-		agents:     make(map[string]*registryv1.Agent),
-		placements: make(map[string]*registryv1.AgentPlacement),
+		relays:      make(map[string]*registryv1.Relay),
+		agents:      make(map[string]*registryv1.Agent),
+		placements:  make(map[string]*registryv1.AgentPlacement),
+		conformance: make(map[string]*registryv1.ConformanceProjection),
 	}
+}
+
+// PublishConformanceSummary validates and stores a defensive copy of the
+// current projection behind its assignment-generation and evaluation-revision
+// cursor. Exact retries are idempotent; stale or conflicting cursors fail.
+//
+// Parameters:
+//   - ctx: controls cancellation before the in-memory mutation.
+//   - req: contains the current conformance summary.
+//   - options: are accepted for gRPC client compatibility and are not used.
+//
+// Returns:
+//   - response: contains the applied or idempotent projection.
+//   - error: reports cancellation, invalid identity, or a stale/conflicting cursor.
+func (c *MemoryClient) PublishConformanceSummary(ctx context.Context, req *registryv1.PublishConformanceSummaryRequest, _ ...grpc.CallOption) (*registryv1.PublishConformanceSummaryResponse, error) {
+	select {
+	case <-ctx.Done():
+		return nil, status.FromContextError(ctx.Err()).Err()
+	default:
+	}
+	summary := req.GetSummary()
+	if err := validateConformanceSummary(summary); err != nil {
+		return nil, err
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	existing := c.conformance[summary.GetAssignmentId()]
+	disposition := registryv1.ConformancePublishDisposition_CONFORMANCE_PUBLISH_DISPOSITION_APPLIED
+	if current := existing.GetSummary(); current != nil {
+		switch {
+		case summary.GetAssignmentGeneration() < current.GetAssignmentGeneration(),
+			summary.GetAssignmentGeneration() == current.GetAssignmentGeneration() && summary.GetEvaluationRevision() < current.GetEvaluationRevision():
+			return nil, status.Error(codes.FailedPrecondition, "conformance cursor is stale")
+		case summary.GetAssignmentGeneration() == current.GetAssignmentGeneration() && summary.GetEvaluationRevision() == current.GetEvaluationRevision():
+			if !proto.Equal(summary, current) {
+				return nil, status.Error(codes.FailedPrecondition, "conformance cursor content changed")
+			}
+			disposition = registryv1.ConformancePublishDisposition_CONFORMANCE_PUBLISH_DISPOSITION_IDEMPOTENT
+		}
+	}
+	projection := &registryv1.ConformanceProjection{
+		Summary:  proto.Clone(summary).(*conformancev1.ConformanceSummary),
+		StoredAt: timestamppb.Now(),
+	}
+	c.conformance[summary.GetAssignmentId()] = projection
+	return &registryv1.PublishConformanceSummaryResponse{
+		Disposition: disposition,
+		Projection:  cloneConformanceProjection(projection),
+	}, nil
+}
+
+// GetConformanceSummary returns a defensive copy of one current in-memory
+// conformance projection.
+//
+// Parameters:
+//   - ctx: controls cancellation before lookup.
+//   - req: identifies the assignment.
+//   - options: are accepted for gRPC client compatibility and are not used.
+//
+// Returns:
+//   - response: contains the current projection.
+//   - error: reports cancellation, invalid identity, or a missing projection.
+func (c *MemoryClient) GetConformanceSummary(ctx context.Context, req *registryv1.GetConformanceSummaryRequest, _ ...grpc.CallOption) (*registryv1.GetConformanceSummaryResponse, error) {
+	select {
+	case <-ctx.Done():
+		return nil, status.FromContextError(ctx.Err()).Err()
+	default:
+	}
+	assignmentID := strings.TrimSpace(req.GetAssignmentId())
+	if assignmentID == "" {
+		return nil, status.Error(codes.InvalidArgument, "assignment_id is required")
+	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	projection := c.conformance[assignmentID]
+	if projection == nil {
+		return nil, status.Error(codes.NotFound, "conformance summary not found")
+	}
+	return &registryv1.GetConformanceSummaryResponse{Projection: cloneConformanceProjection(projection)}, nil
+}
+
+// BatchGetConformanceSummaries returns defensive copies of current projections
+// in deterministic assignment order and separately reports missing IDs.
+//
+// Parameters:
+//   - ctx: controls cancellation before lookup.
+//   - req: identifies one to 250 assignments; duplicate IDs are collapsed.
+//   - options: are accepted for gRPC client compatibility and are not used.
+//
+// Returns:
+//   - response: contains sorted projections and missing assignment IDs.
+//   - error: reports cancellation or invalid request identifiers.
+func (c *MemoryClient) BatchGetConformanceSummaries(ctx context.Context, req *registryv1.BatchGetConformanceSummariesRequest, _ ...grpc.CallOption) (*registryv1.BatchGetConformanceSummariesResponse, error) {
+	select {
+	case <-ctx.Done():
+		return nil, status.FromContextError(ctx.Err()).Err()
+	default:
+	}
+	if len(req.GetAssignmentIds()) == 0 || len(req.GetAssignmentIds()) > 250 {
+		return nil, status.Error(codes.InvalidArgument, "one to 250 assignment_ids are required")
+	}
+	unique := make(map[string]struct{}, len(req.GetAssignmentIds()))
+	for _, rawID := range req.GetAssignmentIds() {
+		assignmentID := strings.TrimSpace(rawID)
+		if assignmentID == "" {
+			return nil, status.Error(codes.InvalidArgument, "assignment_ids cannot contain an empty value")
+		}
+		unique[assignmentID] = struct{}{}
+	}
+	assignmentIDs := make([]string, 0, len(unique))
+	for assignmentID := range unique {
+		assignmentIDs = append(assignmentIDs, assignmentID)
+	}
+	sort.Strings(assignmentIDs)
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	response := &registryv1.BatchGetConformanceSummariesResponse{
+		Projections:          make([]*registryv1.ConformanceProjection, 0, len(assignmentIDs)),
+		MissingAssignmentIds: make([]string, 0),
+	}
+	for _, assignmentID := range assignmentIDs {
+		projection := c.conformance[assignmentID]
+		if projection == nil {
+			response.MissingAssignmentIds = append(response.MissingAssignmentIds, assignmentID)
+			continue
+		}
+		response.Projections = append(response.Projections, cloneConformanceProjection(projection))
+	}
+	return response, nil
+}
+
+func validateConformanceSummary(summary *conformancev1.ConformanceSummary) error {
+	if summary == nil || strings.TrimSpace(summary.GetAssignmentId()) == "" || summary.GetAssignmentGeneration() == 0 || summary.GetEvaluationRevision() == 0 || strings.TrimSpace(summary.GetEvaluationId()) == "" || strings.TrimSpace(summary.GetIntentId()) == "" || strings.TrimSpace(summary.GetAircraftId()) == "" || strings.TrimSpace(summary.GetFlightId()) == "" || summary.GetIntentVersion() == 0 || summary.GetObservedAt() == nil || summary.GetObservedAt().CheckValid() != nil || strings.TrimSpace(summary.GetFrameId()) == "" {
+		return status.Error(codes.InvalidArgument, "conformance summary identity and cursor are required")
+	}
+	if summary.GetCondition() == conformancev1.ConformanceCondition_CONFORMANCE_CONDITION_UNSPECIFIED || summary.GetMonitoringStatus() == conformancev1.MonitoringStatus_MONITORING_STATUS_UNSPECIFIED || summary.GetRecordingStatus() == conformancev1.RecordingStatus_RECORDING_STATUS_UNSPECIFIED {
+		return status.Error(codes.InvalidArgument, "conformance status axes are required")
+	}
+	return nil
+}
+
+func cloneConformanceProjection(projection *registryv1.ConformanceProjection) *registryv1.ConformanceProjection {
+	if projection == nil {
+		return nil
+	}
+	return proto.Clone(projection).(*registryv1.ConformanceProjection)
 }
 
 var _ registryv1.AeroRegistryClient = (*MemoryClient)(nil)

--- a/internal/registry/memory_test.go
+++ b/internal/registry/memory_test.go
@@ -1,0 +1,55 @@
+package registry
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	conformancev1 "github.com/aero-arc/aero-arc-protos/gen/go/aeroarc/conformance/v1"
+	registryv1 "github.com/aero-arc/aero-arc-protos/gen/go/aeroarc/registry/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestMemoryClientConformanceCursorAndBatchContract(t *testing.T) {
+	ctx := context.Background()
+	client := NewMemoryClient()
+	summary := &conformancev1.ConformanceSummary{
+		AssignmentId: "assignment-b", AssignmentGeneration: 2, EvaluationRevision: 3,
+		EvaluationId: "evaluation-3", AircraftId: "aircraft-1", FlightId: "flight-1",
+		IntentId: "assignment-b", IntentVersion: 1,
+		Condition:        conformancev1.ConformanceCondition_CONFORMANCE_CONDITION_CONFORMING,
+		MonitoringStatus: conformancev1.MonitoringStatus_MONITORING_STATUS_CURRENT,
+		RecordingStatus:  conformancev1.RecordingStatus_RECORDING_STATUS_CONFIRMED,
+		ObservedAt:       timestamppb.New(time.Date(2026, 8, 24, 6, 0, 0, 0, time.UTC)), FrameId: "frame-3",
+	}
+	first, err := client.PublishConformanceSummary(ctx, &registryv1.PublishConformanceSummaryRequest{Summary: summary})
+	if err != nil || first.GetDisposition() != registryv1.ConformancePublishDisposition_CONFORMANCE_PUBLISH_DISPOSITION_APPLIED {
+		t.Fatalf("first publish = %#v, %v", first, err)
+	}
+	retry, err := client.PublishConformanceSummary(ctx, &registryv1.PublishConformanceSummaryRequest{Summary: summary})
+	if err != nil || retry.GetDisposition() != registryv1.ConformancePublishDisposition_CONFORMANCE_PUBLISH_DISPOSITION_IDEMPOTENT {
+		t.Fatalf("retry publish = %#v, %v", retry, err)
+	}
+	stale := proto.Clone(summary).(*conformancev1.ConformanceSummary)
+	stale.EvaluationRevision--
+	if _, err := client.PublishConformanceSummary(ctx, &registryv1.PublishConformanceSummaryRequest{Summary: stale}); status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("stale publish error = %v, want FailedPrecondition", err)
+	}
+
+	summary.FrameId = "mutated-after-publish"
+	batch, err := client.BatchGetConformanceSummaries(ctx, &registryv1.BatchGetConformanceSummariesRequest{
+		AssignmentIds: []string{"missing", "assignment-b", "assignment-b"},
+	})
+	if err != nil {
+		t.Fatalf("BatchGetConformanceSummaries returned error: %v", err)
+	}
+	if len(batch.GetProjections()) != 1 || batch.GetProjections()[0].GetSummary().GetFrameId() != "frame-3" {
+		t.Fatalf("batch projections = %#v, want defensive assignment-b copy", batch.GetProjections())
+	}
+	if len(batch.GetMissingAssignmentIds()) != 1 || batch.GetMissingAssignmentIds()[0] != "missing" {
+		t.Fatalf("batch missing = %v, want missing", batch.GetMissingAssignmentIds())
+	}
+}

--- a/internal/relaycontrol/service_test.go
+++ b/internal/relaycontrol/service_test.go
@@ -69,6 +69,9 @@ func (f *fakeRelayClient) ListActiveDrones(context.Context, *relayv1.ListActiveD
 func (f *fakeRelayClient) GetDroneStatus(context.Context, *relayv1.GetDroneStatusRequest, ...grpc.CallOption) (*relayv1.GetDroneStatusResponse, error) {
 	return nil, errors.New("unused")
 }
+func (f *fakeRelayClient) SendAircraftCommand(context.Context, *relayv1.SendAircraftCommandRequest, ...grpc.CallOption) (*relayv1.SendAircraftCommandResponse, error) {
+	return nil, errors.New("unused")
+}
 func (f *fakeRelayClient) SetOperationContext(ctx context.Context, r *relayv1.SetOperationContextRequest, _ ...grpc.CallOption) (*relayv1.SetOperationContextResponse, error) {
 	f.setRequests = append(f.setRequests, r)
 	if f.block {

--- a/internal/service/fleet_service.go
+++ b/internal/service/fleet_service.go
@@ -535,8 +535,8 @@ func registryConformanceSummary(summary *conformancev1.ConformanceSummary, reque
 		FlightID:             summary.GetFlightId(),
 		AircraftID:           summary.GetAircraftId(),
 		Status:               legacyConformanceStatus(condition),
-		AlertCount:           len(violations),
-		ReportabilityStatus:  domain.ReportabilityStatusReview,
+		AlertCount:           activeViolationCount(violations),
+		ReportabilityStatus:  domain.ReportabilityStatusNo,
 		UpdatedAt:            updatedAt,
 		AssignmentID:         assignmentID,
 		AssignmentGeneration: summary.GetAssignmentGeneration(),
@@ -549,6 +549,16 @@ func registryConformanceSummary(summary *conformancev1.ConformanceSummary, reque
 		FrameID:              summary.GetFrameId(),
 		Violations:           violations,
 	}, true
+}
+
+func activeViolationCount(violations []domain.ConformanceViolationSummary) int {
+	count := 0
+	for _, violation := range violations {
+		if violation.Phase != "" && violation.Phase != "clear" {
+			count++
+		}
+	}
+	return count
 }
 
 func mergeLiveConformance(durableSummary, live domain.ConformanceSummary) domain.ConformanceSummary {
@@ -1336,6 +1346,8 @@ func preflightMetrics(checks []domain.PreflightCheck) []readmodel.DashboardMetri
 func conformanceMetrics(summaries []domain.ConformanceSummary, events []domain.ConformanceEvent) []readmodel.DashboardMetric {
 	conforming := 0
 	reportable := 0
+	activeFindings := 0
+	hasLiveProjection := false
 	totalScore := 0.0
 	scores := 0
 	for _, summary := range summaries {
@@ -1349,17 +1361,29 @@ func conformanceMetrics(summaries []domain.ConformanceSummary, events []domain.C
 			totalScore += *summary.Score
 			scores++
 		}
+		if summary.AssignmentID != "" {
+			hasLiveProjection = true
+			activeFindings += activeViolationCount(summary.Violations)
+		}
 	}
 
-	avgScore := 0.0
+	targetValue := "Not scored"
+	targetDetail := "Live condition is reported separately"
 	if scores > 0 {
-		avgScore = totalScore / float64(scores)
+		targetValue = fmt.Sprintf("%.1f%%", totalScore/float64(scores)*100)
+		targetDetail = "Average of durable scored evaluations"
+	}
+	alertLabel := "Open alerts"
+	alertValue := len(events)
+	if hasLiveProjection {
+		alertLabel = "Active findings"
+		alertValue = activeFindings
 	}
 
 	return []readmodel.DashboardMetric{
-		{Label: "Target conformance", Value: fmt.Sprintf("%.1f%%", avgScore*100)},
+		{Label: "Target conformance", Value: targetValue, Detail: targetDetail},
 		{Label: "Conforming", Value: fmt.Sprintf("%d", conforming), Status: string(domain.ConformanceStatusConforming)},
-		{Label: "Open alerts", Value: fmt.Sprintf("%d", len(events))},
+		{Label: alertLabel, Value: fmt.Sprintf("%d", alertValue)},
 		{Label: "Reportable", Value: fmt.Sprintf("%d", reportable), Status: string(domain.ReportabilityStatusReportable)},
 	}
 }

--- a/internal/service/fleet_service.go
+++ b/internal/service/fleet_service.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Aero-Arc/aero-arc-api/internal/store/durable"
 	"github.com/Aero-Arc/aero-arc-api/internal/store/replay"
 	"github.com/Aero-Arc/aero-arc-api/internal/store/telemetry"
+	conformancev1 "github.com/aero-arc/aero-arc-protos/gen/go/aeroarc/conformance/v1"
 	registryv1 "github.com/aero-arc/aero-arc-protos/gen/go/aeroarc/registry/v1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -33,6 +34,7 @@ const (
 	defaultRegistryFreshness  = 30 * time.Second
 	defaultTelemetryFreshness = 15 * time.Second
 	maxPlacementLookups       = 8
+	maxConformanceBatch       = 250
 )
 
 type placementLookup struct {
@@ -50,6 +52,22 @@ type ReplayResponse struct {
 	ReplayManifest    *domain.ReplayManifest    `json:"replay_manifest,omitempty"`
 	Samples           []domain.TelemetrySample  `json:"samples"`
 	ConformanceEvents []domain.ConformanceEvent `json:"conformance_events"`
+}
+
+type InstallBatteryRequest struct {
+	ID          string    `json:"id"`
+	OperatorID  string    `json:"operator_id,omitempty"`
+	BatteryID   string    `json:"battery_id"`
+	InstalledAt time.Time `json:"installed_at,omitempty"`
+}
+
+type CreateFlightRequest struct {
+	ID           string `json:"id"`
+	OperatorID   string `json:"operator_id,omitempty"`
+	Origin       string `json:"origin,omitempty"`
+	Destination  string `json:"destination,omitempty"`
+	MissionType  string `json:"mission_type,omitempty"`
+	TelemetryURI string `json:"telemetry_uri,omitempty"`
 }
 
 // NewFleetService constructs the fleet read/write façade used by HTTP handlers.
@@ -124,6 +142,159 @@ func (s *FleetService) CreateBattery(ctx context.Context, battery domain.Battery
 	return s.durable.CreateBattery(ctx, battery)
 }
 
+// InstallBattery creates the active battery installation for one aircraft
+// after verifying both resources and their operator ownership agree.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - aircraftID: identifies the aircraft receiving the battery.
+//   - req: identifies the installation and battery; a zero time uses the service clock.
+//
+// Returns:
+//   - installation: is the newly recorded active installation.
+//   - error: reports validation, missing resources, ownership mismatch, or an existing active installation.
+func (s *FleetService) InstallBattery(ctx context.Context, aircraftID string, req InstallBatteryRequest) (domain.BatteryInstallation, error) {
+	aircraftID = strings.TrimSpace(aircraftID)
+	req.ID = strings.TrimSpace(req.ID)
+	req.BatteryID = strings.TrimSpace(req.BatteryID)
+	if aircraftID == "" || req.ID == "" || req.BatteryID == "" {
+		return domain.BatteryInstallation{}, fmt.Errorf("%w: aircraft_id, id, and battery_id are required", ErrValidation)
+	}
+	aircraft, err := s.durable.GetAircraft(ctx, aircraftID)
+	if err != nil {
+		return domain.BatteryInstallation{}, fmt.Errorf("get aircraft: %w", err)
+	}
+	battery, err := s.durable.GetBattery(ctx, req.BatteryID)
+	if err != nil {
+		return domain.BatteryInstallation{}, fmt.Errorf("get battery: %w", err)
+	}
+	operatorID, err := consistentOperatorID(req.OperatorID, aircraft.OperatorID, battery.OperatorID)
+	if err != nil {
+		return domain.BatteryInstallation{}, err
+	}
+	if active, err := s.durable.GetActiveBatteryInstallation(ctx, aircraftID); err != nil {
+		return domain.BatteryInstallation{}, fmt.Errorf("get active battery installation: %w", err)
+	} else if active != nil {
+		return domain.BatteryInstallation{}, fmt.Errorf("%w: aircraft %s already has active installation %s", durable.ErrVersionConflict, aircraftID, active.ID)
+	}
+	installedAt := req.InstalledAt.UTC()
+	if installedAt.IsZero() {
+		installedAt = s.now().UTC()
+	}
+	installation := domain.BatteryInstallation{
+		ID: req.ID, OperatorID: operatorID, AircraftID: aircraftID,
+		BatteryID: req.BatteryID, InstalledAt: installedAt,
+	}
+	if err := s.durable.RecordBatteryInstallation(ctx, installation); err != nil {
+		return domain.BatteryInstallation{}, fmt.Errorf("record battery installation: %w", err)
+	}
+	return installation, nil
+}
+
+// CreatePlannedFlight reserves a flight identity for the current accepted or
+// active intent and derives its aircraft, operator, and intent-version linkage.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - intentID: identifies the current operational intent.
+//   - req: supplies the flight identity and optional descriptive metadata.
+//
+// Returns:
+//   - flight: is the newly persisted planned flight.
+//   - error: reports validation, missing resources, ownership mismatch, lifecycle conflict, or duplicate identity.
+func (s *FleetService) CreatePlannedFlight(ctx context.Context, intentID string, req CreateFlightRequest) (domain.FlightRecord, error) {
+	intentID = strings.TrimSpace(intentID)
+	req.ID = strings.TrimSpace(req.ID)
+	if intentID == "" || req.ID == "" {
+		return domain.FlightRecord{}, fmt.Errorf("%w: intent_id and id are required", ErrValidation)
+	}
+	intent, err := s.durable.GetOperationalIntent(ctx, intentID)
+	if err != nil {
+		return domain.FlightRecord{}, fmt.Errorf("get operational intent: %w", err)
+	}
+	if intent.Status != domain.IntentStatusAccepted && intent.Status != domain.IntentStatusActive {
+		return domain.FlightRecord{}, fmt.Errorf("%w: cannot create flight for intent in %s status", ErrInvalidTransition, intent.Status)
+	}
+	aircraft, err := s.durable.GetAircraft(ctx, intent.AircraftID)
+	if err != nil {
+		return domain.FlightRecord{}, fmt.Errorf("get aircraft: %w", err)
+	}
+	operatorID, err := consistentOperatorID(req.OperatorID, intent.OperatorID, aircraft.OperatorID)
+	if err != nil {
+		return domain.FlightRecord{}, err
+	}
+	flight := domain.FlightRecord{
+		ID: req.ID, OperatorID: operatorID, AircraftID: intent.AircraftID,
+		IntentID: intent.ID, IntentVersion: intent.Version, Status: domain.FlightStatusPlanned,
+		Origin: req.Origin, Destination: req.Destination, MissionType: req.MissionType, TelemetryURI: req.TelemetryURI,
+	}
+	if err := s.durable.CreateFlightRecord(ctx, flight); err != nil {
+		return domain.FlightRecord{}, fmt.Errorf("create flight record: %w", err)
+	}
+	return flight, nil
+}
+
+// StartFlight atomically advances a planned flight to active once its exact
+// linked intent version is active. Retrying an already-active flight is safe.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - flightID: identifies the planned flight.
+//
+// Returns:
+//   - flight: is the active flight with its server-owned start timestamp.
+//   - error: reports missing records, stale intent linkage, lifecycle conflict, or persistence failure.
+func (s *FleetService) StartFlight(ctx context.Context, flightID string) (domain.FlightRecord, error) {
+	flightID = strings.TrimSpace(flightID)
+	if flightID == "" {
+		return domain.FlightRecord{}, fmt.Errorf("%w: flight_id is required", ErrValidation)
+	}
+	flight, err := s.durable.GetFlightRecord(ctx, flightID)
+	if err != nil {
+		return domain.FlightRecord{}, fmt.Errorf("get flight record: %w", err)
+	}
+	if flight.Status == domain.FlightStatusActive {
+		return flight, nil
+	}
+	if flight.Status != domain.FlightStatusPlanned {
+		return domain.FlightRecord{}, fmt.Errorf("%w: cannot start flight in %s status", ErrInvalidTransition, flight.Status)
+	}
+	intent, err := s.durable.GetOperationalIntent(ctx, flight.IntentID)
+	if err != nil {
+		return domain.FlightRecord{}, fmt.Errorf("get operational intent: %w", err)
+	}
+	if intent.Status != domain.IntentStatusActive || intent.Version != flight.IntentVersion || intent.AircraftID != flight.AircraftID {
+		return domain.FlightRecord{}, fmt.Errorf("%w: linked intent version is not active", ErrInvalidTransition)
+	}
+	flight.Status = domain.FlightStatusActive
+	flight.StartedAt = s.now().UTC()
+	if err := s.durable.UpdateFlightRecord(ctx, flight, domain.FlightStatusPlanned); err != nil {
+		if errors.Is(err, durable.ErrVersionConflict) {
+			current, getErr := s.durable.GetFlightRecord(ctx, flightID)
+			if getErr == nil && current.Status == domain.FlightStatusActive {
+				return current, nil
+			}
+		}
+		return domain.FlightRecord{}, fmt.Errorf("start flight record: %w", err)
+	}
+	return flight, nil
+}
+
+func consistentOperatorID(values ...string) (string, error) {
+	operatorID := ""
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if operatorID != "" && value != operatorID {
+			return "", fmt.Errorf("%w: operator_id does not match linked resources", ErrValidation)
+		}
+		operatorID = value
+	}
+	return operatorID, nil
+}
+
 // RecordMaintenanceEvent appends a durable aircraft maintenance record.
 //
 // Parameters:
@@ -190,6 +361,7 @@ func (s *FleetService) GetOperationsDashboard(ctx context.Context) (readmodel.Op
 	if err != nil {
 		return readmodel.OperationsDashboard{}, fmt.Errorf("list conformance summaries: %w", err)
 	}
+	conformance = s.overlayRegistryConformance(ctx, intents, conformance)
 	aircraft, err := s.durable.ListAircraft(ctx)
 	if err != nil {
 		return readmodel.OperationsDashboard{}, fmt.Errorf("list aircraft: %w", err)
@@ -242,12 +414,206 @@ func (s *FleetService) GetConformanceDashboard(ctx context.Context) (readmodel.C
 	if err != nil {
 		return readmodel.ConformanceDashboard{}, fmt.Errorf("list conformance events: %w", err)
 	}
+	intents, err := s.durable.ListOperationalIntents(ctx, "")
+	if err != nil {
+		return readmodel.ConformanceDashboard{}, fmt.Errorf("list operational intents: %w", err)
+	}
+	summaries = s.overlayRegistryConformance(ctx, intents, summaries)
 
 	return readmodel.ConformanceDashboard{
 		Metrics:   conformanceMetrics(summaries, events),
 		Summaries: summaries,
 		Events:    events,
 	}, nil
+}
+
+func (s *FleetService) overlayRegistryConformance(ctx context.Context, intents []domain.OperationalIntent, durableSummaries []domain.ConformanceSummary) []domain.ConformanceSummary {
+	if s.registry == nil || len(intents) == 0 {
+		return durableSummaries
+	}
+	requested := make(map[string]struct{}, len(intents))
+	assignmentIDs := make([]string, 0, len(intents))
+	for _, intent := range intents {
+		assignmentID := strings.TrimSpace(intent.ID)
+		if assignmentID == "" {
+			continue
+		}
+		if _, exists := requested[assignmentID]; exists {
+			continue
+		}
+		requested[assignmentID] = struct{}{}
+		assignmentIDs = append(assignmentIDs, assignmentID)
+	}
+	if len(assignmentIDs) == 0 {
+		return durableSummaries
+	}
+	sort.Strings(assignmentIDs)
+
+	liveByVersion := make(map[string]domain.ConformanceSummary)
+	for start := 0; start < len(assignmentIDs); start += maxConformanceBatch {
+		end := min(start+maxConformanceBatch, len(assignmentIDs))
+		response, err := s.registry.BatchGetConformanceSummaries(ctx, &registryv1.BatchGetConformanceSummariesRequest{AssignmentIds: assignmentIDs[start:end]})
+		if err != nil || response == nil {
+			continue
+		}
+		for _, projection := range response.GetProjections() {
+			live, ok := registryConformanceSummary(projection.GetSummary(), requested)
+			if !ok {
+				continue
+			}
+			key := conformanceVersionKey(live.IntentID, live.IntentVersion)
+			current, exists := liveByVersion[key]
+			if !exists || live.AssignmentGeneration > current.AssignmentGeneration || (live.AssignmentGeneration == current.AssignmentGeneration && live.EvaluationRevision > current.EvaluationRevision) {
+				liveByVersion[key] = live
+			}
+		}
+	}
+	if len(liveByVersion) == 0 {
+		return durableSummaries
+	}
+
+	result := make([]domain.ConformanceSummary, 0, len(durableSummaries)+len(liveByVersion))
+	for _, durableSummary := range durableSummaries {
+		key := conformanceVersionKey(durableSummary.IntentID, durableSummary.IntentVersion)
+		live, exists := liveByVersion[key]
+		if !exists {
+			result = append(result, durableSummary)
+			continue
+		}
+		result = append(result, mergeLiveConformance(durableSummary, live))
+		delete(liveByVersion, key)
+	}
+	for _, live := range liveByVersion {
+		result = append(result, live)
+	}
+	sort.SliceStable(result, func(i, j int) bool {
+		if result[i].UpdatedAt.Equal(result[j].UpdatedAt) {
+			return conformanceVersionKey(result[i].IntentID, result[i].IntentVersion) < conformanceVersionKey(result[j].IntentID, result[j].IntentVersion)
+		}
+		return result[i].UpdatedAt.After(result[j].UpdatedAt)
+	})
+	return result
+}
+
+func registryConformanceSummary(summary *conformancev1.ConformanceSummary, requested map[string]struct{}) (domain.ConformanceSummary, bool) {
+	if summary == nil {
+		return domain.ConformanceSummary{}, false
+	}
+	assignmentID := strings.TrimSpace(summary.GetAssignmentId())
+	intentID := strings.TrimSpace(summary.GetIntentId())
+	if assignmentID == "" || assignmentID != intentID || summary.GetIntentVersion() == 0 {
+		return domain.ConformanceSummary{}, false
+	}
+	if _, exists := requested[assignmentID]; !exists {
+		return domain.ConformanceSummary{}, false
+	}
+	observedAt := validProtoTime(summary.GetObservedAt())
+	condition := enumJSONName(summary.GetCondition().String(), "CONFORMANCE_CONDITION_")
+	violations := make([]domain.ConformanceViolationSummary, 0, len(summary.GetViolations()))
+	for _, violation := range summary.GetViolations() {
+		if violation == nil {
+			continue
+		}
+		violations = append(violations, domain.ConformanceViolationSummary{
+			ViolationType:   enumJSONName(violation.GetViolationType().String(), "VIOLATION_TYPE_"),
+			Phase:           enumJSONName(violation.GetPhase().String(), "INCIDENT_PHASE_"),
+			OpeningFrameID:  violation.GetOpeningFrameId(),
+			OpenedAt:        validProtoTime(violation.GetOpenedAt()),
+			LastObservedAt:  validProtoTime(violation.GetLastObservedAt()),
+			WorstDeviationM: violation.GetWorstDeviationM(),
+		})
+	}
+	updatedAt := time.Time{}
+	if observedAt != nil {
+		updatedAt = *observedAt
+	}
+	return domain.ConformanceSummary{
+		ID:                   summary.GetEvaluationId(),
+		OperatorID:           summary.GetOperatorId(),
+		IntentID:             intentID,
+		IntentVersion:        int(summary.GetIntentVersion()),
+		FlightID:             summary.GetFlightId(),
+		AircraftID:           summary.GetAircraftId(),
+		Status:               legacyConformanceStatus(condition),
+		AlertCount:           len(violations),
+		ReportabilityStatus:  domain.ReportabilityStatusReview,
+		UpdatedAt:            updatedAt,
+		AssignmentID:         assignmentID,
+		AssignmentGeneration: summary.GetAssignmentGeneration(),
+		EvaluationRevision:   summary.GetEvaluationRevision(),
+		EvaluationID:         summary.GetEvaluationId(),
+		Condition:            condition,
+		MonitoringStatus:     enumJSONName(summary.GetMonitoringStatus().String(), "MONITORING_STATUS_"),
+		RecordingStatus:      enumJSONName(summary.GetRecordingStatus().String(), "RECORDING_STATUS_"),
+		ObservedAt:           observedAt,
+		FrameID:              summary.GetFrameId(),
+		Violations:           violations,
+	}, true
+}
+
+func mergeLiveConformance(durableSummary, live domain.ConformanceSummary) domain.ConformanceSummary {
+	result := durableSummary
+	result.OperatorID = firstNonEmpty(live.OperatorID, result.OperatorID)
+	result.FlightID = firstNonEmpty(live.FlightID, result.FlightID)
+	result.AircraftID = firstNonEmpty(live.AircraftID, result.AircraftID)
+	result.Status = live.Status
+	if !live.UpdatedAt.IsZero() {
+		result.UpdatedAt = live.UpdatedAt
+	}
+	result.AssignmentID = live.AssignmentID
+	result.AssignmentGeneration = live.AssignmentGeneration
+	result.EvaluationRevision = live.EvaluationRevision
+	result.EvaluationID = live.EvaluationID
+	result.Condition = live.Condition
+	result.MonitoringStatus = live.MonitoringStatus
+	result.RecordingStatus = live.RecordingStatus
+	result.ObservedAt = live.ObservedAt
+	result.FrameID = live.FrameID
+	result.Violations = live.Violations
+	return result
+}
+
+func legacyConformanceStatus(condition string) domain.ConformanceStatus {
+	switch condition {
+	case "conforming":
+		return domain.ConformanceStatusConforming
+	case "non_conforming":
+		return domain.ConformanceStatusNonConforming
+	case "suspected", "recovering":
+		return domain.ConformanceStatusContingent
+	default:
+		return domain.ConformanceStatusUnknown
+	}
+}
+
+func enumJSONName(value, prefix string) string {
+	value = strings.TrimPrefix(value, prefix)
+	if value == "UNSPECIFIED" {
+		return ""
+	}
+	return strings.ToLower(value)
+}
+
+func validProtoTime(value interface {
+	CheckValid() error
+	AsTime() time.Time
+}) *time.Time {
+	if value == nil || value.CheckValid() != nil {
+		return nil
+	}
+	timestamp := value.AsTime().UTC()
+	return &timestamp
+}
+
+func conformanceVersionKey(intentID string, intentVersion int) string {
+	return fmt.Sprintf("%s:%d", intentID, intentVersion)
+}
+
+func firstNonEmpty(preferred, fallback string) string {
+	if preferred != "" {
+		return preferred
+	}
+	return fallback
 }
 
 // GetMaintenanceDashboard composes maintenance history, battery inventory, and

--- a/internal/service/fleet_service_test.go
+++ b/internal/service/fleet_service_test.go
@@ -11,11 +11,16 @@ import (
 	"github.com/Aero-Arc/aero-arc-api/internal/domain"
 	"github.com/Aero-Arc/aero-arc-api/internal/readmodel"
 	"github.com/Aero-Arc/aero-arc-api/internal/registry"
+	"github.com/Aero-Arc/aero-arc-api/internal/store/durable"
 	durablememory "github.com/Aero-Arc/aero-arc-api/internal/store/durable/memory"
 	replaymemory "github.com/Aero-Arc/aero-arc-api/internal/store/replay/memory"
 	telemetrymemory "github.com/Aero-Arc/aero-arc-api/internal/store/telemetry/memory"
+	conformancev1 "github.com/aero-arc/aero-arc-protos/gen/go/aeroarc/conformance/v1"
 	registryv1 "github.com/aero-arc/aero-arc-protos/gen/go/aeroarc/registry/v1"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 type failingRegistry struct{}
@@ -46,6 +51,18 @@ func (failingRegistry) ListAgents(context.Context, *registryv1.ListAgentsRequest
 
 func (failingRegistry) GetAgentPlacement(context.Context, *registryv1.GetAgentPlacementRequest, ...grpc.CallOption) (*registryv1.GetAgentPlacementResponse, error) {
 	return nil, errors.New("registry unavailable")
+}
+
+func (failingRegistry) PublishConformanceSummary(context.Context, *registryv1.PublishConformanceSummaryRequest, ...grpc.CallOption) (*registryv1.PublishConformanceSummaryResponse, error) {
+	return nil, errors.New("registry unavailable")
+}
+
+func (failingRegistry) GetConformanceSummary(context.Context, *registryv1.GetConformanceSummaryRequest, ...grpc.CallOption) (*registryv1.GetConformanceSummaryResponse, error) {
+	return nil, errors.New("registry unavailable")
+}
+
+func (failingRegistry) BatchGetConformanceSummaries(context.Context, *registryv1.BatchGetConformanceSummariesRequest, ...grpc.CallOption) (*registryv1.BatchGetConformanceSummariesResponse, error) {
+	return nil, status.Error(codes.Unavailable, "registry unavailable")
 }
 
 func TestFleetServiceComposesAircraftDashboard(t *testing.T) {
@@ -177,6 +194,190 @@ func TestFleetServiceGracefullyDegradesWhenRegistryUnavailable(t *testing.T) {
 	}
 	if dashboard.Readiness.Status != "warning" {
 		t.Fatalf("readiness = %q, want warning", dashboard.Readiness.Status)
+	}
+}
+
+func TestFleetServiceOverlaysRegistryConformanceInOneBatch(t *testing.T) {
+	ctx := context.Background()
+	observedAt := time.Date(2026, 8, 24, 5, 30, 0, 0, time.UTC)
+	durable := durablememory.NewStore()
+	reg := newTestRegistry()
+	for _, intentID := range []string{"intent-live-only", "intent-merge", "intent-missing"} {
+		must(t, durable.CreateOperationalIntent(ctx, domain.OperationalIntent{ID: intentID, Version: 2, AircraftID: "aircraft-1", ConformanceRequired: true}))
+	}
+	score := 0.91
+	must(t, durable.UpsertConformanceSummary(ctx, domain.ConformanceSummary{
+		ID: "durable-merge", IntentID: "intent-merge", IntentVersion: 2, AircraftID: "aircraft-old",
+		Status: domain.ConformanceStatusConforming, Score: &score, AlertCount: 9,
+		ReportabilityStatus: domain.ReportabilityStatusReportable, UpdatedAt: observedAt.Add(-time.Hour),
+	}))
+	must(t, durable.UpsertConformanceSummary(ctx, domain.ConformanceSummary{
+		ID: "durable-missing", IntentID: "intent-missing", IntentVersion: 2, AircraftID: "aircraft-1",
+		Status: domain.ConformanceStatusConforming, ReportabilityStatus: domain.ReportabilityStatusNo,
+		UpdatedAt: observedAt.Add(-2 * time.Hour),
+	}))
+	must(t, durable.RecordConformanceEvent(ctx, domain.ConformanceEvent{ID: "event-durable", IntentID: "intent-merge", OccurredAt: observedAt.Add(-time.Minute)}))
+
+	publishTestConformance(t, ctx, reg.MemoryClient, testConformanceProto("intent-live-only", observedAt, conformancev1.ConformanceCondition_CONFORMANCE_CONDITION_CONFORMING))
+	mergedProto := testConformanceProto("intent-merge", observedAt.Add(time.Minute), conformancev1.ConformanceCondition_CONFORMANCE_CONDITION_NON_CONFORMING)
+	mergedProto.EvaluationRevision = 7
+	mergedProto.EvaluationId = "evaluation-merge"
+	mergedProto.AircraftId = "aircraft-live"
+	mergedProto.Violations = []*conformancev1.ViolationSummary{{
+		ViolationType:   conformancev1.ViolationType_VIOLATION_TYPE_LATERAL_DEVIATION,
+		Phase:           conformancev1.IncidentPhase_INCIDENT_PHASE_OPEN,
+		OpeningFrameId:  "frame-opening",
+		OpenedAt:        timestamppb.New(observedAt.Add(-time.Minute)),
+		LastObservedAt:  timestamppb.New(observedAt),
+		WorstDeviationM: 12.5,
+	}}
+	publishTestConformance(t, ctx, reg.MemoryClient, mergedProto)
+
+	svc := NewFleetService(durable, telemetrymemory.NewStore(), replaymemory.NewStore(), reg)
+	operations, err := svc.GetOperationsDashboard(ctx)
+	if err != nil {
+		t.Fatalf("GetOperationsDashboard returned error: %v", err)
+	}
+	if reg.batchConformanceCalls != 1 {
+		t.Fatalf("BatchGetConformanceSummaries calls = %d, want 1", reg.batchConformanceCalls)
+	}
+	if got := reg.batchAssignmentIDs[0]; fmt.Sprint(got) != "[intent-live-only intent-merge intent-missing]" {
+		t.Fatalf("assignment IDs = %v", got)
+	}
+	byIntent := conformanceByIntent(operations.Conformance)
+	if len(byIntent) != 3 {
+		t.Fatalf("conformance summaries = %#v, want live-only, merged, and durable fallback", operations.Conformance)
+	}
+	liveOnly := byIntent["intent-live-only"]
+	if liveOnly.AssignmentID != "intent-live-only" || liveOnly.Status != domain.ConformanceStatusConforming || liveOnly.ObservedAt == nil || !liveOnly.ObservedAt.Equal(observedAt) {
+		t.Fatalf("live-only summary = %#v", liveOnly)
+	}
+	merged := byIntent["intent-merge"]
+	if merged.ID != "durable-merge" || merged.Status != domain.ConformanceStatusNonConforming || merged.Condition != "non_conforming" || merged.EvaluationRevision != 7 {
+		t.Fatalf("merged summary identity/status = %#v", merged)
+	}
+	if merged.Score == nil || *merged.Score != score || merged.AlertCount != 9 || merged.ReportabilityStatus != domain.ReportabilityStatusReportable {
+		t.Fatalf("merged durable fields = %#v, want preserved score/alerts/reportability", merged)
+	}
+	if len(merged.Violations) != 1 || merged.Violations[0].ViolationType != "lateral_deviation" || merged.Violations[0].Phase != "open" || merged.Violations[0].WorstDeviationM != 12.5 {
+		t.Fatalf("merged violations = %#v", merged.Violations)
+	}
+	if missing := byIntent["intent-missing"]; missing.ID != "durable-missing" || missing.AssignmentID != "" {
+		t.Fatalf("missing projection fallback = %#v", missing)
+	}
+
+	conformance, err := svc.GetConformanceDashboard(ctx)
+	if err != nil {
+		t.Fatalf("GetConformanceDashboard returned error: %v", err)
+	}
+	if reg.batchConformanceCalls != 2 {
+		t.Fatalf("batch calls after both dashboards = %d, want one per dashboard", reg.batchConformanceCalls)
+	}
+	if len(conformance.Summaries) != 3 || len(conformance.Events) != 1 || conformance.Events[0].ID != "event-durable" {
+		t.Fatalf("conformance dashboard = %#v, want live summaries plus durable event", conformance)
+	}
+}
+
+func TestFleetServiceConformanceOverlayDegradesOnRegistryFailure(t *testing.T) {
+	ctx := context.Background()
+	for _, code := range []codes.Code{codes.Unimplemented, codes.Unavailable} {
+		t.Run(code.String(), func(t *testing.T) {
+			durable := durablememory.NewStore()
+			must(t, durable.CreateOperationalIntent(ctx, domain.OperationalIntent{ID: "intent-1", Version: 1, ConformanceRequired: true}))
+			must(t, durable.UpsertConformanceSummary(ctx, domain.ConformanceSummary{
+				ID: "durable-1", IntentID: "intent-1", IntentVersion: 1,
+				Status: domain.ConformanceStatusConforming, ReportabilityStatus: domain.ReportabilityStatusNo,
+			}))
+			reg := &conformanceFailureRegistry{testRegistry: newTestRegistry(), err: status.Error(code, "projection unavailable")}
+			svc := NewFleetService(durable, telemetrymemory.NewStore(), replaymemory.NewStore(), reg)
+			operations, err := svc.GetOperationsDashboard(ctx)
+			if err != nil {
+				t.Fatalf("GetOperationsDashboard returned error: %v", err)
+			}
+			if len(operations.Conformance) != 1 || operations.Conformance[0].ID != "durable-1" {
+				t.Fatalf("operations conformance = %#v, want durable fallback", operations.Conformance)
+			}
+			conformance, err := svc.GetConformanceDashboard(ctx)
+			if err != nil {
+				t.Fatalf("GetConformanceDashboard returned error: %v", err)
+			}
+			if len(conformance.Summaries) != 1 || conformance.Summaries[0].ID != "durable-1" {
+				t.Fatalf("conformance summaries = %#v, want durable fallback", conformance.Summaries)
+			}
+		})
+	}
+}
+
+func TestFleetServiceBootstrapsBatteryAndFlightLifecycle(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 8, 24, 7, 0, 0, 0, time.UTC)
+	store := durablememory.NewStore()
+	must(t, store.CreateAircraft(ctx, domain.Aircraft{ID: "aircraft-1", OperatorID: "operator-1"}))
+	must(t, store.CreateBattery(ctx, domain.Battery{ID: "battery-1", OperatorID: "operator-1"}))
+	intent := domain.OperationalIntent{
+		ID: "intent-1", Version: 3, OperatorID: "operator-1", AircraftID: "aircraft-1",
+		Status: domain.IntentStatusAccepted, UpdatedAt: now.Add(-time.Minute),
+	}
+	must(t, store.CreateOperationalIntent(ctx, intent))
+	svc := NewFleetService(store, telemetrymemory.NewStore(), replaymemory.NewStore(), newTestRegistry())
+	svc.now = func() time.Time { return now }
+
+	installation, err := svc.InstallBattery(ctx, "aircraft-1", InstallBatteryRequest{ID: "install-1", BatteryID: "battery-1"})
+	if err != nil {
+		t.Fatalf("InstallBattery returned error: %v", err)
+	}
+	if installation.OperatorID != "operator-1" || !installation.InstalledAt.Equal(now) {
+		t.Fatalf("installation = %#v, want derived operator and server time", installation)
+	}
+	if _, err := svc.InstallBattery(ctx, "aircraft-1", InstallBatteryRequest{ID: "install-2", BatteryID: "battery-1"}); !errors.Is(err, durable.ErrVersionConflict) {
+		t.Fatalf("second InstallBattery error = %v, want version conflict", err)
+	}
+
+	flight, err := svc.CreatePlannedFlight(ctx, "intent-1", CreateFlightRequest{ID: "flight-1", MissionType: "sitl"})
+	if err != nil {
+		t.Fatalf("CreatePlannedFlight returned error: %v", err)
+	}
+	if flight.Status != domain.FlightStatusPlanned || flight.OperatorID != "operator-1" || flight.AircraftID != "aircraft-1" || flight.IntentVersion != 3 || !flight.StartedAt.IsZero() {
+		t.Fatalf("planned flight = %#v", flight)
+	}
+	if _, err := svc.CreatePlannedFlight(ctx, "intent-1", CreateFlightRequest{ID: "flight-1"}); !errors.Is(err, durable.ErrAlreadyExists) {
+		t.Fatalf("duplicate CreatePlannedFlight error = %v, want already exists", err)
+	}
+	if _, err := svc.StartFlight(ctx, "flight-1"); !errors.Is(err, ErrInvalidTransition) {
+		t.Fatalf("StartFlight with accepted intent error = %v, want invalid transition", err)
+	}
+
+	intent.Status = domain.IntentStatusActive
+	intent.UpdatedAt = now
+	must(t, store.UpdateOperationalIntent(ctx, intent, 0))
+	started, err := svc.StartFlight(ctx, "flight-1")
+	if err != nil {
+		t.Fatalf("StartFlight returned error: %v", err)
+	}
+	if started.Status != domain.FlightStatusActive || !started.StartedAt.Equal(now) {
+		t.Fatalf("started flight = %#v", started)
+	}
+	retry, err := svc.StartFlight(ctx, "flight-1")
+	if err != nil || retry.Status != domain.FlightStatusActive || !retry.StartedAt.Equal(started.StartedAt) {
+		t.Fatalf("StartFlight retry = %#v, %v", retry, err)
+	}
+}
+
+func TestFleetServiceBootstrapRejectsOperatorMismatch(t *testing.T) {
+	ctx := context.Background()
+	store := durablememory.NewStore()
+	must(t, store.CreateAircraft(ctx, domain.Aircraft{ID: "aircraft-1", OperatorID: "operator-aircraft"}))
+	must(t, store.CreateBattery(ctx, domain.Battery{ID: "battery-1", OperatorID: "operator-battery"}))
+	svc := NewFleetService(store, telemetrymemory.NewStore(), replaymemory.NewStore(), newTestRegistry())
+	if _, err := svc.InstallBattery(ctx, "aircraft-1", InstallBatteryRequest{ID: "install-1", BatteryID: "battery-1"}); !errors.Is(err, ErrValidation) {
+		t.Fatalf("InstallBattery error = %v, want validation", err)
+	}
+
+	must(t, store.CreateOperationalIntent(ctx, domain.OperationalIntent{
+		ID: "intent-1", Version: 1, OperatorID: "operator-intent", AircraftID: "aircraft-1", Status: domain.IntentStatusAccepted,
+	}))
+	if _, err := svc.CreatePlannedFlight(ctx, "intent-1", CreateFlightRequest{ID: "flight-1"}); !errors.Is(err, ErrValidation) {
+		t.Fatalf("CreatePlannedFlight error = %v, want validation", err)
 	}
 }
 
@@ -608,7 +809,14 @@ func newTestRegistry() *testRegistry {
 
 type testRegistry struct {
 	*registry.MemoryClient
-	listAgentCalls int
+	listAgentCalls        int
+	batchConformanceCalls int
+	batchAssignmentIDs    [][]string
+}
+
+type conformanceFailureRegistry struct {
+	*testRegistry
+	err error
 }
 
 type controlledPlacementRegistry struct {
@@ -670,6 +878,50 @@ func (r *controlledPlacementRegistry) counts() (calls, active, maxActive int) {
 func (r *testRegistry) ListAgents(ctx context.Context, request *registryv1.ListAgentsRequest, options ...grpc.CallOption) (*registryv1.ListAgentsResponse, error) {
 	r.listAgentCalls++
 	return r.MemoryClient.ListAgents(ctx, request, options...)
+}
+
+func (r *testRegistry) BatchGetConformanceSummaries(ctx context.Context, request *registryv1.BatchGetConformanceSummariesRequest, options ...grpc.CallOption) (*registryv1.BatchGetConformanceSummariesResponse, error) {
+	r.batchConformanceCalls++
+	r.batchAssignmentIDs = append(r.batchAssignmentIDs, append([]string(nil), request.GetAssignmentIds()...))
+	return r.MemoryClient.BatchGetConformanceSummaries(ctx, request, options...)
+}
+
+func (r *conformanceFailureRegistry) BatchGetConformanceSummaries(context.Context, *registryv1.BatchGetConformanceSummariesRequest, ...grpc.CallOption) (*registryv1.BatchGetConformanceSummariesResponse, error) {
+	return nil, r.err
+}
+
+func testConformanceProto(intentID string, observedAt time.Time, condition conformancev1.ConformanceCondition) *conformancev1.ConformanceSummary {
+	return &conformancev1.ConformanceSummary{
+		AssignmentId:         intentID,
+		AssignmentGeneration: 3,
+		EvaluationRevision:   4,
+		EvaluationId:         "evaluation-" + intentID,
+		OperatorId:           "operator-1",
+		AircraftId:           "aircraft-1",
+		FlightId:             "flight-1",
+		IntentId:             intentID,
+		IntentVersion:        2,
+		Condition:            condition,
+		MonitoringStatus:     conformancev1.MonitoringStatus_MONITORING_STATUS_CURRENT,
+		RecordingStatus:      conformancev1.RecordingStatus_RECORDING_STATUS_CONFIRMED,
+		ObservedAt:           timestamppb.New(observedAt),
+		FrameId:              "frame-1",
+	}
+}
+
+func publishTestConformance(t *testing.T, ctx context.Context, client *registry.MemoryClient, summary *conformancev1.ConformanceSummary) {
+	t.Helper()
+	if _, err := client.PublishConformanceSummary(ctx, &registryv1.PublishConformanceSummaryRequest{Summary: summary}); err != nil {
+		t.Fatalf("PublishConformanceSummary returned error: %v", err)
+	}
+}
+
+func conformanceByIntent(summaries []domain.ConformanceSummary) map[string]domain.ConformanceSummary {
+	result := make(map[string]domain.ConformanceSummary, len(summaries))
+	for _, summary := range summaries {
+		result[summary.IntentID] = summary
+	}
+	return result
 }
 
 func must(t *testing.T, err error) {

--- a/internal/service/fleet_service_test.go
+++ b/internal/service/fleet_service_test.go
@@ -308,6 +308,26 @@ func TestFleetServiceConformanceOverlayDegradesOnRegistryFailure(t *testing.T) {
 	}
 }
 
+func TestConformanceMetricsSeparateLiveConditionFromScoresAndClearAxes(t *testing.T) {
+	summary := domain.ConformanceSummary{
+		AssignmentID: "intent-1", Status: domain.ConformanceStatusConforming,
+		Violations: []domain.ConformanceViolationSummary{
+			{ViolationType: "lateral_deviation", Phase: "clear"},
+			{ViolationType: "altitude_deviation", Phase: "open"},
+		},
+	}
+	metrics := conformanceMetrics([]domain.ConformanceSummary{summary}, nil)
+	if metrics[0].Value != "Not scored" || metrics[0].Detail != "Live condition is reported separately" {
+		t.Fatalf("target metric = %#v", metrics[0])
+	}
+	if metrics[2].Label != "Active findings" || metrics[2].Value != "1" {
+		t.Fatalf("findings metric = %#v", metrics[2])
+	}
+	if got := activeViolationCount(summary.Violations); got != 1 {
+		t.Fatalf("activeViolationCount() = %d, want 1", got)
+	}
+}
+
 func TestFleetServiceBootstrapsBatteryAndFlightLifecycle(t *testing.T) {
 	ctx := context.Background()
 	now := time.Date(2026, 8, 24, 7, 0, 0, 0, time.UTC)

--- a/internal/service/intent_service.go
+++ b/internal/service/intent_service.go
@@ -516,16 +516,21 @@ func (s *IntentService) ActivateIntent(ctx context.Context, intentID string) (do
 	intent.Status = domain.IntentStatusActive
 	intent.ActivatedAt = &now
 	intent.UpdatedAt = now
-	if err := s.durable.UpdateOperationalIntent(ctx, intent, expectedRevision); err != nil {
-		if errors.Is(err, durable.ErrVersionConflict) && s.deconfliction != nil && s.deconfliction.PublishingEnabled() {
+	if err := s.durable.ActivateOperationalIntent(ctx, intent, expectedRevision); err != nil {
+		activationErr := fmt.Errorf("update operational intent: %w", err)
+		if errors.Is(err, durable.ErrActiveIntent) {
+			activationErr = fmt.Errorf("%w: aircraft %s already has an active operational intent", ErrActivationBlocked, intent.AircraftID)
+		}
+		if (errors.Is(err, durable.ErrVersionConflict) || errors.Is(err, durable.ErrActiveIntent)) &&
+			s.deconfliction != nil && s.deconfliction.PublishingEnabled() {
 			if compensationErr := s.compensatePublishedActivation(ctx, intent.ID); compensationErr != nil {
 				return domain.OperationalIntent{}, errors.Join(
-					fmt.Errorf("update operational intent: %w", err),
+					activationErr,
 					fmt.Errorf("compensate DSS activation: %w", compensationErr),
 				)
 			}
 		}
-		return domain.OperationalIntent{}, fmt.Errorf("update operational intent: %w", err)
+		return domain.OperationalIntent{}, activationErr
 	}
 	intent.Revision = expectedRevision + 1
 	return intent, nil

--- a/internal/service/workflow_service_test.go
+++ b/internal/service/workflow_service_test.go
@@ -110,6 +110,15 @@ type durableWorkflowCoordinator struct {
 	beforeConfirm func(context.Context, domain.OperationalIntentPublication) error
 }
 
+type activationRejectingStore struct {
+	durable.Store
+	err error
+}
+
+func (s *activationRejectingStore) ActivateOperationalIntent(context.Context, domain.OperationalIntent, int64) error {
+	return s.err
+}
+
 func (c *durableWorkflowCoordinator) CheckIntent(context.Context, string) (domain.DeconflictionResult, error) {
 	return domain.DeconflictionResult{Posture: domain.DeconflictionPostureClear}, nil
 }
@@ -395,6 +404,49 @@ func TestActivateIntentRestoresAcceptedPublicationAfterReconcileFailure(t *testi
 		t.Fatal(err)
 	}
 	coordinator.reconcileErr = context.DeadlineExceeded
+	if _, err := intents.ActivateIntent(ctx, intent.ID); !errors.Is(err, ErrActivationBlocked) {
+		t.Fatalf("ActivateIntent error = %v, want activation blocked", err)
+	}
+	current, err := store.GetOperationalIntent(ctx, intent.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	publication, err := store.GetOperationalIntentPublication(ctx, intent.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if current.Status != domain.IntentStatusAccepted ||
+		publication.DesiredState != domain.OperationalIntentExternalStateAccepted ||
+		publication.ConfirmedState != domain.OperationalIntentExternalStateAccepted {
+		t.Fatalf("current=%+v publication=%+v", current, publication)
+	}
+}
+
+func TestActivateIntentCompensatesDSSAfterAircraftActivationRace(t *testing.T) {
+	ctx := context.Background()
+	now := fixedWorkflowTime()
+	store := durablememory.NewStore()
+	coordinator := &durableWorkflowCoordinator{store: store, now: now}
+	intents := NewIntentServiceWithClock(
+		&activationRejectingStore{Store: store, err: durable.ErrActiveIntent},
+		fixedClock(now),
+		coordinator,
+	)
+	intent := seedSubmittedIntentWithVolume(t, ctx, store, now)
+	var err error
+	if intent, err = intents.AcceptIntent(ctx, intent.ID); err != nil {
+		t.Fatal(err)
+	}
+	if err := coordinator.ReconcileIntent(ctx, intent.ID); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.RecordPreflightCheck(ctx, domain.PreflightCheck{
+		ID: "preflight", IntentID: intent.ID, IntentVersion: intent.Version,
+		Status: domain.PreflightStatusClear, CapturedAt: now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
 	if _, err := intents.ActivateIntent(ctx, intent.ID); !errors.Is(err, ErrActivationBlocked) {
 		t.Fatalf("ActivateIntent error = %v, want activation blocked", err)
 	}
@@ -1191,7 +1243,10 @@ func TestConformanceTelemetryHonorsSampleIntentID(t *testing.T) {
 	telemetry := telemetrymemory.NewStore()
 	now := fixedWorkflowTime()
 	seedWorkflowAircraft(t, ctx, store, now, float64Ptr(95))
-	createActiveIntentWithVolume(t, ctx, store, now, "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", "volume-a", squareGeoJSON(), now)
+	prior := createActiveIntentWithVolume(t, ctx, store, now, "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", "volume-a", squareGeoJSON(), now)
+	if _, err := NewIntentServiceWithClock(store, fixedClock(now), nil).CompleteIntent(ctx, prior.ID); err != nil {
+		t.Fatalf("CompleteIntent returned error: %v", err)
+	}
 	createActiveIntentWithVolume(t, ctx, store, now, "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb", "volume-b", eastSquareGeoJSON(), now.Add(10*time.Minute))
 
 	evaluation, err := NewConformanceServiceWithClock(store, telemetry, fixedClock(now)).EvaluateTelemetry(ctx, domain.TelemetrySample{

--- a/internal/store/durable/durable.go
+++ b/internal/store/durable/durable.go
@@ -105,6 +105,7 @@ type Store interface {
 	ListPreflightChecks(ctx context.Context, intentID string) ([]domain.PreflightCheck, error)
 
 	CreateFlightRecord(ctx context.Context, flight domain.FlightRecord) error
+	UpdateFlightRecord(ctx context.Context, flight domain.FlightRecord, expectedStatus domain.FlightStatus) error
 	GetFlightRecord(ctx context.Context, flightID string) (domain.FlightRecord, error)
 	ListFlightRecords(ctx context.Context, aircraftID string) ([]domain.FlightRecord, error)
 

--- a/internal/store/durable/durable.go
+++ b/internal/store/durable/durable.go
@@ -19,6 +19,7 @@ var (
 	ErrNotFound        = errors.New("not found")
 	ErrAlreadyExists   = errors.New("already exists")
 	ErrVersionConflict = errors.New("version conflict")
+	ErrActiveIntent    = errors.New("aircraft already has an active operational intent")
 )
 
 type CandidateQuery struct {
@@ -38,6 +39,7 @@ type OperationalStore interface {
 	FindCandidates(context.Context, CandidateQuery) ([]Candidate, error)
 	CreateOperationalIntent(ctx context.Context, intent domain.OperationalIntent) error
 	UpdateOperationalIntent(ctx context.Context, intent domain.OperationalIntent, expectedRevision int64) error
+	ActivateOperationalIntent(ctx context.Context, intent domain.OperationalIntent, expectedRevision int64) error
 	AcceptOperationalIntent(ctx context.Context, intent domain.OperationalIntent, expectedRevision int64) error
 	GetOperationalIntent(ctx context.Context, intentID string) (domain.OperationalIntent, error)
 	GetOperationalIntentVersion(ctx context.Context, intentID string, version int) (domain.OperationalIntent, error)

--- a/internal/store/durable/memory/durable.go
+++ b/internal/store/durable/memory/durable.go
@@ -415,6 +415,35 @@ func (s *Store) UpdateOperationalIntent(_ context.Context, intent domain.Operati
 	return s.updateOperationalIntentLocked(intent, expectedRevision)
 }
 
+// ActivateOperationalIntent atomically activates the supplied intent only
+// when its aircraft has no other active operational intent.
+//
+// Parameters:
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
+//   - intent: is the accepted intent to transition to active.
+//   - expectedRevision: fences the target intent against concurrent mutation.
+//
+// Returns:
+//   - error: reports stale target state or durable.ErrActiveIntent when another
+//     intent already owns the aircraft's active-flight lifecycle.
+func (s *Store) ActivateOperationalIntent(_ context.Context, intent domain.OperationalIntent, expectedRevision int64) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	current, exists := s.latestOperationalIntent(intent.ID)
+	if !exists {
+		return durable.ErrNotFound
+	}
+	if current.Version != intent.Version || current.Revision != expectedRevision {
+		return durable.ErrVersionConflict
+	}
+	for _, existing := range s.operationalIntents {
+		if (existing.ID != intent.ID || existing.Version != intent.Version) && existing.AircraftID == intent.AircraftID && existing.Status == domain.IntentStatusActive {
+			return durable.ErrActiveIntent
+		}
+	}
+	return s.updateOperationalIntentLocked(intent, expectedRevision)
+}
+
 func (s *Store) updateOperationalIntentLocked(intent domain.OperationalIntent, expectedRevision int64) error {
 	current, exists := s.latestOperationalIntent(intent.ID)
 	if !exists {

--- a/internal/store/durable/memory/durable.go
+++ b/internal/store/durable/memory/durable.go
@@ -235,6 +235,14 @@ func (s *Store) ListBatteries(_ context.Context) ([]domain.Battery, error) {
 func (s *Store) RecordBatteryInstallation(_ context.Context, installation domain.BatteryInstallation) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	for _, existing := range s.batteryInstallations {
+		if existing.ID == installation.ID {
+			return durable.ErrAlreadyExists
+		}
+		if existing.AircraftID == installation.AircraftID && existing.RemovedAt == nil {
+			return durable.ErrVersionConflict
+		}
+	}
 	s.batteryInstallations = append(s.batteryInstallations, installation)
 	return nil
 }
@@ -1242,6 +1250,33 @@ func (s *Store) ListPreflightChecks(_ context.Context, intentID string) ([]domai
 func (s *Store) CreateFlightRecord(_ context.Context, flight domain.FlightRecord) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if _, exists := s.flightRecords[flight.ID]; exists {
+		return durable.ErrAlreadyExists
+	}
+	s.flightRecords[flight.ID] = flight
+	return nil
+}
+
+// UpdateFlightRecord replaces an existing flight only while its current status
+// matches the caller's expected lifecycle state.
+//
+// Parameters:
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
+//   - flight: contains the replacement flight record.
+//   - expectedStatus: fences the update against concurrent lifecycle changes.
+//
+// Returns:
+//   - error: reports a missing flight or a lifecycle version conflict.
+func (s *Store) UpdateFlightRecord(_ context.Context, flight domain.FlightRecord, expectedStatus domain.FlightStatus) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	current, exists := s.flightRecords[flight.ID]
+	if !exists {
+		return durable.ErrNotFound
+	}
+	if current.Status != expectedStatus {
+		return durable.ErrVersionConflict
+	}
 	s.flightRecords[flight.ID] = flight
 	return nil
 }

--- a/internal/store/durable/memory/operational_test.go
+++ b/internal/store/durable/memory/operational_test.go
@@ -3,6 +3,7 @@ package memory
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -63,6 +64,65 @@ func TestOperationalIntentCreateAndUpdateConcurrency(t *testing.T) {
 	second.UpdatedAt = now.Add(2 * time.Second)
 	if err := store.UpdateOperationalIntent(ctx, second, 0); !errors.Is(err, durable.ErrVersionConflict) {
 		t.Fatalf("stale update error = %v, want ErrVersionConflict", err)
+	}
+}
+
+func TestConcurrentAircraftActivationsAllowExactlyOneIntent(t *testing.T) {
+	ctx := context.Background()
+	store := NewStore()
+	now := time.Date(2026, time.August, 24, 12, 0, 0, 0, time.UTC)
+	intents := []domain.OperationalIntent{
+		{ID: "intent-a", Version: 1, AircraftID: "aircraft-1", Status: domain.IntentStatusAccepted, UpdatedAt: now},
+		{ID: "intent-b", Version: 1, AircraftID: "aircraft-1", Status: domain.IntentStatusAccepted, UpdatedAt: now},
+	}
+	for _, intent := range intents {
+		if err := store.CreateOperationalIntent(ctx, intent); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	start := make(chan struct{})
+	errs := make(chan error, len(intents))
+	var ready sync.WaitGroup
+	ready.Add(len(intents))
+	for _, accepted := range intents {
+		active := accepted
+		active.Status = domain.IntentStatusActive
+		go func() {
+			ready.Done()
+			<-start
+			errs <- store.ActivateOperationalIntent(ctx, active, active.Revision)
+		}()
+	}
+	ready.Wait()
+	close(start)
+
+	var activated, rejected int
+	for range intents {
+		switch err := <-errs; {
+		case err == nil:
+			activated++
+		case errors.Is(err, durable.ErrActiveIntent):
+			rejected++
+		default:
+			t.Fatalf("activation error = %v", err)
+		}
+	}
+	if activated != 1 || rejected != 1 {
+		t.Fatalf("activated = %d, rejected = %d", activated, rejected)
+	}
+	stored, err := store.ListOperationalIntents(ctx, "aircraft-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	activeCount := 0
+	for _, intent := range stored {
+		if intent.Status == domain.IntentStatusActive {
+			activeCount++
+		}
+	}
+	if activeCount != 1 {
+		t.Fatalf("active intents = %d, want 1; intents=%#v", activeCount, stored)
 	}
 }
 

--- a/internal/store/durable/postgres/schema.sql
+++ b/internal/store/durable/postgres/schema.sql
@@ -41,6 +41,10 @@ $$;
 CREATE INDEX IF NOT EXISTS operational_intents_aircraft_start_idx
     ON operational_intents (aircraft_id, planned_start_at);
 
+CREATE UNIQUE INDEX IF NOT EXISTS operational_intents_one_active_aircraft_idx
+    ON operational_intents (aircraft_id)
+    WHERE data->>'status' = 'active';
+
 CREATE TABLE IF NOT EXISTS operational_volumes (
     intent_id text NOT NULL,
     intent_version integer NOT NULL CHECK (intent_version > 0),

--- a/internal/store/durable/postgres/store.go
+++ b/internal/store/durable/postgres/store.go
@@ -117,6 +117,56 @@ func (s *Store) UpdateOperationalIntent(ctx context.Context, intent domain.Opera
 	return nil
 }
 
+// ActivateOperationalIntent atomically activates the supplied intent only
+// when its aircraft has no other active operational intent. An aircraft-scoped
+// transaction lock serializes competing activations across API replicas, and a
+// partial unique index remains the final storage-level backstop.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the transaction.
+//   - intent: is the accepted intent to transition to active.
+//   - expectedRevision: fences the target intent against concurrent mutation.
+//
+// Returns:
+//   - error: reports stale target state or durable.ErrActiveIntent when another
+//     intent already owns the aircraft's active-flight lifecycle.
+func (s *Store) ActivateOperationalIntent(ctx context.Context, intent domain.OperationalIntent, expectedRevision int64) error {
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("begin operational intent activation: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	if _, err = tx.Exec(ctx, `SELECT pg_advisory_xact_lock(hashtextextended($1, 0))`, intent.AircraftID); err != nil {
+		return fmt.Errorf("lock aircraft operational lifecycle: %w", err)
+	}
+	if err = lockIntent(ctx, tx, intent.ID); err != nil {
+		return err
+	}
+	var activeIntentID string
+	err = tx.QueryRow(ctx, `
+		SELECT id
+		FROM operational_intents
+		WHERE aircraft_id = $1 AND (id <> $2 OR version <> $3) AND data->>'status' = $4
+		LIMIT 1`, intent.AircraftID, intent.ID, intent.Version, domain.IntentStatusActive).Scan(&activeIntentID)
+	switch {
+	case err == nil:
+		return durable.ErrActiveIntent
+	case !errors.Is(err, pgx.ErrNoRows):
+		return fmt.Errorf("check active aircraft operational intent: %w", err)
+	}
+	if err = updateOperationalIntentTx(ctx, tx, intent, expectedRevision); err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" && pgErr.ConstraintName == "operational_intents_one_active_aircraft_idx" {
+			return durable.ErrActiveIntent
+		}
+		return err
+	}
+	if err = tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit operational intent activation: %w", err)
+	}
+	return nil
+}
+
 func updateOperationalIntentTx(ctx context.Context, tx pgx.Tx, intent domain.OperationalIntent, expectedRevision int64) error {
 	raw, err := json.Marshal(intent)
 	if err != nil {

--- a/internal/store/durable/postgres/store_integration_test.go
+++ b/internal/store/durable/postgres/store_integration_test.go
@@ -146,6 +146,67 @@ func TestConcurrentIntentUpdatesUseOptimisticRevision(t *testing.T) {
 	}
 }
 
+func TestConcurrentAircraftActivationsAllowExactlyOneIntent(t *testing.T) {
+	ctx, first, second := integrationStores(t)
+	now := time.Date(2026, time.August, 24, 12, 0, 0, 0, time.UTC)
+	intents := []domain.OperationalIntent{
+		integrationIntent("activation-a", now),
+		integrationIntent("activation-b", now),
+	}
+	for index := range intents {
+		intents[index].AircraftID = "aircraft-race"
+		intents[index].Status = domain.IntentStatusAccepted
+		if err := first.CreateOperationalIntent(ctx, intents[index]); err != nil {
+			t.Fatal(err)
+		}
+	}
+	stores := []*Store{first, second}
+	start := make(chan struct{})
+	errs := make(chan error, len(intents))
+	var ready sync.WaitGroup
+	ready.Add(len(intents))
+	for index, accepted := range intents {
+		active := accepted
+		active.Status = domain.IntentStatusActive
+		store := stores[index]
+		go func() {
+			ready.Done()
+			<-start
+			errs <- store.ActivateOperationalIntent(ctx, active, active.Revision)
+		}()
+	}
+	ready.Wait()
+	close(start)
+
+	var activated, rejected int
+	for range intents {
+		switch err := <-errs; {
+		case err == nil:
+			activated++
+		case errors.Is(err, durable.ErrActiveIntent):
+			rejected++
+		default:
+			t.Fatalf("activation error = %v", err)
+		}
+	}
+	if activated != 1 || rejected != 1 {
+		t.Fatalf("activated = %d, rejected = %d", activated, rejected)
+	}
+	stored, err := first.ListOperationalIntents(ctx, "aircraft-race")
+	if err != nil {
+		t.Fatal(err)
+	}
+	activeCount := 0
+	for _, intent := range stored {
+		if intent.Status == domain.IntentStatusActive {
+			activeCount++
+		}
+	}
+	if activeCount != 1 {
+		t.Fatalf("active intents = %d, want 1; intents=%#v", activeCount, stored)
+	}
+}
+
 func TestUpdateOperationalIntentRejectsSupersededVersion(t *testing.T) {
 	ctx, store, _ := integrationStores(t)
 	now := time.Date(2026, time.August, 7, 12, 0, 0, 0, time.UTC)


### PR DESCRIPTION
## Summary

- batch-read live Conformance projections from Registry and overlay them onto
  `/api/v1/operations` and `/api/v1/conformance`
- expose assignment/evaluation identity, condition, monitoring, recording,
  observation, frame, and per-axis violation state
- degrade safely to durable API data if Registry is missing, partial, or
  unavailable, with no per-aircraft N+1 requests
- add the battery-installation and planned-flight/start routes required for a
  clean no-seed SITL run
- transactionally enforce at most one active operational intent per aircraft
  in both memory and PostgreSQL stores
- serialize competing PostgreSQL activations with an aircraft-scoped advisory
  lock and retain a partial unique index as the storage backstop
- compensate a losing external DSS activation back to Accepted when the local
  same-aircraft race rejects it

## Why

Ops needs one API boundary for durable workflow state, live Registry state, and
conformance posture. Activation also needs a transactional invariant: UI and
DSS behavior alone cannot prevent two simultaneous requests from activating
different flights for the same aircraft.

## Validation

- `go test ./...`
- `go vet ./...`
- `go test -race ./...`
- Docker-backed PostGIS integration suite, including a simultaneous activation
  race proving exactly one winner
- service coverage proving a rejected local activation compensates DSS state
- live no-seed ArduCopter SITL run proving Registry, conformance, telemetry,
  lifecycle, and command data reach the API and Ops

## Known follow-up

The current PostgreSQL store still delegates flight and battery-installation
records to its embedded memory store, so those bootstrap records do not survive
an API restart yet.

All commits include a DCO sign-off.
