### PR TITLE
Split preflight policy into dedicated checkers

### DIFF
--- a/internal/httpapi/handlers_test.go
+++ b/internal/httpapi/handlers_test.go
@@ -164,7 +164,7 @@ func TestHandleBootstrapBatteryAndFlightLifecycle(t *testing.T) {
 	server := NewWithWorkflows(
 		fleet,
 		service.NewIntentService(store, nil),
-		service.NewPreflightService(store),
+		preflight.NewPreflightService(store),
 		service.NewConformanceService(store, telemetry),
 		time.Second,
 	)

--- a/internal/service/preflight/aircraft_checker.go
+++ b/internal/service/preflight/aircraft_checker.go
@@ -1,0 +1,24 @@
+package preflight
+
+import (
+	"context"
+
+	"github.com/Aero-Arc/aero-arc-api/internal/domain"
+)
+
+type AircraftChecker struct{}
+
+func (AircraftChecker) Name() string { return "aircraft" }
+
+func (AircraftChecker) Evaluate(_ context.Context, snapshot Snapshot, builder *Builder) {
+	if snapshot.AircraftErr != nil {
+		builder.Block(domain.PreflightCheckAirspace, "aircraft_exists", "fleet_registry", "AIRCRAFT-EXISTS", "aircraft does not exist", "create or select a valid aircraft")
+		return
+	}
+	builder.Clear(domain.PreflightCheckAirspace, "aircraft_exists", "fleet_registry", "AIRCRAFT-EXISTS", "aircraft exists")
+	if snapshot.Aircraft.Status != domain.AircraftStatusActive || snapshot.Aircraft.AcceptanceStatus != domain.AcceptanceStatusAccepted {
+		builder.Block(domain.PreflightCheckAirspace, "aircraft_operational_status", "fleet_registry", "AIRCRAFT-STATUS", "aircraft is not active or accepted", "set aircraft active or complete acceptance")
+	} else {
+		builder.Clear(domain.PreflightCheckAirspace, "aircraft_operational_status", "fleet_registry", "AIRCRAFT-STATUS", "aircraft status allows operation")
+	}
+}

--- a/internal/service/preflight/aircraft_checker_test.go
+++ b/internal/service/preflight/aircraft_checker_test.go
@@ -1,0 +1,32 @@
+package preflight
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Aero-Arc/aero-arc-api/internal/domain"
+)
+
+func TestAircraftCheckerMissingAircraftDoesNotEmitStatus(t *testing.T) {
+	snapshot := testSnapshot(timeNow())
+	snapshot.AircraftErr = errors.New("missing")
+	builder := evaluateChecker(t, AircraftChecker{}, snapshot)
+	requireCheck(t, builder, "aircraft_exists", "AIRCRAFT-EXISTS", "fleet_registry", true)
+	requireNoCheck(t, builder, "aircraft_operational_status")
+}
+
+func TestAircraftCheckerBlocksWhenNotActiveAndAccepted(t *testing.T) {
+	snapshot := testSnapshot(timeNow())
+	snapshot.Aircraft = domain.Aircraft{Status: domain.AircraftStatusInactive, AcceptanceStatus: domain.AcceptanceStatusAccepted}
+	builder := evaluateChecker(t, AircraftChecker{}, snapshot)
+	requireCheck(t, builder, "aircraft_exists", "AIRCRAFT-EXISTS", "fleet_registry", false)
+	requireCheck(t, builder, "aircraft_operational_status", "AIRCRAFT-STATUS", "fleet_registry", true)
+}
+
+func TestAircraftCheckerClearWhenActiveAndAccepted(t *testing.T) {
+	snapshot := testSnapshot(timeNow())
+	snapshot.Aircraft = domain.Aircraft{Status: domain.AircraftStatusActive, AcceptanceStatus: domain.AcceptanceStatusAccepted}
+	builder := evaluateChecker(t, AircraftChecker{}, snapshot)
+	requireCheck(t, builder, "aircraft_exists", "AIRCRAFT-EXISTS", "fleet_registry", false)
+	requireCheck(t, builder, "aircraft_operational_status", "AIRCRAFT-STATUS", "fleet_registry", false)
+}

--- a/internal/service/preflight/battery_checker.go
+++ b/internal/service/preflight/battery_checker.go
@@ -1,0 +1,39 @@
+package preflight
+
+import (
+	"context"
+
+	"github.com/Aero-Arc/aero-arc-api/internal/domain"
+	"github.com/Aero-Arc/aero-arc-api/internal/store/durable"
+)
+
+type BatteryChecker struct {
+	durable durable.Store
+}
+
+func (BatteryChecker) Name() string { return "battery" }
+
+func (c BatteryChecker) Evaluate(ctx context.Context, snapshot Snapshot, builder *Builder) {
+	installation, err := c.durable.GetActiveBatteryInstallation(ctx, snapshot.Intent.AircraftID)
+	if err != nil || installation == nil {
+		builder.Block(domain.PreflightCheckBattery, "battery_installed", "maintenance_control", "BATTERY-INSTALLED", "battery is not installed", "install a battery")
+		return
+	}
+	builder.Clear(domain.PreflightCheckBattery, "battery_installed", "maintenance_control", "BATTERY-INSTALLED", "battery is installed")
+
+	battery, err := c.durable.GetBattery(ctx, installation.BatteryID)
+	if err != nil {
+		builder.Block(domain.PreflightCheckBattery, "battery_soh_known", "maintenance_control", "BATTERY-SOH-KNOWN", "battery state of health is unknown", "record battery state of health")
+		return
+	}
+	if battery.StateOfHealth == nil {
+		builder.Block(domain.PreflightCheckBattery, "battery_soh_known", "maintenance_control", "BATTERY-SOH-KNOWN", "battery state of health is unknown", "record battery state of health")
+		return
+	}
+	builder.Clear(domain.PreflightCheckBattery, "battery_soh_known", "maintenance_control", "BATTERY-SOH-KNOWN", "battery state of health is known")
+	if *battery.StateOfHealth < 80 {
+		builder.Block(domain.PreflightCheckBattery, "battery_soh_minimum", "maintenance_control", "BATTERY-SOH-80", "battery state of health is below 80", "replace or service battery")
+		return
+	}
+	builder.Clear(domain.PreflightCheckBattery, "battery_soh_minimum", "maintenance_control", "BATTERY-SOH-80", "battery state of health is at least 80")
+}

--- a/internal/service/preflight/battery_checker_test.go
+++ b/internal/service/preflight/battery_checker_test.go
@@ -1,0 +1,54 @@
+package preflight
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Aero-Arc/aero-arc-api/internal/domain"
+	durablememory "github.com/Aero-Arc/aero-arc-api/internal/store/durable/memory"
+)
+
+func TestBatteryCheckerBlocksWhenNotInstalled(t *testing.T) {
+	store := durablememory.NewStore()
+	builder := evaluateChecker(t, BatteryChecker{durable: store}, testSnapshot(timeNow()))
+	requireCheck(t, builder, "battery_installed", "BATTERY-INSTALLED", "maintenance_control", true)
+	requireNoCheck(t, builder, "battery_soh_known")
+}
+
+func TestBatteryCheckerBlocksWhenSOHMissing(t *testing.T) {
+	ctx := context.Background()
+	now := timeNow()
+	store := durablememory.NewStore()
+	if err := store.CreateBattery(ctx, domain.Battery{ID: "battery-1", OperatorID: "operator-1", Status: domain.MaintenanceStatusCurrent, CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.RecordBatteryInstallation(ctx, domain.BatteryInstallation{ID: "install-1", AircraftID: "aircraft-1", BatteryID: "battery-1", InstalledAt: now}); err != nil {
+		t.Fatal(err)
+	}
+	builder := evaluateChecker(t, BatteryChecker{durable: store}, testSnapshot(now))
+	requireCheck(t, builder, "battery_installed", "BATTERY-INSTALLED", "maintenance_control", false)
+	requireCheck(t, builder, "battery_soh_known", "BATTERY-SOH-KNOWN", "maintenance_control", true)
+	requireNoCheck(t, builder, "battery_soh_minimum")
+}
+
+func TestBatteryCheckerThresholdIsEighty(t *testing.T) {
+	ctx := context.Background()
+	now := timeNow()
+	low := 79.0
+	ok := 80.0
+	for _, test := range []struct {
+		soh     *float64
+		blocked bool
+	}{{soh: &low, blocked: true}, {soh: &ok, blocked: false}} {
+		store := durablememory.NewStore()
+		if err := store.CreateBattery(ctx, domain.Battery{ID: "battery-1", StateOfHealth: test.soh, Status: domain.MaintenanceStatusCurrent, CreatedAt: now, UpdatedAt: now}); err != nil {
+			t.Fatal(err)
+		}
+		if err := store.RecordBatteryInstallation(ctx, domain.BatteryInstallation{ID: "install-1", AircraftID: "aircraft-1", BatteryID: "battery-1", InstalledAt: now}); err != nil {
+			t.Fatal(err)
+		}
+		builder := evaluateChecker(t, BatteryChecker{durable: store}, testSnapshot(now))
+		requireCheck(t, builder, "battery_soh_known", "BATTERY-SOH-KNOWN", "maintenance_control", false)
+		requireCheck(t, builder, "battery_soh_minimum", "BATTERY-SOH-80", "maintenance_control", test.blocked)
+	}
+}

--- a/internal/service/preflight/builder.go
+++ b/internal/service/preflight/builder.go
@@ -1,0 +1,96 @@
+package preflight
+
+import (
+	"fmt"
+
+	"github.com/Aero-Arc/aero-arc-api/internal/domain"
+)
+
+const ruleVersion = "demo.v1"
+
+// Builder constructs PreflightCheck and ComplianceFinding records for one evaluation.
+type Builder struct {
+	snapshot Snapshot
+	checks   []domain.PreflightCheck
+	findings []domain.ComplianceFinding
+	blocked  bool
+}
+
+func newBuilder(snapshot Snapshot) *Builder {
+	return &Builder{snapshot: snapshot}
+}
+
+func (b *Builder) Checks() []domain.PreflightCheck {
+	return b.checks
+}
+
+func (b *Builder) Findings() []domain.ComplianceFinding {
+	return b.findings
+}
+
+func (b *Builder) Blocked() bool {
+	return b.blocked
+}
+
+func (b *Builder) Clear(category domain.PreflightCheckCategory, key, source, requirementCode, summary string) {
+	b.record(category, key, source, requirementCode, summary, "", domain.PreflightStatusClear, false)
+}
+
+func (b *Builder) Block(category domain.PreflightCheckCategory, key, source, requirementCode, summary, remediation string) {
+	b.record(category, key, source, requirementCode, summary, remediation, domain.PreflightStatusBlocked, true)
+	b.blocked = true
+}
+
+func (b *Builder) record(category domain.PreflightCheckCategory, key, source, requirementCode, summary, remediation string, status domain.PreflightStatus, blocking bool) {
+	intent := b.snapshot.Intent
+	check := domain.PreflightCheck{
+		ID:              fmt.Sprintf("preflight-%s-v%d-%s", intent.ID, intent.Version, key),
+		OperatorID:      intent.OperatorID,
+		IntentID:        intent.ID,
+		IntentVersion:   intent.Version,
+		AircraftID:      intent.AircraftID,
+		Category:        category,
+		Source:          source,
+		Status:          status,
+		Summary:         summary,
+		RequirementCode: requirementCode,
+		RuleVersion:     ruleVersion,
+		Blocking:        blocking,
+		CapturedAt:      b.snapshot.Now,
+	}
+	b.checks = append(b.checks, check)
+	if !blocking {
+		b.findings = append(b.findings, domain.ComplianceFinding{
+			ID:              fmt.Sprintf("finding-%s-v%d-%s", intent.ID, intent.Version, key),
+			OperatorID:      intent.OperatorID,
+			IntentID:        intent.ID,
+			IntentVersion:   intent.Version,
+			SubjectType:     "operational_intent",
+			SubjectID:       intent.ID,
+			RequirementCode: requirementCode,
+			Status:          domain.ComplianceFindingPass,
+			Severity:        domain.SeverityInfo,
+			Blocking:        false,
+			RuleVersion:     ruleVersion,
+			Message:         summary,
+			EvaluatedAt:     b.snapshot.Now,
+		})
+		return
+	}
+	b.findings = append(b.findings, domain.ComplianceFinding{
+		ID:              fmt.Sprintf("finding-%s-v%d-%s", intent.ID, intent.Version, key),
+		OperatorID:      intent.OperatorID,
+		IntentID:        intent.ID,
+		IntentVersion:   intent.Version,
+		SubjectType:     "operational_intent",
+		SubjectID:       intent.ID,
+		RequirementCode: requirementCode,
+		Status:          domain.ComplianceFindingFail,
+		Severity:        domain.SeverityCritical,
+		Blocking:        true,
+		RuleVersion:     ruleVersion,
+		Remediation:     remediation,
+		Message:         summary,
+		EvaluatedAt:     b.snapshot.Now,
+	})
+}

--- a/internal/service/preflight/builder_test.go
+++ b/internal/service/preflight/builder_test.go
@@ -1,0 +1,82 @@
+package preflight
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Aero-Arc/aero-arc-api/internal/domain"
+)
+
+func testSnapshot(now time.Time) Snapshot {
+	return Snapshot{
+		Intent: domain.OperationalIntent{
+			ID:         "intent-1",
+			Version:    2,
+			OperatorID: "operator-1",
+			AircraftID: "aircraft-1",
+		},
+		Now: now,
+	}
+}
+
+func TestBuilderClearWritesPassFinding(t *testing.T) {
+	now := time.Date(2026, time.January, 15, 12, 0, 0, 0, time.UTC)
+	builder := newBuilder(testSnapshot(now))
+	builder.Clear(domain.PreflightCheckAirspace, "aircraft_exists", "fleet_registry", "AIRCRAFT-EXISTS", "aircraft exists")
+
+	if builder.Blocked() {
+		t.Fatal("clear should not block")
+	}
+	if len(builder.Checks()) != 1 || len(builder.Findings()) != 1 {
+		t.Fatalf("checks=%d findings=%d, want 1 each", len(builder.Checks()), len(builder.Findings()))
+	}
+
+	check := builder.Checks()[0]
+	if check.ID != "preflight-intent-1-v2-aircraft_exists" {
+		t.Fatalf("check ID = %q", check.ID)
+	}
+	if check.Status != domain.PreflightStatusClear || check.Blocking || check.RuleVersion != "demo.v1" {
+		t.Fatalf("check = %#v", check)
+	}
+	if !check.CapturedAt.Equal(now) {
+		t.Fatalf("CapturedAt = %v, want %v", check.CapturedAt, now)
+	}
+
+	finding := builder.Findings()[0]
+	if finding.ID != "finding-intent-1-v2-aircraft_exists" {
+		t.Fatalf("finding ID = %q", finding.ID)
+	}
+	if finding.Status != domain.ComplianceFindingPass || finding.Severity != domain.SeverityInfo || finding.Blocking {
+		t.Fatalf("finding = %#v", finding)
+	}
+	if finding.RuleVersion != "demo.v1" || finding.Remediation != "" {
+		t.Fatalf("finding = %#v", finding)
+	}
+	if !finding.EvaluatedAt.Equal(now) {
+		t.Fatalf("EvaluatedAt = %v, want %v", finding.EvaluatedAt, now)
+	}
+}
+
+func TestBuilderBlockWritesFailFinding(t *testing.T) {
+	now := time.Date(2026, time.January, 15, 12, 0, 0, 0, time.UTC)
+	builder := newBuilder(testSnapshot(now))
+	builder.Block(domain.PreflightCheckBattery, "battery_soh_known", "maintenance_control", "BATTERY-SOH-KNOWN", "battery state of health is unknown", "record battery state of health")
+
+	if !builder.Blocked() {
+		t.Fatal("block should set blocked")
+	}
+	check := builder.Checks()[0]
+	if check.ID != "preflight-intent-1-v2-battery_soh_known" || check.Status != domain.PreflightStatusBlocked || !check.Blocking {
+		t.Fatalf("check = %#v", check)
+	}
+	finding := builder.Findings()[0]
+	if finding.ID != "finding-intent-1-v2-battery_soh_known" {
+		t.Fatalf("finding ID = %q", finding.ID)
+	}
+	if finding.Status != domain.ComplianceFindingFail || finding.Severity != domain.SeverityCritical || !finding.Blocking {
+		t.Fatalf("finding = %#v", finding)
+	}
+	if finding.Remediation != "record battery state of health" {
+		t.Fatalf("remediation = %q", finding.Remediation)
+	}
+}

--- a/internal/service/preflight/checker.go
+++ b/internal/service/preflight/checker.go
@@ -1,0 +1,10 @@
+package preflight
+
+import "context"
+
+// Checker evaluates one readiness concern against a Snapshot and records
+// results through Builder. Existing policy stays in service.go until PR 3.
+type Checker interface {
+	Name() string
+	Evaluate(ctx context.Context, snapshot Snapshot, builder *Builder)
+}

--- a/internal/service/preflight/checker.go
+++ b/internal/service/preflight/checker.go
@@ -3,7 +3,7 @@ package preflight
 import "context"
 
 // Checker evaluates one readiness concern against a Snapshot and records
-// results through Builder. Existing policy stays in service.go until PR 3.
+// results through Builder.
 type Checker interface {
 	Name() string
 	Evaluate(ctx context.Context, snapshot Snapshot, builder *Builder)

--- a/internal/service/preflight/checker_test.go
+++ b/internal/service/preflight/checker_test.go
@@ -1,0 +1,60 @@
+package preflight
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/Aero-Arc/aero-arc-api/internal/domain"
+)
+
+func timeNow() time.Time {
+	return time.Date(2026, time.January, 15, 12, 0, 0, 0, time.UTC)
+}
+
+func evaluateChecker(t *testing.T, checker Checker, snapshot Snapshot) *Builder {
+	t.Helper()
+	builder := newBuilder(snapshot)
+	checker.Evaluate(context.Background(), snapshot, builder)
+	return builder
+}
+
+func requireCheck(t *testing.T, builder *Builder, key, requirementCode, source string, blocked bool) domain.PreflightCheck {
+	t.Helper()
+	wantID := fmt.Sprintf("preflight-%s-v%d-%s", builder.snapshot.Intent.ID, builder.snapshot.Intent.Version, key)
+	for _, check := range builder.Checks() {
+		if check.ID != wantID {
+			continue
+		}
+		if check.RequirementCode != requirementCode || check.Source != source || check.RuleVersion != "demo.v1" || check.Blocking != blocked {
+			t.Fatalf("check %#v, want code=%s source=%s blocked=%v demo.v1", check, requirementCode, source, blocked)
+		}
+		return check
+	}
+	t.Fatalf("missing check %s in %#v", wantID, builder.Checks())
+	return domain.PreflightCheck{}
+}
+
+func requireNoCheck(t *testing.T, builder *Builder, key string) {
+	t.Helper()
+	wantID := fmt.Sprintf("preflight-%s-v%d-%s", builder.snapshot.Intent.ID, builder.snapshot.Intent.Version, key)
+	for _, check := range builder.Checks() {
+		if check.ID == wantID {
+			t.Fatalf("unexpected check %s", check.ID)
+		}
+	}
+}
+
+func TestDefaultCheckerOrder(t *testing.T) {
+	service := NewPreflightService(nil)
+	want := []string{"aircraft", "remote_id", "intent_volume", "battery", "maintenance", "static_environment"}
+	if len(service.checkers) != len(want) {
+		t.Fatalf("checkers = %d, want %d", len(service.checkers), len(want))
+	}
+	for i, name := range want {
+		if got := service.checkers[i].Name(); got != name {
+			t.Fatalf("checkers[%d] = %q, want %q", i, got, name)
+		}
+	}
+}

--- a/internal/service/preflight/maintenance_checker.go
+++ b/internal/service/preflight/maintenance_checker.go
@@ -1,0 +1,29 @@
+package preflight
+
+import (
+	"context"
+
+	"github.com/Aero-Arc/aero-arc-api/internal/domain"
+	"github.com/Aero-Arc/aero-arc-api/internal/store/durable"
+)
+
+type MaintenanceChecker struct {
+	durable durable.Store
+}
+
+func (MaintenanceChecker) Name() string { return "maintenance" }
+
+func (c MaintenanceChecker) Evaluate(ctx context.Context, snapshot Snapshot, builder *Builder) {
+	events, err := c.durable.ListMaintenanceEvents(ctx, snapshot.Intent.AircraftID)
+	if err != nil {
+		builder.Block(domain.PreflightCheckMaintenance, "maintenance_events_available", "maintenance_control", "MX-AVAILABLE", "maintenance status could not be loaded", "retry maintenance status lookup")
+		return
+	}
+	for _, event := range events {
+		if event.Severity == domain.SeverityCritical && event.ResolvedAt == nil && event.Status != domain.MaintenanceStatusClosed {
+			builder.Block(domain.PreflightCheckMaintenance, "critical_open_maintenance", "maintenance_control", "MX-CRITICAL-OPEN", "critical open maintenance event exists", "resolve critical maintenance before activation")
+			return
+		}
+	}
+	builder.Clear(domain.PreflightCheckMaintenance, "critical_open_maintenance", "maintenance_control", "MX-CRITICAL-OPEN", "no critical open maintenance events")
+}

--- a/internal/service/preflight/maintenance_checker_test.go
+++ b/internal/service/preflight/maintenance_checker_test.go
@@ -1,0 +1,34 @@
+package preflight
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Aero-Arc/aero-arc-api/internal/domain"
+	durablememory "github.com/Aero-Arc/aero-arc-api/internal/store/durable/memory"
+)
+
+func TestMaintenanceCheckerClearsWhenNoCriticalOpen(t *testing.T) {
+	builder := evaluateChecker(t, MaintenanceChecker{durable: durablememory.NewStore()}, testSnapshot(timeNow()))
+	requireCheck(t, builder, "critical_open_maintenance", "MX-CRITICAL-OPEN", "maintenance_control", false)
+	requireNoCheck(t, builder, "maintenance_events_available")
+}
+
+func TestMaintenanceCheckerBlocksCriticalOpen(t *testing.T) {
+	ctx := context.Background()
+	now := timeNow()
+	store := durablememory.NewStore()
+	if err := store.RecordMaintenanceEvent(ctx, domain.MaintenanceEvent{
+		ID:         "mx-critical",
+		AircraftID: "aircraft-1",
+		Severity:   domain.SeverityCritical,
+		Status:     domain.MaintenanceStatusOpen,
+		Title:      "critical item",
+		OpenedAt:   now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	builder := evaluateChecker(t, MaintenanceChecker{durable: store}, testSnapshot(now))
+	requireCheck(t, builder, "critical_open_maintenance", "MX-CRITICAL-OPEN", "maintenance_control", true)
+	requireNoCheck(t, builder, "maintenance_events_available")
+}

--- a/internal/service/preflight/remote_id_checker.go
+++ b/internal/service/preflight/remote_id_checker.go
@@ -1,0 +1,22 @@
+package preflight
+
+import (
+	"context"
+
+	"github.com/Aero-Arc/aero-arc-api/internal/domain"
+)
+
+type RemoteIDChecker struct{}
+
+func (RemoteIDChecker) Name() string { return "remote_id" }
+
+func (RemoteIDChecker) Evaluate(_ context.Context, snapshot Snapshot, builder *Builder) {
+	if snapshot.AircraftErr != nil {
+		return
+	}
+	if snapshot.Aircraft.RemoteIDStatus == domain.RemoteIDStatusOffline {
+		builder.Block(domain.PreflightCheckRemoteID, "remote_id_online", "remote_id_monitor", "RID-ONLINE", "remote ID is offline", "restore Remote ID broadcast before activation")
+	} else {
+		builder.Clear(domain.PreflightCheckRemoteID, "remote_id_online", "remote_id_monitor", "RID-ONLINE", "remote ID is not offline")
+	}
+}

--- a/internal/service/preflight/remote_id_checker_test.go
+++ b/internal/service/preflight/remote_id_checker_test.go
@@ -1,0 +1,35 @@
+package preflight
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Aero-Arc/aero-arc-api/internal/domain"
+)
+
+func TestRemoteIDCheckerSkipsWhenAircraftMissing(t *testing.T) {
+	snapshot := testSnapshot(timeNow())
+	snapshot.AircraftErr = errors.New("missing")
+	builder := evaluateChecker(t, RemoteIDChecker{}, snapshot)
+	requireNoCheck(t, builder, "remote_id_online")
+	if len(builder.Checks()) != 0 {
+		t.Fatalf("checks = %#v, want none", builder.Checks())
+	}
+}
+
+func TestRemoteIDCheckerBlocksWhenOffline(t *testing.T) {
+	snapshot := testSnapshot(timeNow())
+	snapshot.Aircraft.RemoteIDStatus = domain.RemoteIDStatusOffline
+	builder := evaluateChecker(t, RemoteIDChecker{}, snapshot)
+	check := requireCheck(t, builder, "remote_id_online", "RID-ONLINE", "remote_id_monitor", true)
+	if check.Summary != "remote ID is offline" {
+		t.Fatalf("summary = %q", check.Summary)
+	}
+}
+
+func TestRemoteIDCheckerClearsWhenNotOffline(t *testing.T) {
+	snapshot := testSnapshot(timeNow())
+	snapshot.Aircraft.RemoteIDStatus = domain.RemoteIDStatusBroadcasting
+	builder := evaluateChecker(t, RemoteIDChecker{}, snapshot)
+	requireCheck(t, builder, "remote_id_online", "RID-ONLINE", "remote_id_monitor", false)
+}

--- a/internal/service/preflight/service.go
+++ b/internal/service/preflight/service.go
@@ -10,8 +10,9 @@ import (
 )
 
 type PreflightService struct {
-	durable durable.Store
-	now     func() time.Time
+	durable  durable.Store
+	now      func() time.Time
+	checkers []Checker
 }
 
 type PreflightEvaluation struct {
@@ -44,7 +45,11 @@ func NewPreflightServiceWithClock(durableStore durable.Store, now func() time.Ti
 	if now == nil {
 		now = func() time.Time { return time.Now().UTC() }
 	}
-	return &PreflightService{durable: durableStore, now: now}
+	return &PreflightService{
+		durable:  durableStore,
+		now:      now,
+		checkers: []Checker{currentPolicy{durable: durableStore}},
+	}
 }
 
 // EvaluateIntent runs the current preflight policy against an operational
@@ -58,211 +63,135 @@ func NewPreflightServiceWithClock(durableStore durable.Store, now func() time.Ti
 //   - result: is the PreflightEvaluation value produced by EvaluateIntent.
 //   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *PreflightService) EvaluateIntent(ctx context.Context, intentID string) (PreflightEvaluation, error) {
-	intent, err := s.durable.GetOperationalIntent(ctx, intentID)
+	snapshot, err := s.loadSnapshot(ctx, intentID)
 	if err != nil {
-		return PreflightEvaluation{}, fmt.Errorf("get operational intent: %w", err)
+		return PreflightEvaluation{}, err
 	}
 
-	aircraft, aircraftErr := s.durable.GetAircraft(ctx, intent.AircraftID)
-	volumes, err := s.durable.ListOperationalVolumes(ctx, intent.ID)
-	if err != nil {
-		return PreflightEvaluation{}, fmt.Errorf("list operational volumes: %w", err)
-	}
-	volumes = volumesForVersion(volumes, intent.Version)
-
-	now := s.now().UTC()
-	builder := preflightBuilder{intent: intent, now: now}
-	if aircraftErr != nil {
-		builder.block(domain.PreflightCheckAirspace, "aircraft_exists", "fleet_registry", "AIRCRAFT-EXISTS", "aircraft does not exist", "create or select a valid aircraft")
-	} else {
-		builder.clear(domain.PreflightCheckAirspace, "aircraft_exists", "fleet_registry", "AIRCRAFT-EXISTS", "aircraft exists")
-		if aircraft.Status != domain.AircraftStatusActive || aircraft.AcceptanceStatus != domain.AcceptanceStatusAccepted {
-			builder.block(domain.PreflightCheckAirspace, "aircraft_operational_status", "fleet_registry", "AIRCRAFT-STATUS", "aircraft is not active or accepted", "set aircraft active or complete acceptance")
-		} else {
-			builder.clear(domain.PreflightCheckAirspace, "aircraft_operational_status", "fleet_registry", "AIRCRAFT-STATUS", "aircraft status allows operation")
-		}
-		if aircraft.RemoteIDStatus == domain.RemoteIDStatusOffline {
-			builder.block(domain.PreflightCheckRemoteID, "remote_id_online", "remote_id_monitor", "RID-ONLINE", "remote ID is offline", "restore Remote ID broadcast before activation")
-		} else {
-			builder.clear(domain.PreflightCheckRemoteID, "remote_id_online", "remote_id_monitor", "RID-ONLINE", "remote ID is not offline")
-		}
+	builder := newBuilder(snapshot)
+	for _, checker := range s.checkers {
+		checker.Evaluate(ctx, snapshot, builder)
 	}
 
-	if intent.PlannedStartAt.Before(intent.PlannedEndAt) {
-		builder.clear(domain.PreflightCheckAirspace, "intent_time_window", "intent_service", "INTENT-WINDOW", "intent planned time window is valid")
-	} else {
-		builder.block(domain.PreflightCheckAirspace, "intent_time_window", "intent_service", "INTENT-WINDOW", "intent planned start must be before planned end", "set planned_start_at before planned_end_at")
-	}
-
-	if len(volumes) == 0 {
-		builder.block(domain.PreflightCheckAirspace, "operational_volume_exists", "intent_service", "VOLUME-EXISTS", "at least one operational volume is required", "add an operational volume")
-	} else {
-		builder.clear(domain.PreflightCheckAirspace, "operational_volume_exists", "intent_service", "VOLUME-EXISTS", "operational volume exists")
-	}
-	for _, volume := range volumes {
-		prefix := fmt.Sprintf("volume_%s", volume.ID)
-		if volume.StartsAt.Before(volume.EndsAt) {
-			builder.clear(domain.PreflightCheckAirspace, prefix+"_time_window", "intent_service", "VOLUME-WINDOW", "operational volume time window is valid")
-		} else {
-			builder.block(domain.PreflightCheckAirspace, prefix+"_time_window", "intent_service", "VOLUME-WINDOW", "operational volume start must be before end", "set volume starts_at before ends_at")
-		}
-		if volume.MinAltitudeM <= volume.MaxAltitudeM {
-			builder.clear(domain.PreflightCheckAirspace, prefix+"_altitude_range", "intent_service", "VOLUME-ALTITUDE", "operational volume altitude range is valid")
-		} else {
-			builder.block(domain.PreflightCheckAirspace, prefix+"_altitude_range", "intent_service", "VOLUME-ALTITUDE", "operational volume minimum altitude exceeds maximum altitude", "set min_altitude_m <= max_altitude_m")
-		}
-		if !volume.StartsAt.Before(intent.PlannedStartAt) && !volume.EndsAt.After(intent.PlannedEndAt) {
-			builder.clear(domain.PreflightCheckAirspace, prefix+"_inside_intent_window", "intent_service", "VOLUME-IN-INTENT", "operational volume is inside planned intent window")
-		} else {
-			builder.block(domain.PreflightCheckAirspace, prefix+"_inside_intent_window", "intent_service", "VOLUME-IN-INTENT", "operational volume must be inside planned intent window", "adjust volume or planned intent time window")
-		}
-		if volume.GeoJSON != "" {
-			builder.clear(domain.PreflightCheckAirspace, prefix+"_inline_geojson", "intent_service", "VOLUME-GEOJSON", "operational volume has inline GeoJSON evaluable by this server")
-		} else {
-			builder.block(domain.PreflightCheckAirspace, prefix+"_inline_geojson", "intent_service", "VOLUME-GEOJSON", "operational volume requires inline GeoJSON for local conformance evaluation", "provide inline GeoJSON; geometry_uri resolution is not implemented")
-		}
-	}
-
-	s.evaluateBattery(ctx, &builder, intent)
-	s.evaluateMaintenance(ctx, &builder, intent)
-	builder.clear(domain.PreflightCheckWeather, "demo_weather", "demo_weather_provider", "WX-DEMO", "demo weather check clear")
-	builder.clear(domain.PreflightCheckNOTAM, "demo_notam", "demo_notam_provider", "NOTAM-DEMO", "demo NOTAM check clear")
-
-	for _, check := range builder.checks {
+	for _, check := range builder.Checks() {
 		if err := s.durable.RecordPreflightCheck(ctx, check); err != nil {
 			return PreflightEvaluation{}, fmt.Errorf("record preflight check: %w", err)
 		}
 	}
-	for _, finding := range builder.findings {
+	for _, finding := range builder.Findings() {
 		if err := s.durable.RecordComplianceFinding(ctx, finding); err != nil {
 			return PreflightEvaluation{}, fmt.Errorf("record compliance finding: %w", err)
 		}
 	}
 
 	return PreflightEvaluation{
-		Intent:   intent,
-		Checks:   builder.checks,
-		Findings: builder.findings,
-		Blocked:  builder.blocked,
+		Intent:   snapshot.Intent,
+		Checks:   builder.Checks(),
+		Findings: builder.Findings(),
+		Blocked:  builder.Blocked(),
 	}, nil
 }
 
-func (s *PreflightService) evaluateBattery(ctx context.Context, builder *preflightBuilder, intent domain.OperationalIntent) {
-	installation, err := s.durable.GetActiveBatteryInstallation(ctx, intent.AircraftID)
+type currentPolicy struct {
+	durable durable.Store
+}
+
+func (currentPolicy) Name() string { return "current_policy" }
+
+func (c currentPolicy) Evaluate(ctx context.Context, snapshot Snapshot, builder *Builder) {
+	if snapshot.AircraftErr != nil {
+		builder.Block(domain.PreflightCheckAirspace, "aircraft_exists", "fleet_registry", "AIRCRAFT-EXISTS", "aircraft does not exist", "create or select a valid aircraft")
+	} else {
+		builder.Clear(domain.PreflightCheckAirspace, "aircraft_exists", "fleet_registry", "AIRCRAFT-EXISTS", "aircraft exists")
+		if snapshot.Aircraft.Status != domain.AircraftStatusActive || snapshot.Aircraft.AcceptanceStatus != domain.AcceptanceStatusAccepted {
+			builder.Block(domain.PreflightCheckAirspace, "aircraft_operational_status", "fleet_registry", "AIRCRAFT-STATUS", "aircraft is not active or accepted", "set aircraft active or complete acceptance")
+		} else {
+			builder.Clear(domain.PreflightCheckAirspace, "aircraft_operational_status", "fleet_registry", "AIRCRAFT-STATUS", "aircraft status allows operation")
+		}
+		if snapshot.Aircraft.RemoteIDStatus == domain.RemoteIDStatusOffline {
+			builder.Block(domain.PreflightCheckRemoteID, "remote_id_online", "remote_id_monitor", "RID-ONLINE", "remote ID is offline", "restore Remote ID broadcast before activation")
+		} else {
+			builder.Clear(domain.PreflightCheckRemoteID, "remote_id_online", "remote_id_monitor", "RID-ONLINE", "remote ID is not offline")
+		}
+	}
+
+	if snapshot.Intent.PlannedStartAt.Before(snapshot.Intent.PlannedEndAt) {
+		builder.Clear(domain.PreflightCheckAirspace, "intent_time_window", "intent_service", "INTENT-WINDOW", "intent planned time window is valid")
+	} else {
+		builder.Block(domain.PreflightCheckAirspace, "intent_time_window", "intent_service", "INTENT-WINDOW", "intent planned start must be before planned end", "set planned_start_at before planned_end_at")
+	}
+
+	if len(snapshot.Volumes) == 0 {
+		builder.Block(domain.PreflightCheckAirspace, "operational_volume_exists", "intent_service", "VOLUME-EXISTS", "at least one operational volume is required", "add an operational volume")
+	} else {
+		builder.Clear(domain.PreflightCheckAirspace, "operational_volume_exists", "intent_service", "VOLUME-EXISTS", "operational volume exists")
+	}
+	for _, volume := range snapshot.Volumes {
+		prefix := fmt.Sprintf("volume_%s", volume.ID)
+		if volume.StartsAt.Before(volume.EndsAt) {
+			builder.Clear(domain.PreflightCheckAirspace, prefix+"_time_window", "intent_service", "VOLUME-WINDOW", "operational volume time window is valid")
+		} else {
+			builder.Block(domain.PreflightCheckAirspace, prefix+"_time_window", "intent_service", "VOLUME-WINDOW", "operational volume start must be before end", "set volume starts_at before ends_at")
+		}
+		if volume.MinAltitudeM <= volume.MaxAltitudeM {
+			builder.Clear(domain.PreflightCheckAirspace, prefix+"_altitude_range", "intent_service", "VOLUME-ALTITUDE", "operational volume altitude range is valid")
+		} else {
+			builder.Block(domain.PreflightCheckAirspace, prefix+"_altitude_range", "intent_service", "VOLUME-ALTITUDE", "operational volume minimum altitude exceeds maximum altitude", "set min_altitude_m <= max_altitude_m")
+		}
+		if !volume.StartsAt.Before(snapshot.Intent.PlannedStartAt) && !volume.EndsAt.After(snapshot.Intent.PlannedEndAt) {
+			builder.Clear(domain.PreflightCheckAirspace, prefix+"_inside_intent_window", "intent_service", "VOLUME-IN-INTENT", "operational volume is inside planned intent window")
+		} else {
+			builder.Block(domain.PreflightCheckAirspace, prefix+"_inside_intent_window", "intent_service", "VOLUME-IN-INTENT", "operational volume must be inside planned intent window", "adjust volume or planned intent time window")
+		}
+		if volume.GeoJSON != "" {
+			builder.Clear(domain.PreflightCheckAirspace, prefix+"_inline_geojson", "intent_service", "VOLUME-GEOJSON", "operational volume has inline GeoJSON evaluable by this server")
+		} else {
+			builder.Block(domain.PreflightCheckAirspace, prefix+"_inline_geojson", "intent_service", "VOLUME-GEOJSON", "operational volume requires inline GeoJSON for local conformance evaluation", "provide inline GeoJSON; geometry_uri resolution is not implemented")
+		}
+	}
+
+	c.evaluateBattery(ctx, snapshot, builder)
+	c.evaluateMaintenance(ctx, snapshot, builder)
+	builder.Clear(domain.PreflightCheckWeather, "demo_weather", "demo_weather_provider", "WX-DEMO", "demo weather check clear")
+	builder.Clear(domain.PreflightCheckNOTAM, "demo_notam", "demo_notam_provider", "NOTAM-DEMO", "demo NOTAM check clear")
+}
+
+func (c currentPolicy) evaluateBattery(ctx context.Context, snapshot Snapshot, builder *Builder) {
+	installation, err := c.durable.GetActiveBatteryInstallation(ctx, snapshot.Intent.AircraftID)
 	if err != nil || installation == nil {
-		builder.block(domain.PreflightCheckBattery, "battery_installed", "maintenance_control", "BATTERY-INSTALLED", "battery is not installed", "install a battery")
+		builder.Block(domain.PreflightCheckBattery, "battery_installed", "maintenance_control", "BATTERY-INSTALLED", "battery is not installed", "install a battery")
 		return
 	}
-	builder.clear(domain.PreflightCheckBattery, "battery_installed", "maintenance_control", "BATTERY-INSTALLED", "battery is installed")
+	builder.Clear(domain.PreflightCheckBattery, "battery_installed", "maintenance_control", "BATTERY-INSTALLED", "battery is installed")
 
-	battery, err := s.durable.GetBattery(ctx, installation.BatteryID)
+	battery, err := c.durable.GetBattery(ctx, installation.BatteryID)
 	if err != nil {
-		builder.block(domain.PreflightCheckBattery, "battery_soh_known", "maintenance_control", "BATTERY-SOH-KNOWN", "battery state of health is unknown", "record battery state of health")
+		builder.Block(domain.PreflightCheckBattery, "battery_soh_known", "maintenance_control", "BATTERY-SOH-KNOWN", "battery state of health is unknown", "record battery state of health")
 		return
 	}
 	if battery.StateOfHealth == nil {
-		builder.block(domain.PreflightCheckBattery, "battery_soh_known", "maintenance_control", "BATTERY-SOH-KNOWN", "battery state of health is unknown", "record battery state of health")
+		builder.Block(domain.PreflightCheckBattery, "battery_soh_known", "maintenance_control", "BATTERY-SOH-KNOWN", "battery state of health is unknown", "record battery state of health")
 		return
 	}
-	builder.clear(domain.PreflightCheckBattery, "battery_soh_known", "maintenance_control", "BATTERY-SOH-KNOWN", "battery state of health is known")
+	builder.Clear(domain.PreflightCheckBattery, "battery_soh_known", "maintenance_control", "BATTERY-SOH-KNOWN", "battery state of health is known")
 	if *battery.StateOfHealth < 80 {
-		builder.block(domain.PreflightCheckBattery, "battery_soh_minimum", "maintenance_control", "BATTERY-SOH-80", "battery state of health is below 80", "replace or service battery")
+		builder.Block(domain.PreflightCheckBattery, "battery_soh_minimum", "maintenance_control", "BATTERY-SOH-80", "battery state of health is below 80", "replace or service battery")
 		return
 	}
-	builder.clear(domain.PreflightCheckBattery, "battery_soh_minimum", "maintenance_control", "BATTERY-SOH-80", "battery state of health is at least 80")
+	builder.Clear(domain.PreflightCheckBattery, "battery_soh_minimum", "maintenance_control", "BATTERY-SOH-80", "battery state of health is at least 80")
 }
 
-func (s *PreflightService) evaluateMaintenance(ctx context.Context, builder *preflightBuilder, intent domain.OperationalIntent) {
-	events, err := s.durable.ListMaintenanceEvents(ctx, intent.AircraftID)
+func (c currentPolicy) evaluateMaintenance(ctx context.Context, snapshot Snapshot, builder *Builder) {
+	events, err := c.durable.ListMaintenanceEvents(ctx, snapshot.Intent.AircraftID)
 	if err != nil {
-		builder.block(domain.PreflightCheckMaintenance, "maintenance_events_available", "maintenance_control", "MX-AVAILABLE", "maintenance status could not be loaded", "retry maintenance status lookup")
+		builder.Block(domain.PreflightCheckMaintenance, "maintenance_events_available", "maintenance_control", "MX-AVAILABLE", "maintenance status could not be loaded", "retry maintenance status lookup")
 		return
 	}
 	for _, event := range events {
 		if event.Severity == domain.SeverityCritical && event.ResolvedAt == nil && event.Status != domain.MaintenanceStatusClosed {
-			builder.block(domain.PreflightCheckMaintenance, "critical_open_maintenance", "maintenance_control", "MX-CRITICAL-OPEN", "critical open maintenance event exists", "resolve critical maintenance before activation")
+			builder.Block(domain.PreflightCheckMaintenance, "critical_open_maintenance", "maintenance_control", "MX-CRITICAL-OPEN", "critical open maintenance event exists", "resolve critical maintenance before activation")
 			return
 		}
 	}
-	builder.clear(domain.PreflightCheckMaintenance, "critical_open_maintenance", "maintenance_control", "MX-CRITICAL-OPEN", "no critical open maintenance events")
-}
-
-type preflightBuilder struct {
-	intent   domain.OperationalIntent
-	now      time.Time
-	checks   []domain.PreflightCheck
-	findings []domain.ComplianceFinding
-	blocked  bool
-}
-
-func (b *preflightBuilder) clear(category domain.PreflightCheckCategory, key, source, requirementCode, summary string) {
-	b.check(category, key, source, requirementCode, summary, "", domain.PreflightStatusClear, false)
-}
-
-func (b *preflightBuilder) block(category domain.PreflightCheckCategory, key, source, requirementCode, summary, remediation string) {
-	b.check(category, key, source, requirementCode, summary, remediation, domain.PreflightStatusBlocked, true)
-	b.blocked = true
-}
-
-func (b *preflightBuilder) check(category domain.PreflightCheckCategory, key, source, requirementCode, summary, remediation string, status domain.PreflightStatus, blocking bool) {
-	check := domain.PreflightCheck{
-		ID:              fmt.Sprintf("preflight-%s-v%d-%s", b.intent.ID, b.intent.Version, key),
-		OperatorID:      b.intent.OperatorID,
-		IntentID:        b.intent.ID,
-		IntentVersion:   b.intent.Version,
-		AircraftID:      b.intent.AircraftID,
-		Category:        category,
-		Source:          source,
-		Status:          status,
-		Summary:         summary,
-		RequirementCode: requirementCode,
-		RuleVersion:     "demo.v1",
-		Blocking:        blocking,
-		CapturedAt:      b.now,
-	}
-	b.checks = append(b.checks, check)
-	if !blocking {
-		b.findings = append(b.findings, domain.ComplianceFinding{
-			ID:              fmt.Sprintf("finding-%s-v%d-%s", b.intent.ID, b.intent.Version, key),
-			OperatorID:      b.intent.OperatorID,
-			IntentID:        b.intent.ID,
-			IntentVersion:   b.intent.Version,
-			SubjectType:     "operational_intent",
-			SubjectID:       b.intent.ID,
-			RequirementCode: requirementCode,
-			Status:          domain.ComplianceFindingPass,
-			Severity:        domain.SeverityInfo,
-			Blocking:        false,
-			RuleVersion:     "demo.v1",
-			Message:         summary,
-			EvaluatedAt:     b.now,
-		})
-		return
-	}
-	b.findings = append(b.findings, domain.ComplianceFinding{
-		ID:              fmt.Sprintf("finding-%s-v%d-%s", b.intent.ID, b.intent.Version, key),
-		OperatorID:      b.intent.OperatorID,
-		IntentID:        b.intent.ID,
-		IntentVersion:   b.intent.Version,
-		SubjectType:     "operational_intent",
-		SubjectID:       b.intent.ID,
-		RequirementCode: requirementCode,
-		Status:          domain.ComplianceFindingFail,
-		Severity:        domain.SeverityCritical,
-		Blocking:        true,
-		RuleVersion:     "demo.v1",
-		Remediation:     remediation,
-		Message:         summary,
-		EvaluatedAt:     b.now,
-	})
-}
-
-func volumesForVersion(volumes []domain.OperationalVolume, version int) []domain.OperationalVolume {
-	filtered := make([]domain.OperationalVolume, 0, len(volumes))
-	for _, volume := range volumes {
-		if volume.IntentVersion == version {
-			filtered = append(filtered, volume)
-		}
-	}
-	return filtered
+	builder.Clear(domain.PreflightCheckMaintenance, "critical_open_maintenance", "maintenance_control", "MX-CRITICAL-OPEN", "no critical open maintenance events")
 }

--- a/internal/service/preflight/service.go
+++ b/internal/service/preflight/service.go
@@ -46,9 +46,16 @@ func NewPreflightServiceWithClock(durableStore durable.Store, now func() time.Ti
 		now = func() time.Time { return time.Now().UTC() }
 	}
 	return &PreflightService{
-		durable:  durableStore,
-		now:      now,
-		checkers: []Checker{currentPolicy{durable: durableStore}},
+		durable: durableStore,
+		now:     now,
+		checkers: []Checker{
+			AircraftChecker{},
+			RemoteIDChecker{},
+			IntentVolumeChecker{},
+			BatteryChecker{durable: durableStore},
+			MaintenanceChecker{durable: durableStore},
+			StaticEnvironmentChecker{},
+		},
 	}
 }
 
@@ -90,108 +97,4 @@ func (s *PreflightService) EvaluateIntent(ctx context.Context, intentID string) 
 		Findings: builder.Findings(),
 		Blocked:  builder.Blocked(),
 	}, nil
-}
-
-type currentPolicy struct {
-	durable durable.Store
-}
-
-func (currentPolicy) Name() string { return "current_policy" }
-
-func (c currentPolicy) Evaluate(ctx context.Context, snapshot Snapshot, builder *Builder) {
-	if snapshot.AircraftErr != nil {
-		builder.Block(domain.PreflightCheckAirspace, "aircraft_exists", "fleet_registry", "AIRCRAFT-EXISTS", "aircraft does not exist", "create or select a valid aircraft")
-	} else {
-		builder.Clear(domain.PreflightCheckAirspace, "aircraft_exists", "fleet_registry", "AIRCRAFT-EXISTS", "aircraft exists")
-		if snapshot.Aircraft.Status != domain.AircraftStatusActive || snapshot.Aircraft.AcceptanceStatus != domain.AcceptanceStatusAccepted {
-			builder.Block(domain.PreflightCheckAirspace, "aircraft_operational_status", "fleet_registry", "AIRCRAFT-STATUS", "aircraft is not active or accepted", "set aircraft active or complete acceptance")
-		} else {
-			builder.Clear(domain.PreflightCheckAirspace, "aircraft_operational_status", "fleet_registry", "AIRCRAFT-STATUS", "aircraft status allows operation")
-		}
-		if snapshot.Aircraft.RemoteIDStatus == domain.RemoteIDStatusOffline {
-			builder.Block(domain.PreflightCheckRemoteID, "remote_id_online", "remote_id_monitor", "RID-ONLINE", "remote ID is offline", "restore Remote ID broadcast before activation")
-		} else {
-			builder.Clear(domain.PreflightCheckRemoteID, "remote_id_online", "remote_id_monitor", "RID-ONLINE", "remote ID is not offline")
-		}
-	}
-
-	if snapshot.Intent.PlannedStartAt.Before(snapshot.Intent.PlannedEndAt) {
-		builder.Clear(domain.PreflightCheckAirspace, "intent_time_window", "intent_service", "INTENT-WINDOW", "intent planned time window is valid")
-	} else {
-		builder.Block(domain.PreflightCheckAirspace, "intent_time_window", "intent_service", "INTENT-WINDOW", "intent planned start must be before planned end", "set planned_start_at before planned_end_at")
-	}
-
-	if len(snapshot.Volumes) == 0 {
-		builder.Block(domain.PreflightCheckAirspace, "operational_volume_exists", "intent_service", "VOLUME-EXISTS", "at least one operational volume is required", "add an operational volume")
-	} else {
-		builder.Clear(domain.PreflightCheckAirspace, "operational_volume_exists", "intent_service", "VOLUME-EXISTS", "operational volume exists")
-	}
-	for _, volume := range snapshot.Volumes {
-		prefix := fmt.Sprintf("volume_%s", volume.ID)
-		if volume.StartsAt.Before(volume.EndsAt) {
-			builder.Clear(domain.PreflightCheckAirspace, prefix+"_time_window", "intent_service", "VOLUME-WINDOW", "operational volume time window is valid")
-		} else {
-			builder.Block(domain.PreflightCheckAirspace, prefix+"_time_window", "intent_service", "VOLUME-WINDOW", "operational volume start must be before end", "set volume starts_at before ends_at")
-		}
-		if volume.MinAltitudeM <= volume.MaxAltitudeM {
-			builder.Clear(domain.PreflightCheckAirspace, prefix+"_altitude_range", "intent_service", "VOLUME-ALTITUDE", "operational volume altitude range is valid")
-		} else {
-			builder.Block(domain.PreflightCheckAirspace, prefix+"_altitude_range", "intent_service", "VOLUME-ALTITUDE", "operational volume minimum altitude exceeds maximum altitude", "set min_altitude_m <= max_altitude_m")
-		}
-		if !volume.StartsAt.Before(snapshot.Intent.PlannedStartAt) && !volume.EndsAt.After(snapshot.Intent.PlannedEndAt) {
-			builder.Clear(domain.PreflightCheckAirspace, prefix+"_inside_intent_window", "intent_service", "VOLUME-IN-INTENT", "operational volume is inside planned intent window")
-		} else {
-			builder.Block(domain.PreflightCheckAirspace, prefix+"_inside_intent_window", "intent_service", "VOLUME-IN-INTENT", "operational volume must be inside planned intent window", "adjust volume or planned intent time window")
-		}
-		if volume.GeoJSON != "" {
-			builder.Clear(domain.PreflightCheckAirspace, prefix+"_inline_geojson", "intent_service", "VOLUME-GEOJSON", "operational volume has inline GeoJSON evaluable by this server")
-		} else {
-			builder.Block(domain.PreflightCheckAirspace, prefix+"_inline_geojson", "intent_service", "VOLUME-GEOJSON", "operational volume requires inline GeoJSON for local conformance evaluation", "provide inline GeoJSON; geometry_uri resolution is not implemented")
-		}
-	}
-
-	c.evaluateBattery(ctx, snapshot, builder)
-	c.evaluateMaintenance(ctx, snapshot, builder)
-	builder.Clear(domain.PreflightCheckWeather, "demo_weather", "demo_weather_provider", "WX-DEMO", "demo weather check clear")
-	builder.Clear(domain.PreflightCheckNOTAM, "demo_notam", "demo_notam_provider", "NOTAM-DEMO", "demo NOTAM check clear")
-}
-
-func (c currentPolicy) evaluateBattery(ctx context.Context, snapshot Snapshot, builder *Builder) {
-	installation, err := c.durable.GetActiveBatteryInstallation(ctx, snapshot.Intent.AircraftID)
-	if err != nil || installation == nil {
-		builder.Block(domain.PreflightCheckBattery, "battery_installed", "maintenance_control", "BATTERY-INSTALLED", "battery is not installed", "install a battery")
-		return
-	}
-	builder.Clear(domain.PreflightCheckBattery, "battery_installed", "maintenance_control", "BATTERY-INSTALLED", "battery is installed")
-
-	battery, err := c.durable.GetBattery(ctx, installation.BatteryID)
-	if err != nil {
-		builder.Block(domain.PreflightCheckBattery, "battery_soh_known", "maintenance_control", "BATTERY-SOH-KNOWN", "battery state of health is unknown", "record battery state of health")
-		return
-	}
-	if battery.StateOfHealth == nil {
-		builder.Block(domain.PreflightCheckBattery, "battery_soh_known", "maintenance_control", "BATTERY-SOH-KNOWN", "battery state of health is unknown", "record battery state of health")
-		return
-	}
-	builder.Clear(domain.PreflightCheckBattery, "battery_soh_known", "maintenance_control", "BATTERY-SOH-KNOWN", "battery state of health is known")
-	if *battery.StateOfHealth < 80 {
-		builder.Block(domain.PreflightCheckBattery, "battery_soh_minimum", "maintenance_control", "BATTERY-SOH-80", "battery state of health is below 80", "replace or service battery")
-		return
-	}
-	builder.Clear(domain.PreflightCheckBattery, "battery_soh_minimum", "maintenance_control", "BATTERY-SOH-80", "battery state of health is at least 80")
-}
-
-func (c currentPolicy) evaluateMaintenance(ctx context.Context, snapshot Snapshot, builder *Builder) {
-	events, err := c.durable.ListMaintenanceEvents(ctx, snapshot.Intent.AircraftID)
-	if err != nil {
-		builder.Block(domain.PreflightCheckMaintenance, "maintenance_events_available", "maintenance_control", "MX-AVAILABLE", "maintenance status could not be loaded", "retry maintenance status lookup")
-		return
-	}
-	for _, event := range events {
-		if event.Severity == domain.SeverityCritical && event.ResolvedAt == nil && event.Status != domain.MaintenanceStatusClosed {
-			builder.Block(domain.PreflightCheckMaintenance, "critical_open_maintenance", "maintenance_control", "MX-CRITICAL-OPEN", "critical open maintenance event exists", "resolve critical maintenance before activation")
-			return
-		}
-	}
-	builder.Clear(domain.PreflightCheckMaintenance, "critical_open_maintenance", "maintenance_control", "MX-CRITICAL-OPEN", "no critical open maintenance events")
 }

--- a/internal/service/preflight/snapshot.go
+++ b/internal/service/preflight/snapshot.go
@@ -1,0 +1,49 @@
+package preflight
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/Aero-Arc/aero-arc-api/internal/domain"
+)
+
+// Snapshot is the immutable input state for one preflight evaluation.
+type Snapshot struct {
+	Intent      domain.OperationalIntent
+	Aircraft    domain.Aircraft
+	AircraftErr error
+	Volumes     []domain.OperationalVolume
+	Now         time.Time
+}
+
+func (s *PreflightService) loadSnapshot(ctx context.Context, intentID string) (Snapshot, error) {
+	intent, err := s.durable.GetOperationalIntent(ctx, intentID)
+	if err != nil {
+		return Snapshot{}, fmt.Errorf("get operational intent: %w", err)
+	}
+
+	aircraft, aircraftErr := s.durable.GetAircraft(ctx, intent.AircraftID)
+	volumes, err := s.durable.ListOperationalVolumes(ctx, intent.ID)
+	if err != nil {
+		return Snapshot{}, fmt.Errorf("list operational volumes: %w", err)
+	}
+
+	return Snapshot{
+		Intent:      intent,
+		Aircraft:    aircraft,
+		AircraftErr: aircraftErr,
+		Volumes:     volumesForVersion(volumes, intent.Version),
+		Now:         s.now().UTC(),
+	}, nil
+}
+
+func volumesForVersion(volumes []domain.OperationalVolume, version int) []domain.OperationalVolume {
+	filtered := make([]domain.OperationalVolume, 0, len(volumes))
+	for _, volume := range volumes {
+		if volume.IntentVersion == version {
+			filtered = append(filtered, volume)
+		}
+	}
+	return filtered
+}

--- a/internal/service/preflight/snapshot_test.go
+++ b/internal/service/preflight/snapshot_test.go
@@ -1,0 +1,80 @@
+package preflight
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/Aero-Arc/aero-arc-api/internal/domain"
+	"github.com/Aero-Arc/aero-arc-api/internal/store/durable"
+	durablememory "github.com/Aero-Arc/aero-arc-api/internal/store/durable/memory"
+)
+
+func TestVolumesForVersionKeepsCurrentIntentVersion(t *testing.T) {
+	volumes := []domain.OperationalVolume{
+		{ID: "old", IntentVersion: 1},
+		{ID: "current", IntentVersion: 2},
+		{ID: "other", IntentVersion: 3},
+	}
+	got := volumesForVersion(volumes, 2)
+	if len(got) != 1 || got[0].ID != "current" {
+		t.Fatalf("volumesForVersion = %#v, want only current", got)
+	}
+}
+
+func TestLoadSnapshotPreservesMissingAircraftAsCheckInput(t *testing.T) {
+	ctx := context.Background()
+	store := durablememory.NewStore()
+	now := time.Date(2026, time.January, 15, 12, 0, 0, 0, time.UTC)
+	if err := store.CreateOperationalIntent(ctx, domain.OperationalIntent{
+		ID:             "intent-1",
+		AircraftID:     "missing-aircraft",
+		Version:        2,
+		PlannedStartAt: now,
+		PlannedEndAt:   now.Add(time.Hour),
+		UpdatedAt:      now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.RecordOperationalVolume(ctx, domain.OperationalVolume{
+		ID:            "volume-old",
+		IntentID:      "intent-1",
+		IntentVersion: 1,
+		UpdatedAt:     now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.RecordOperationalVolume(ctx, domain.OperationalVolume{
+		ID:            "volume-current",
+		IntentID:      "intent-1",
+		IntentVersion: 2,
+		UpdatedAt:     now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	service := NewPreflightServiceWithClock(store, func() time.Time { return now })
+	snapshot, err := service.loadSnapshot(ctx, "intent-1")
+	if err != nil {
+		t.Fatalf("loadSnapshot returned error: %v", err)
+	}
+	if snapshot.AircraftErr == nil || !errors.Is(snapshot.AircraftErr, durable.ErrNotFound) {
+		t.Fatalf("AircraftErr = %v, want durable.ErrNotFound", snapshot.AircraftErr)
+	}
+	if len(snapshot.Volumes) != 1 || snapshot.Volumes[0].ID != "volume-current" {
+		t.Fatalf("volumes = %#v, want current version only", snapshot.Volumes)
+	}
+	if !snapshot.Now.Equal(now) {
+		t.Fatalf("Now = %v, want %v", snapshot.Now, now)
+	}
+}
+
+func TestLoadSnapshotMissingIntentIsAnError(t *testing.T) {
+	ctx := context.Background()
+	service := NewPreflightService(durablememory.NewStore())
+	_, err := service.loadSnapshot(ctx, "missing")
+	if err == nil || !errors.Is(err, durable.ErrNotFound) {
+		t.Fatalf("error = %v, want wrapped durable.ErrNotFound", err)
+	}
+}

--- a/internal/service/preflight/static_checker.go
+++ b/internal/service/preflight/static_checker.go
@@ -1,0 +1,16 @@
+package preflight
+
+import (
+	"context"
+
+	"github.com/Aero-Arc/aero-arc-api/internal/domain"
+)
+
+type StaticEnvironmentChecker struct{}
+
+func (StaticEnvironmentChecker) Name() string { return "static_environment" }
+
+func (StaticEnvironmentChecker) Evaluate(_ context.Context, _ Snapshot, builder *Builder) {
+	builder.Clear(domain.PreflightCheckWeather, "demo_weather", "demo_weather_provider", "WX-DEMO", "demo weather check clear")
+	builder.Clear(domain.PreflightCheckNOTAM, "demo_notam", "demo_notam_provider", "NOTAM-DEMO", "demo NOTAM check clear")
+}

--- a/internal/service/preflight/static_checker_test.go
+++ b/internal/service/preflight/static_checker_test.go
@@ -1,0 +1,15 @@
+package preflight
+
+import "testing"
+
+func TestStaticEnvironmentCheckerKeepsDemoClears(t *testing.T) {
+	builder := evaluateChecker(t, StaticEnvironmentChecker{}, testSnapshot(timeNow()))
+	wx := requireCheck(t, builder, "demo_weather", "WX-DEMO", "demo_weather_provider", false)
+	notam := requireCheck(t, builder, "demo_notam", "NOTAM-DEMO", "demo_notam_provider", false)
+	if wx.Summary != "demo weather check clear" || notam.Summary != "demo NOTAM check clear" {
+		t.Fatalf("summaries = %q, %q", wx.Summary, notam.Summary)
+	}
+	if builder.Checks()[0].ID != wx.ID || builder.Checks()[1].ID != notam.ID {
+		t.Fatalf("order = %#v", builder.Checks())
+	}
+}

--- a/internal/service/preflight/volume_checker.go
+++ b/internal/service/preflight/volume_checker.go
@@ -1,0 +1,49 @@
+package preflight
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Aero-Arc/aero-arc-api/internal/domain"
+)
+
+type IntentVolumeChecker struct{}
+
+func (IntentVolumeChecker) Name() string { return "intent_volume" }
+
+func (IntentVolumeChecker) Evaluate(_ context.Context, snapshot Snapshot, builder *Builder) {
+	if snapshot.Intent.PlannedStartAt.Before(snapshot.Intent.PlannedEndAt) {
+		builder.Clear(domain.PreflightCheckAirspace, "intent_time_window", "intent_service", "INTENT-WINDOW", "intent planned time window is valid")
+	} else {
+		builder.Block(domain.PreflightCheckAirspace, "intent_time_window", "intent_service", "INTENT-WINDOW", "intent planned start must be before planned end", "set planned_start_at before planned_end_at")
+	}
+
+	if len(snapshot.Volumes) == 0 {
+		builder.Block(domain.PreflightCheckAirspace, "operational_volume_exists", "intent_service", "VOLUME-EXISTS", "at least one operational volume is required", "add an operational volume")
+	} else {
+		builder.Clear(domain.PreflightCheckAirspace, "operational_volume_exists", "intent_service", "VOLUME-EXISTS", "operational volume exists")
+	}
+	for _, volume := range snapshot.Volumes {
+		prefix := fmt.Sprintf("volume_%s", volume.ID)
+		if volume.StartsAt.Before(volume.EndsAt) {
+			builder.Clear(domain.PreflightCheckAirspace, prefix+"_time_window", "intent_service", "VOLUME-WINDOW", "operational volume time window is valid")
+		} else {
+			builder.Block(domain.PreflightCheckAirspace, prefix+"_time_window", "intent_service", "VOLUME-WINDOW", "operational volume start must be before end", "set volume starts_at before ends_at")
+		}
+		if volume.MinAltitudeM <= volume.MaxAltitudeM {
+			builder.Clear(domain.PreflightCheckAirspace, prefix+"_altitude_range", "intent_service", "VOLUME-ALTITUDE", "operational volume altitude range is valid")
+		} else {
+			builder.Block(domain.PreflightCheckAirspace, prefix+"_altitude_range", "intent_service", "VOLUME-ALTITUDE", "operational volume minimum altitude exceeds maximum altitude", "set min_altitude_m <= max_altitude_m")
+		}
+		if !volume.StartsAt.Before(snapshot.Intent.PlannedStartAt) && !volume.EndsAt.After(snapshot.Intent.PlannedEndAt) {
+			builder.Clear(domain.PreflightCheckAirspace, prefix+"_inside_intent_window", "intent_service", "VOLUME-IN-INTENT", "operational volume is inside planned intent window")
+		} else {
+			builder.Block(domain.PreflightCheckAirspace, prefix+"_inside_intent_window", "intent_service", "VOLUME-IN-INTENT", "operational volume must be inside planned intent window", "adjust volume or planned intent time window")
+		}
+		if volume.GeoJSON != "" {
+			builder.Clear(domain.PreflightCheckAirspace, prefix+"_inline_geojson", "intent_service", "VOLUME-GEOJSON", "operational volume has inline GeoJSON evaluable by this server")
+		} else {
+			builder.Block(domain.PreflightCheckAirspace, prefix+"_inline_geojson", "intent_service", "VOLUME-GEOJSON", "operational volume requires inline GeoJSON for local conformance evaluation", "provide inline GeoJSON; geometry_uri resolution is not implemented")
+		}
+	}
+}

--- a/internal/service/preflight/volume_checker_test.go
+++ b/internal/service/preflight/volume_checker_test.go
@@ -1,0 +1,57 @@
+package preflight
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Aero-Arc/aero-arc-api/internal/domain"
+)
+
+func TestIntentVolumeCheckerBlocksInvalidWindowAndMissingVolume(t *testing.T) {
+	now := timeNow()
+	snapshot := testSnapshot(now)
+	snapshot.Intent.PlannedStartAt = now.Add(time.Hour)
+	snapshot.Intent.PlannedEndAt = now
+	builder := evaluateChecker(t, IntentVolumeChecker{}, snapshot)
+	requireCheck(t, builder, "intent_time_window", "INTENT-WINDOW", "intent_service", true)
+	requireCheck(t, builder, "operational_volume_exists", "VOLUME-EXISTS", "intent_service", true)
+}
+
+func TestIntentVolumeCheckerClearsCurrentVersionVolume(t *testing.T) {
+	now := timeNow()
+	snapshot := testSnapshot(now)
+	snapshot.Intent.PlannedStartAt = now
+	snapshot.Intent.PlannedEndAt = now.Add(time.Hour)
+	snapshot.Volumes = []domain.OperationalVolume{{
+		ID:           "volume-1",
+		GeoJSON:      `{"type":"Polygon"}`,
+		MinAltitudeM: 10,
+		MaxAltitudeM: 120,
+		StartsAt:     now,
+		EndsAt:       now.Add(time.Hour),
+	}}
+	builder := evaluateChecker(t, IntentVolumeChecker{}, snapshot)
+	requireCheck(t, builder, "intent_time_window", "INTENT-WINDOW", "intent_service", false)
+	requireCheck(t, builder, "operational_volume_exists", "VOLUME-EXISTS", "intent_service", false)
+	requireCheck(t, builder, "volume_volume-1_time_window", "VOLUME-WINDOW", "intent_service", false)
+	requireCheck(t, builder, "volume_volume-1_altitude_range", "VOLUME-ALTITUDE", "intent_service", false)
+	requireCheck(t, builder, "volume_volume-1_inside_intent_window", "VOLUME-IN-INTENT", "intent_service", false)
+	requireCheck(t, builder, "volume_volume-1_inline_geojson", "VOLUME-GEOJSON", "intent_service", false)
+}
+
+func TestIntentVolumeCheckerBlocksURIOnlyGeometry(t *testing.T) {
+	now := timeNow()
+	snapshot := testSnapshot(now)
+	snapshot.Intent.PlannedStartAt = now
+	snapshot.Intent.PlannedEndAt = now.Add(time.Hour)
+	snapshot.Volumes = []domain.OperationalVolume{{
+		ID:           "volume-uri",
+		GeometryURI:  "s3://demo/volume.geojson",
+		MinAltitudeM: 10,
+		MaxAltitudeM: 120,
+		StartsAt:     now,
+		EndsAt:       now.Add(time.Hour),
+	}}
+	builder := evaluateChecker(t, IntentVolumeChecker{}, snapshot)
+	requireCheck(t, builder, "volume_volume-uri_inline_geojson", "VOLUME-GEOJSON", "intent_service", true)
+}


### PR DESCRIPTION
## Summary
- Stacked on #34 and #35. This is a **separate PR** for outline PR 3 only.
- Replace the single `currentPolicy` checker with dedicated files: aircraft, remote ID, intent/volume, battery, maintenance, and static environment.
- Preserve checker execution order, check/finding IDs, requirement codes, sources, summaries, `demo.v1`, demo weather/NOTAM clears, persistence order, and activation semantics. No providers, personnel, or HTTP/JSON changes.

## Test plan
- [ ] `go test ./internal/service/preflight/ ./internal/service/ ./internal/httpapi/`
- [ ] Confirm default checker order: aircraft → remote_id → intent_volume → battery → maintenance → static_environment
- [ ] Confirm missing-aircraft still emits only `aircraft_exists` (no status/RID checks)
- [ ] Confirm battery SOH threshold remains 80 and demo WX/NOTAM still always clear